### PR TITLE
Normalize collection ownership lookups

### DIFF
--- a/tests/test_collection_loading.py
+++ b/tests/test_collection_loading.py
@@ -48,6 +48,23 @@ def test_collection_service_loads_inventory_from_export(tmp_path):
     assert service.load_collection(temp_file)
 
     inventory = service.get_inventory()
-    assert inventory["Lightning Bolt"] == 5  # 4 + 1 duplicate entry
-    assert inventory["Island"] == 12
-    assert inventory["Spell Pierce"] == 2
+    assert inventory["lightning bolt"] == 5  # 4 + 1 duplicate entry
+    assert inventory["island"] == 12
+    assert inventory["spell pierce"] == 2
+
+
+def test_collection_service_owns_cards_case_insensitively(tmp_path):
+    repo = CardRepository()
+    service = CollectionService(card_repository=repo)
+
+    temp_file = tmp_path / "collection_full_trade_20240102.json"
+    temp_file.write_text(FIXTURE_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+    service.load_collection(temp_file)
+
+    # Under the hood everything is lowercase, but lookups should be case-insensitive
+    assert service.get_owned_count("Lightning Bolt") == 5
+    assert service.get_owned_count("lightning bolt") == 5
+    assert service.get_owned_count("LIGHTNING BOLT") == 5
+    assert service.owns_card("Spell Pierce", required_count=2)
+    assert not service.owns_card("Spell Pierce", required_count=3)


### PR DESCRIPTION
## Summary
- normalize every collection entry through a shared helper so caches, exports, and runtime updates all use lowercase keys
- make ownership queries/add/remove/set paths case-insensitive and keep set_inventory/load helpers aggregating duplicate entries
- update collection-loading tests and add a regression proving that owns_card/get_owned_count work regardless of deck card casing

## Testing
- pytest tests/test_collection_loading.py *(fails: ImportError: cannot import name 'UTC' from 'datetime'; repo currently runs under Python 3.10 but utils/card_images.py imports datetime.UTC (3.11+))*
