### PR TITLE
Refactor panels to use direct method calls instead of lambda callbacks

### DIFF
--- a/widgets/deck_selector.py
+++ b/widgets/deck_selector.py
@@ -527,15 +527,13 @@ class MTGDeckSelectionFrame(DeckSelectorEventHandlers, wx.Frame):
 
         self.sideboard_guide_panel = SideboardGuidePanel(
             self.deck_tabs,
-            on_add_callback=lambda: self._on_add_guide_entry(),
-            on_edit_callback=lambda: self._on_edit_guide_entry(),
-            on_remove_callback=lambda: self._on_remove_guide_entry(),
-            on_exclusions_callback=lambda: self._on_edit_exclusions(),
+            deck_selector_frame=self,
         )
         self.deck_tabs.AddPage(self.sideboard_guide_panel, "Sideboard Guide")
 
         self.deck_notes_panel = DeckNotesPanel(
-            self.deck_tabs, on_save_callback=lambda notes: self._save_current_notes()
+            self.deck_tabs,
+            deck_selector_frame=self,
         )
         self.deck_tabs.AddPage(self.deck_notes_panel, "Deck Notes")
 

--- a/widgets/panels/deck_notes_panel.py
+++ b/widgets/panels/deck_notes_panel.py
@@ -4,29 +4,34 @@ Deck Notes Panel - Simple text editor for deck notes.
 Allows users to write and save notes about their decks.
 """
 
-from collections.abc import Callable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import wx
 
 from utils.stylize import stylize_button, stylize_textctrl
 from utils.ui_constants import DARK_PANEL
 
+if TYPE_CHECKING:
+    from widgets.deck_selector import MTGDeckSelectionFrame
+
 
 class DeckNotesPanel(wx.Panel):
     """Panel for editing and saving deck notes."""
 
-    def __init__(self, parent: wx.Window, on_save_callback: Callable[[str], None] | None = None):
+    def __init__(self, parent: wx.Window, deck_selector_frame: MTGDeckSelectionFrame):
         """
         Initialize the deck notes panel.
 
         Args:
             parent: Parent window
-            on_save_callback: Callback when Save Notes button clicked, receives notes text
+            deck_selector_frame: Reference to the main deck selector frame
         """
         super().__init__(parent)
         self.SetBackgroundColour(DARK_PANEL)
 
-        self.on_save = on_save_callback
+        self.deck_selector_frame = deck_selector_frame
 
         self._build_ui()
 
@@ -79,6 +84,4 @@ class DeckNotesPanel(wx.Panel):
 
     def _on_save_clicked(self, _event: wx.Event) -> None:
         """Handle Save Notes button click."""
-        if self.on_save:
-            notes = self.get_notes()
-            self.on_save(notes)
+        self.deck_selector_frame._save_current_notes()

--- a/widgets/panels/sideboard_guide_panel.py
+++ b/widgets/panels/sideboard_guide_panel.py
@@ -5,13 +5,18 @@ Allows users to create, edit, and manage sideboard guides for different matchups
 including cards to side in/out and matchup notes.
 """
 
-from collections.abc import Callable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import wx
 import wx.dataview as dv
 
 from utils.stylize import stylize_button
 from utils.ui_constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+
+if TYPE_CHECKING:
+    from widgets.deck_selector import MTGDeckSelectionFrame
 
 
 class SideboardGuidePanel(wx.Panel):
@@ -20,28 +25,19 @@ class SideboardGuidePanel(wx.Panel):
     def __init__(
         self,
         parent: wx.Window,
-        on_add_callback: Callable[[], None] | None = None,
-        on_edit_callback: Callable[[], None] | None = None,
-        on_remove_callback: Callable[[], None] | None = None,
-        on_exclusions_callback: Callable[[], None] | None = None,
+        deck_selector_frame: MTGDeckSelectionFrame,
     ):
         """
         Initialize the sideboard guide panel.
 
         Args:
             parent: Parent window
-            on_add_callback: Callback when Add Entry button clicked
-            on_edit_callback: Callback when Edit Entry button clicked
-            on_remove_callback: Callback when Remove Entry button clicked
-            on_exclusions_callback: Callback when Exclude Archetypes button clicked
+            deck_selector_frame: Reference to the main deck selector frame
         """
         super().__init__(parent)
         self.SetBackgroundColour(DARK_PANEL)
 
-        self.on_add = on_add_callback
-        self.on_edit = on_edit_callback
-        self.on_remove = on_remove_callback
-        self.on_exclusions = on_exclusions_callback
+        self.deck_selector_frame = deck_selector_frame
 
         self.entries: list[dict[str, str]] = []
         self.exclusions: list[str] = []
@@ -164,20 +160,16 @@ class SideboardGuidePanel(wx.Panel):
 
     def _on_add_clicked(self, _event: wx.Event) -> None:
         """Handle Add Entry button click."""
-        if self.on_add:
-            self.on_add()
+        self.deck_selector_frame._on_add_guide_entry()
 
     def _on_edit_clicked(self, _event: wx.Event) -> None:
         """Handle Edit Entry button click."""
-        if self.on_edit:
-            self.on_edit()
+        self.deck_selector_frame._on_edit_guide_entry()
 
     def _on_remove_clicked(self, _event: wx.Event) -> None:
         """Handle Remove Entry button click."""
-        if self.on_remove:
-            self.on_remove()
+        self.deck_selector_frame._on_remove_guide_entry()
 
     def _on_exclusions_clicked(self, _event: wx.Event) -> None:
         """Handle Exclude Archetypes button click."""
-        if self.on_exclusions:
-            self.on_exclusions()
+        self.deck_selector_frame._on_edit_exclusions()


### PR DESCRIPTION
Simplified panel instantiation by removing lambda callback parameters. Panels now receive a reference to the deck selector frame and call methods directly.

## Changes
- **SideboardGuidePanel**: Removed callback parameters, calls frame methods directly
- **DeckNotesPanel**: Removed callback parameter, calls frame methods directly  
- Cleaner instantiation code in MTGDeckSelectionFrame (L528-539)
- Used TYPE_CHECKING to prevent circular imports

## Benefits
- Simpler, more explicit coupling between panels and frame
- No lambda wrappers needed at instantiation time
- Easier to follow event flow