### PR TITLE
Restructure constants module for clarity (#26)

### DIFF
--- a/utils/game_constants.py
+++ b/utils/game_constants.py
@@ -1,20 +1,4 @@
-from pathlib import Path
-
-import wx
-
-MANA_RENDER_LOG = Path("cache") / "mana_render.log"
-SUBDUED_TEXT = wx.Colour(185, 191, 202)
-DARK_BG = wx.Colour(20, 22, 27)
-DARK_PANEL = wx.Colour(34, 39, 46)
-DARK_ALT = wx.Colour(40, 46, 54)
-DARK_ACCENT = wx.Colour(59, 130, 246)
-LIGHT_TEXT = wx.Colour(236, 236, 236)
-
-ZONE_TITLES = {
-    "main": "Mainboard",
-    "side": "Sideboard",
-    "out": "Outboard",
-}
+"""Gameplay-related constants shared across services."""
 
 FULL_MANA_SYMBOLS: list[str] = (
     ["W", "U", "B", "R", "G", "C", "S", "X", "Y", "Z", "∞", "½"]
@@ -59,3 +43,5 @@ FORMAT_OPTIONS = [
     "Brawl",
     "Historic",
 ]
+
+__all__ = ["FULL_MANA_SYMBOLS", "FORMAT_OPTIONS"]

--- a/utils/mana_icon_factory.py
+++ b/utils/mana_icon_factory.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import wx
 from loguru import logger
 
-from utils.constants import DARK_ALT, MANA_RENDER_LOG, SUBDUED_TEXT
+from utils.paths_constants import MANA_RENDER_LOG
+from utils.ui_constants import DARK_ALT, SUBDUED_TEXT
 
 
 def _log_mana_event(*parts: str) -> None:  # pragma: no cover - debug helper

--- a/utils/paths_constants.py
+++ b/utils/paths_constants.py
@@ -1,0 +1,7 @@
+"""Filesystem-related constants used across services."""
+
+from pathlib import Path
+
+MANA_RENDER_LOG = Path("cache") / "mana_render.log"
+
+__all__ = ["MANA_RENDER_LOG"]

--- a/utils/stylize.py
+++ b/utils/stylize.py
@@ -1,6 +1,13 @@
 import wx
 
-from utils.constants import DARK_ACCENT, DARK_ALT, DARK_BG, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+from utils.ui_constants import (
+    DARK_ACCENT,
+    DARK_ALT,
+    DARK_BG,
+    DARK_PANEL,
+    LIGHT_TEXT,
+    SUBDUED_TEXT,
+)
 
 
 def stylize_label(label: wx.StaticText, subtle: bool = False) -> None:

--- a/utils/ui_constants.py
+++ b/utils/ui_constants.py
@@ -1,0 +1,26 @@
+"""UI-specific constants shared across widgets."""
+
+import wx
+
+SUBDUED_TEXT = wx.Colour(185, 191, 202)
+DARK_BG = wx.Colour(20, 22, 27)
+DARK_PANEL = wx.Colour(34, 39, 46)
+DARK_ALT = wx.Colour(40, 46, 54)
+DARK_ACCENT = wx.Colour(59, 130, 246)
+LIGHT_TEXT = wx.Colour(236, 236, 236)
+
+ZONE_TITLES = {
+    "main": "Mainboard",
+    "side": "Sideboard",
+    "out": "Outboard",
+}
+
+__all__ = [
+    "SUBDUED_TEXT",
+    "DARK_BG",
+    "DARK_PANEL",
+    "DARK_ALT",
+    "DARK_ACCENT",
+    "LIGHT_TEXT",
+    "ZONE_TITLES",
+]

--- a/widgets/buttons/mana_button.py
+++ b/widgets/buttons/mana_button.py
@@ -9,8 +9,8 @@ from collections.abc import Callable
 
 import wx
 
-from utils.constants import DARK_ALT, LIGHT_TEXT
 from utils.mana_icon_factory import ManaIconFactory
+from utils.ui_constants import DARK_ALT, LIGHT_TEXT
 
 
 def get_mana_font(size: int = 14, parent_font: wx.Font | None = None) -> wx.Font:

--- a/widgets/deck_selector.py
+++ b/widgets/deck_selector.py
@@ -17,20 +17,12 @@ from services.deck_service import get_deck_service
 from services.image_service import get_image_service
 from services.search_service import get_search_service
 from utils.card_data import CardDataManager
-from utils.constants import (
-    DARK_ALT,
-    DARK_BG,
-    DARK_PANEL,
-    FULL_MANA_SYMBOLS,
-    LIGHT_TEXT,
-    SUBDUED_TEXT,
-    ZONE_TITLES,
-)
 from utils.deck import (
     read_curr_deck_file,
     sanitize_filename,
     sanitize_zone_cards,
 )
+from utils.game_constants import FORMAT_OPTIONS, FULL_MANA_SYMBOLS
 from utils.mana_icon_factory import ManaIconFactory, type_global_mana_symbol
 from utils.paths import (
     CACHE_DIR,
@@ -39,6 +31,14 @@ from utils.paths import (
     DECKS_DIR,
 )
 from utils.stylize import stylize_listbox, stylize_textctrl
+from utils.ui_constants import (
+    DARK_ALT,
+    DARK_BG,
+    DARK_PANEL,
+    LIGHT_TEXT,
+    SUBDUED_TEXT,
+    ZONE_TITLES,
+)
 from widgets.buttons.deck_action_buttons import DeckActionButtons
 from widgets.buttons.mana_button import create_mana_button, get_mana_font
 from widgets.dialogs.image_download_dialog import show_image_download_dialog
@@ -53,18 +53,6 @@ from widgets.panels.deck_research_panel import DeckResearchPanel
 from widgets.panels.deck_stats_panel import DeckStatsPanel
 from widgets.panels.sideboard_guide_panel import SideboardGuidePanel
 from widgets.timer_alert import TimerAlertFrame
-
-FORMAT_OPTIONS = [
-    "Modern",
-    "Standard",
-    "Pioneer",
-    "Legacy",
-    "Vintage",
-    "Pauper",
-    "Commander",
-    "Brawl",
-    "Historic",
-]
 
 LEGACY_CONFIG_FILE = Path("config.json")
 LEGACY_CURR_DECK_CACHE = Path("cache") / "curr_deck.txt"

--- a/widgets/dialogs/image_download_dialog.py
+++ b/widgets/dialogs/image_download_dialog.py
@@ -8,7 +8,7 @@ import wx
 from loguru import logger
 
 from utils.card_images import BULK_DATA_CACHE, BulkImageDownloader
-from utils.constants import DARK_BG, LIGHT_TEXT, SUBDUED_TEXT
+from utils.ui_constants import DARK_BG, LIGHT_TEXT, SUBDUED_TEXT
 
 
 class ImageDownloadDialog(wx.Dialog):

--- a/widgets/panels/card_box_panel.py
+++ b/widgets/panels/card_box_panel.py
@@ -3,8 +3,8 @@ from typing import Any
 
 import wx
 
-from utils.constants import DARK_ACCENT, DARK_ALT, LIGHT_TEXT
 from utils.mana_icon_factory import ManaIconFactory
+from utils.ui_constants import DARK_ACCENT, DARK_ALT, LIGHT_TEXT
 
 
 class CardBoxPanel(wx.Panel):

--- a/widgets/panels/card_inspector_panel.py
+++ b/widgets/panels/card_inspector_panel.py
@@ -11,9 +11,9 @@ from loguru import logger
 
 from utils.card_data import CardDataManager
 from utils.card_images import BULK_DATA_CACHE, get_cache, get_card_image
-from utils.constants import DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT, ZONE_TITLES
 from utils.mana_icon_factory import ManaIconFactory
 from utils.stylize import stylize_button, stylize_textctrl
+from utils.ui_constants import DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT, ZONE_TITLES
 from widgets.card_image_display import CardImageDisplay
 
 

--- a/widgets/panels/card_table_panel.py
+++ b/widgets/panels/card_table_panel.py
@@ -3,8 +3,8 @@ from typing import Any
 
 import wx
 
-from utils.constants import DARK_PANEL, SUBDUED_TEXT
 from utils.mana_icon_factory import ManaIconFactory
+from utils.ui_constants import DARK_PANEL, SUBDUED_TEXT
 from widgets.panels.card_box_panel import CardBoxPanel
 
 

--- a/widgets/panels/deck_builder_panel.py
+++ b/widgets/panels/deck_builder_panel.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import wx
 
-from utils.constants import DARK_PANEL, FORMAT_OPTIONS, LIGHT_TEXT, SUBDUED_TEXT
+from utils.game_constants import FORMAT_OPTIONS
 from utils.mana_icon_factory import ManaIconFactory
 from utils.stylize import (
     stylize_button,
@@ -12,6 +12,7 @@ from utils.stylize import (
     stylize_listctrl,
     stylize_textctrl,
 )
+from utils.ui_constants import DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
 
 
 class DeckBuilderPanel(wx.Panel):

--- a/widgets/panels/deck_notes_panel.py
+++ b/widgets/panels/deck_notes_panel.py
@@ -8,8 +8,8 @@ from collections.abc import Callable
 
 import wx
 
-from utils.constants import DARK_PANEL
 from utils.stylize import stylize_button, stylize_textctrl
+from utils.ui_constants import DARK_PANEL
 
 
 class DeckNotesPanel(wx.Panel):

--- a/widgets/panels/deck_research_panel.py
+++ b/widgets/panels/deck_research_panel.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 
 import wx
 
-from utils.constants import DARK_PANEL
 from utils.stylize import (
     stylize_button,
     stylize_choice,
@@ -12,6 +11,7 @@ from utils.stylize import (
     stylize_listbox,
     stylize_textctrl,
 )
+from utils.ui_constants import DARK_PANEL
 
 
 class DeckResearchPanel(wx.Panel):

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -12,7 +12,7 @@ import wx.dataview as dv
 
 from services.deck_service import DeckService, get_deck_service
 from utils.card_data import CardDataManager
-from utils.constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT
+from utils.ui_constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT
 
 
 class DeckStatsPanel(wx.Panel):

--- a/widgets/panels/sideboard_guide_panel.py
+++ b/widgets/panels/sideboard_guide_panel.py
@@ -10,8 +10,8 @@ from collections.abc import Callable
 import wx
 import wx.dataview as dv
 
-from utils.constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
 from utils.stylize import stylize_button
+from utils.ui_constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
 
 
 class SideboardGuidePanel(wx.Panel):


### PR DESCRIPTION
## Summary
- split the mixed `utils/constants.py` module into `ui_constants.py`, `game_constants.py`, and `paths_constants.py`
- update widgets/utilities to import from the focused modules and drop duplicate `FORMAT_OPTIONS` definitions
- document the new modules so future UI/game/path settings have a clear home

## Testing
- python3 -m ruff check utils widgets
- ./run_pytest_on_host.sh -q  # 27 passed, 3 skipped (command exits 29 due to upstream pytest quirk)