### PR TITLE
Refactor deck selector handlers and stores

### DIFF
--- a/repositories/card_repository.py
+++ b/repositories/card_repository.py
@@ -354,6 +354,25 @@ class CardRepository:
         if manager is not None:
             self._card_data_ready = True
 
+    def ensure_card_data_loaded(self, force: bool = False) -> CardDataManager:
+        """
+        Ensure that card data is available, loading it if necessary.
+
+        Args:
+            force: If True, force reload even if already loaded
+
+        Returns:
+            Initialized CardDataManager
+        """
+        if not force and self._card_data_manager is not None:
+            return self._card_data_manager
+
+        from utils.card_data import load_card_manager
+
+        manager = load_card_manager()
+        self.set_card_manager(manager)
+        return manager
+
 
 # Global instance for backward compatibility
 _default_repository = None

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -9,14 +9,17 @@ from services.collection_service import CollectionService, get_collection_servic
 from services.deck_service import DeckService, get_deck_service
 from services.image_service import ImageService, get_image_service
 from services.search_service import SearchService, get_search_service
+from services.store_service import StoreService, get_store_service
 
 __all__ = [
     "CollectionService",
     "DeckService",
     "ImageService",
     "SearchService",
+    "StoreService",
     "get_collection_service",
     "get_deck_service",
     "get_image_service",
     "get_search_service",
+    "get_store_service",
 ]

--- a/services/collection_service.py
+++ b/services/collection_service.py
@@ -15,9 +15,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import wx
 from loguru import logger
 
 from repositories.card_repository import CardRepository, get_card_repository
+from utils.ui_constants import SUBDUED_TEXT
 
 
 class CollectionService:
@@ -83,6 +85,27 @@ class CollectionService:
         except Exception as exc:
             logger.error(f"Failed to load collection: {exc}")
             return False
+
+    def get_owned_status(self, name: str, required: int) -> tuple[str, wx.Colour]:
+        """
+        Return ownership status text and color for a given card requirement.
+
+        Args:
+            name: Card name
+            required: Quantity needed
+
+        Returns:
+            Tuple containing the status label and wx colour
+        """
+        collection_inventory = self.get_inventory()
+        if not collection_inventory:
+            return ("Owned —", SUBDUED_TEXT)
+        have = collection_inventory.get(name.lower(), 0)
+        if have >= required:
+            return (f"Owned {have}/{required}", wx.Colour(120, 200, 120))
+        if have > 0:
+            return (f"Owned {have}/{required}", wx.Colour(230, 200, 90))
+        return ("Owned 0", wx.Colour(230, 120, 120))
 
     def find_latest_cached_file(
         self, directory: Path, pattern: str = "collection_full_trade_*.json"

--- a/services/store_service.py
+++ b/services/store_service.py
@@ -1,0 +1,59 @@
+"""Utility service for simple JSON-backed key/value stores."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+
+class StoreService:
+    """Service that reads and writes lightweight JSON stores."""
+
+    def load_store(self, path: Path) -> dict[str, Any]:
+        """
+        Load JSON data from the given path.
+
+        Args:
+            path: Path to the JSON store
+
+        Returns:
+            Dictionary payload (empty dict if unreadable)
+        """
+        if not path.exists():
+            return {}
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logger.warning(f"Invalid JSON at {path}; ignoring store")
+            return {}
+        except OSError as exc:
+            logger.warning(f"Failed to read {path}: {exc}")
+            return {}
+
+    def save_store(self, path: Path, data: dict[str, Any]) -> None:
+        """
+        Persist JSON data to the given path.
+
+        Args:
+            path: Path to write
+            data: Dictionary payload
+        """
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        except OSError as exc:
+            logger.warning(f"Failed to write {path}: {exc}")
+
+
+_default_store_service: StoreService | None = None
+
+
+def get_store_service() -> StoreService:
+    """Return a shared StoreService instance."""
+    global _default_store_service
+    if _default_store_service is None:
+        _default_store_service = StoreService()
+    return _default_store_service

--- a/tests/ui/test_deck_selector.py
+++ b/tests/ui/test_deck_selector.py
@@ -60,14 +60,14 @@ def test_notes_persist_across_frames(
     try:
         first_frame.deck_repo.set_current_deck({"href": "manual", "name": "Manual Deck"})
         first_frame.deck_notes_panel.notes_text.ChangeValue("Important note")
-        first_frame._save_current_notes()
+        first_frame.deck_notes_panel.save_current_notes()
     finally:
         first_frame.Destroy()
 
     second_frame = deck_selector_factory()
     try:
         second_frame.deck_repo.set_current_deck({"href": "manual", "name": "Manual Deck"})
-        second_frame._load_notes_for_current()
+        second_frame.deck_notes_panel.load_notes_for_current()
         assert second_frame.deck_notes_panel.notes_text.GetValue() == "Important note"
     finally:
         second_frame.Destroy()

--- a/utils/ui_helpers.py
+++ b/utils/ui_helpers.py
@@ -1,0 +1,71 @@
+"""Utility helpers for wx UI interactions shared across widgets."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import wx
+from loguru import logger
+
+
+def widget_exists(window: wx.Window | None) -> bool:
+    """
+    Check if a wx window reference is still valid and shown.
+
+    Args:
+        window: Window instance or None
+
+    Returns:
+        True if the window exists and is shown, else False
+    """
+    if window is None:
+        return False
+    try:
+        return bool(window.IsShown())
+    except wx.PyDeadObjectError:
+        return False
+
+
+def open_child_window(
+    owner: Any,
+    attr: str,
+    window_class: type[wx.Window],
+    title: str,
+    on_close: Callable[[wx.CloseEvent, str], None],
+    *args,
+    **kwargs,
+) -> wx.Window | None:
+    """
+    Create or raise a child window tracked on the parent frame.
+
+    Args:
+        owner: Parent frame that owns the window reference
+        attr: Attribute name on the owner storing the window
+        window_class: wx window class to instantiate
+        title: Friendly title used in error dialogs
+        on_close: Callback invoked when the window closes
+        *args: Positional args passed to the window constructor
+        **kwargs: Keyword args passed to the window constructor
+
+    Returns:
+        The opened window instance or None if creation failed
+    """
+    existing = getattr(owner, attr, None)
+    if widget_exists(existing):
+        existing.Raise()
+        return existing
+    try:
+        window = window_class(owner, *args, **kwargs)
+        window.Bind(wx.EVT_CLOSE, lambda evt: on_close(evt, attr))
+        window.Show()
+        setattr(owner, attr, window)
+        return window
+    except Exception as exc:  # pragma: no cover - UI side-effects
+        logger.error(f"Failed to open {title.lower()}: {exc}")
+        wx.MessageBox(
+            f"Unable to open {title.lower()}:\n{exc}",
+            title,
+            wx.OK | wx.ICON_ERROR,
+        )
+        return None

--- a/widgets/handlers/__init__.py
+++ b/widgets/handlers/__init__.py
@@ -1,0 +1,11 @@
+"""Handler mixins for widgets."""
+
+from widgets.handlers.card_table_panel_handler import CardTablePanelHandler
+from widgets.handlers.deck_selector_handlers import DeckSelectorHandlers
+from widgets.handlers.sideboard_guide_handlers import SideboardGuideHandlers
+
+__all__ = [
+    "CardTablePanelHandler",
+    "DeckSelectorHandlers",
+    "SideboardGuideHandlers",
+]

--- a/widgets/handlers/card_table_panel_handler.py
+++ b/widgets/handlers/card_table_panel_handler.py
@@ -1,0 +1,101 @@
+"""Handlers for card table interactions."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import wx
+
+from utils.ui_constants import ZONE_TITLES
+
+if TYPE_CHECKING:
+    from widgets.deck_selector import MTGDeckSelectionFrame
+
+
+class CardTablePanelHandler:
+    """Mixin containing zone editing and card focus handlers."""
+
+    def _handle_zone_delta(self: MTGDeckSelectionFrame, zone: str, name: str, delta: int) -> None:
+        cards = self.zone_cards.get(zone, [])
+        for entry in cards:
+            if entry["name"].lower() == name.lower():
+                current_qty = entry["qty"]
+                if isinstance(current_qty, float) and not current_qty.is_integer():
+                    current_qty = math.ceil(current_qty) if delta > 0 else math.floor(current_qty)
+                entry["qty"] = max(0, current_qty + delta)
+                if entry["qty"] == 0:
+                    cards.remove(entry)
+                break
+        else:
+            if delta > 0:
+                cards.append({"name": name, "qty": delta})
+        cards.sort(key=lambda item: item["name"].lower())
+        self.zone_cards[zone] = cards
+        self._after_zone_change(zone)
+
+    def _handle_zone_remove(self: MTGDeckSelectionFrame, zone: str, name: str) -> None:
+        cards = self.zone_cards.get(zone, [])
+        self.zone_cards[zone] = [entry for entry in cards if entry["name"].lower() != name.lower()]
+        self._after_zone_change(zone)
+
+    def _handle_zone_add(self: MTGDeckSelectionFrame, zone: str) -> None:
+        if zone == "out":
+            main_cards = [entry["name"] for entry in self.zone_cards.get("main", [])]
+            existing = {entry["name"].lower() for entry in self.zone_cards.get("out", [])}
+            candidates = [name for name in main_cards if name.lower() not in existing]
+            if not candidates:
+                wx.MessageBox(
+                    "All mainboard cards are already in the outboard list.",
+                    "Outboard",
+                    wx.OK | wx.ICON_INFORMATION,
+                )
+                return
+            dlg = wx.SingleChoiceDialog(
+                self, "Select a mainboard card eligible for sideboarding.", "Outboard", candidates
+            )
+            if dlg.ShowModal() != wx.ID_OK:
+                dlg.Destroy()
+                return
+            selection = dlg.GetStringSelection()
+            dlg.Destroy()
+            qty = next(
+                (entry["qty"] for entry in self.zone_cards["main"] if entry["name"] == selection), 1
+            )
+            self.zone_cards.setdefault("out", []).append({"name": selection, "qty": qty})
+            self.zone_cards["out"].sort(key=lambda item: item["name"].lower())
+            self._after_zone_change("out")
+            return
+
+        dlg = wx.TextEntryDialog(
+            self, f"Add card to {ZONE_TITLES.get(zone, zone)} (format: 'Qty Card Name')", "Add Card"
+        )
+        if dlg.ShowModal() != wx.ID_OK:
+            dlg.Destroy()
+            return
+        value = dlg.GetValue().strip()
+        dlg.Destroy()
+        if not value:
+            return
+        parts = value.split(" ", 1)
+        try:
+            qty = int(parts[0]) if len(parts) > 1 else 1
+        except ValueError:
+            qty = 1
+        name = parts[1].strip() if len(parts) > 1 else value
+        if not name:
+            return
+        self.zone_cards.setdefault(zone, []).append({"name": name, "qty": max(1, qty)})
+        self.zone_cards[zone].sort(key=lambda item: item["name"].lower())
+        self._after_zone_change(zone)
+
+    def _handle_card_focus(
+        self: MTGDeckSelectionFrame, zone: str, card: dict[str, Any] | None
+    ) -> None:
+        if card is None:
+            if self.card_inspector_panel.active_zone == zone:
+                self.card_inspector_panel.reset()
+            return
+        self._collapse_other_zone_tables(zone)
+        meta = self.card_repo.get_card_metadata(card["name"])
+        self.card_inspector_panel.update_card(card, zone=zone, meta=meta)

--- a/widgets/handlers/deck_selector_handlers.py
+++ b/widgets/handlers/deck_selector_handlers.py
@@ -8,11 +8,13 @@ from typing import TYPE_CHECKING, Any
 import wx
 from loguru import logger
 
+from utils.ui_helpers import widget_exists
+
 if TYPE_CHECKING:
     from widgets.deck_selector import MTGDeckSelectionFrame
 
 
-class DeckSelectorEventHandlers:
+class DeckSelectorHandlers:
     """Mixin class containing all event handlers for MTGDeckSelectionFrame."""
 
     # UI Event Handlers
@@ -76,7 +78,7 @@ class DeckSelectorEventHandlers:
                 return
         if not self.deck_repo.get_decks_list():
             return
-        self._build_daily_average_deck()
+        self._start_daily_average_build()
 
     def on_copy_clicked(self: MTGDeckSelectionFrame, _event: wx.CommandEvent) -> None:
         deck_content = self._build_deck_text().strip()
@@ -152,7 +154,7 @@ class DeckSelectorEventHandlers:
         self._save_window_settings()
         for attr in ("tracker_window", "timer_window", "history_window"):
             window = getattr(self, attr)
-            if self._widget_exists(window):
+            if widget_exists(window):
                 window.Destroy()
                 setattr(self, attr, None)
         if self.mana_keyboard_window and self.mana_keyboard_window.IsShown():
@@ -236,7 +238,7 @@ class DeckSelectorEventHandlers:
         self._update_stats(deck_text)
         self.copy_button.Enable(True)
         self.save_button.Enable(True)
-        self._load_notes_for_current()
+        self.deck_notes_panel.load_notes_for_current()
         self._load_guide_for_current()
         self._set_status(f"Deck ready ({source}).")
         self._show_left_panel("builder")

--- a/widgets/handlers/sideboard_guide_handlers.py
+++ b/widgets/handlers/sideboard_guide_handlers.py
@@ -1,0 +1,120 @@
+"""Sideboard guide and outboard handlers for the deck selector frame."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import wx
+
+from widgets.dialogs.guide_entry_dialog import GuideEntryDialog
+
+if TYPE_CHECKING:
+    from widgets.deck_selector import MTGDeckSelectionFrame
+
+
+class SideboardGuideHandlers:
+    """Mixin that centralizes guide/outboard interactions for the deck selector."""
+
+    def _persist_outboard_for_current(self: MTGDeckSelectionFrame) -> None:
+        key = self.deck_repo.get_current_deck_key()
+        self.outboard_store[key] = self.zone_cards.get("out", [])
+        self.store_service.save_store(self.outboard_store_path, self.outboard_store)
+
+    def _load_outboard_for_current(self: MTGDeckSelectionFrame) -> list[dict[str, Any]]:
+        key = self.deck_repo.get_current_deck_key()
+        data = self.outboard_store.get(key, [])
+        cleaned: list[dict[str, Any]] = []
+        for entry in data:
+            name = entry.get("name")
+            qty_raw = entry.get("qty", 0)
+            try:
+                qty_float = float(qty_raw)
+                qty = int(qty_float) if qty_float.is_integer() else qty_float
+            except (TypeError, ValueError):
+                qty = 0
+            if name and qty > 0:
+                cleaned.append({"name": name, "qty": qty})
+        return cleaned
+
+    def _load_guide_for_current(self: MTGDeckSelectionFrame) -> None:
+        key = self.deck_repo.get_current_deck_key()
+        payload = self.guide_store.get(key) or {}
+        self.sideboard_guide_entries = payload.get("entries", [])
+        self.sideboard_exclusions = payload.get("exclusions", [])
+        self.sideboard_guide_panel.set_entries(
+            self.sideboard_guide_entries, self.sideboard_exclusions
+        )
+
+    def _persist_guide_for_current(self: MTGDeckSelectionFrame) -> None:
+        key = self.deck_repo.get_current_deck_key()
+        self.guide_store[key] = {
+            "entries": self.sideboard_guide_entries,
+            "exclusions": self.sideboard_exclusions,
+        }
+        self.store_service.save_store(self.guide_store_path, self.guide_store)
+
+    def _refresh_guide_view(self: MTGDeckSelectionFrame) -> None:
+        self.sideboard_guide_panel.set_entries(
+            self.sideboard_guide_entries, self.sideboard_exclusions
+        )
+
+    def _on_add_guide_entry(self: MTGDeckSelectionFrame) -> None:
+        names = [item.get("name", "") for item in self.archetypes]
+        dlg = GuideEntryDialog(self, names)
+        if dlg.ShowModal() == wx.ID_OK:
+            data = dlg.get_data()
+            if data.get("archetype"):
+                self.sideboard_guide_entries.append(data)
+                self._persist_guide_for_current()
+                self._refresh_guide_view()
+        dlg.Destroy()
+
+    def _on_edit_guide_entry(self: MTGDeckSelectionFrame) -> None:
+        index = self.sideboard_guide_panel.get_selected_index()
+        if index is None:
+            wx.MessageBox(
+                "Select an entry to edit.", "Sideboard Guide", wx.OK | wx.ICON_INFORMATION
+            )
+            return
+        data = self.sideboard_guide_entries[index]
+        names = [item.get("name", "") for item in self.archetypes]
+        dlg = GuideEntryDialog(self, names, data=data)
+        if dlg.ShowModal() == wx.ID_OK:
+            updated = dlg.get_data()
+            if updated.get("archetype"):
+                self.sideboard_guide_entries[index] = updated
+                self._persist_guide_for_current()
+                self._refresh_guide_view()
+        dlg.Destroy()
+
+    def _on_remove_guide_entry(self: MTGDeckSelectionFrame) -> None:
+        index = self.sideboard_guide_panel.get_selected_index()
+        if index is None:
+            wx.MessageBox(
+                "Select an entry to remove.", "Sideboard Guide", wx.OK | wx.ICON_INFORMATION
+            )
+            return
+        del self.sideboard_guide_entries[index]
+        self._persist_guide_for_current()
+        self._refresh_guide_view()
+
+    def _on_edit_exclusions(self: MTGDeckSelectionFrame) -> None:
+        archetype_names = [item.get("name", "") for item in self.archetypes]
+        dlg = wx.MultiChoiceDialog(
+            self,
+            "Select archetypes to exclude from the printed guide.",
+            "Sideboard Guide",
+            archetype_names,
+        )
+        selected_indices = [
+            archetype_names.index(name)
+            for name in self.sideboard_exclusions
+            if name in archetype_names
+        ]
+        dlg.SetSelections(selected_indices)
+        if dlg.ShowModal() == wx.ID_OK:
+            selections = dlg.GetSelections()
+            self.sideboard_exclusions = [archetype_names[idx] for idx in selections]
+            self._persist_guide_for_current()
+            self._refresh_guide_view()
+        dlg.Destroy()

--- a/widgets/panels/deck_notes_panel.py
+++ b/widgets/panels/deck_notes_panel.py
@@ -80,8 +80,26 @@ class DeckNotesPanel(wx.Panel):
         """Clear the notes text."""
         self.notes_text.ChangeValue("")
 
+    def load_notes_for_current(self) -> None:
+        """Load notes for the deck currently selected in the frame."""
+        deck_selector = self.deck_selector_frame
+        deck_key = deck_selector.deck_repo.get_current_deck_key()
+        note = deck_selector.deck_notes_store.get(deck_key, "")
+        self.set_notes(note)
+
+    def save_current_notes(self) -> None:
+        """Persist notes for the currently selected deck."""
+        deck_selector = self.deck_selector_frame
+        deck_key = deck_selector.deck_repo.get_current_deck_key()
+        deck_selector.deck_notes_store[deck_key] = self.get_notes()
+        deck_selector.store_service.save_store(
+            deck_selector.notes_store_path,
+            deck_selector.deck_notes_store,
+        )
+        deck_selector._set_status("Deck notes saved.")
+
     # ============= Private Methods =============
 
     def _on_save_clicked(self, _event: wx.Event) -> None:
         """Handle Save Notes button click."""
-        self.deck_selector_frame._save_current_notes()
+        self.save_current_notes()

--- a/widgets/panels/sideboard_guide_panel.py
+++ b/widgets/panels/sideboard_guide_panel.py
@@ -7,14 +7,13 @@ to side in/out and matchup notes.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import wx
 import wx.dataview as dv
 
 from utils.stylize import stylize_button
 from utils.ui_constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
-from widgets.dialogs.guide_entry_dialog import GuideEntryDialog
 
 if TYPE_CHECKING:
     from widgets.deck_selector import MTGDeckSelectionFrame
@@ -174,111 +173,3 @@ class SideboardGuidePanel(wx.Panel):
     def _on_exclusions_clicked(self, _event: wx.Event) -> None:
         """Handle Exclude Archetypes button click."""
         self.deck_selector_frame._on_edit_exclusions()
-
-
-class SideboardGuideHandlers:
-    """Mixin that centralizes guide/outboard interactions for the deck selector."""
-
-    def _persist_outboard_for_current(self) -> None:
-        key = self._current_deck_key()
-        self.outboard_store[key] = self.zone_cards.get("out", [])
-        self._save_store(self.outboard_store_path, self.outboard_store)
-
-    def _load_outboard_for_current(self) -> list[dict[str, Any]]:
-        key = self._current_deck_key()
-        data = self.outboard_store.get(key, [])
-        cleaned: list[dict[str, Any]] = []
-        for entry in data:
-            name = entry.get("name")
-            qty_raw = entry.get("qty", 0)
-            try:
-                qty_float = float(qty_raw)
-                qty = int(qty_float) if qty_float.is_integer() else qty_float
-            except (TypeError, ValueError):
-                qty = 0
-            if name and qty > 0:
-                cleaned.append({"name": name, "qty": qty})
-        return cleaned
-
-    def _load_guide_for_current(self) -> None:
-        key = self._current_deck_key()
-        payload = self.guide_store.get(key) or {}
-        self.sideboard_guide_entries = payload.get("entries", [])
-        self.sideboard_exclusions = payload.get("exclusions", [])
-        self.sideboard_guide_panel.set_entries(
-            self.sideboard_guide_entries, self.sideboard_exclusions
-        )
-
-    def _persist_guide_for_current(self) -> None:
-        key = self._current_deck_key()
-        self.guide_store[key] = {
-            "entries": self.sideboard_guide_entries,
-            "exclusions": self.sideboard_exclusions,
-        }
-        self._save_store(self.guide_store_path, self.guide_store)
-
-    def _refresh_guide_view(self) -> None:
-        self.sideboard_guide_panel.set_entries(
-            self.sideboard_guide_entries, self.sideboard_exclusions
-        )
-
-    def _on_add_guide_entry(self) -> None:
-        names = [item.get("name", "") for item in self.archetypes]
-        dlg = GuideEntryDialog(self, names)
-        if dlg.ShowModal() == wx.ID_OK:
-            data = dlg.get_data()
-            if data.get("archetype"):
-                self.sideboard_guide_entries.append(data)
-                self._persist_guide_for_current()
-                self._refresh_guide_view()
-        dlg.Destroy()
-
-    def _on_edit_guide_entry(self) -> None:
-        index = self.sideboard_guide_panel.get_selected_index()
-        if index is None:
-            wx.MessageBox(
-                "Select an entry to edit.", "Sideboard Guide", wx.OK | wx.ICON_INFORMATION
-            )
-            return
-        data = self.sideboard_guide_entries[index]
-        names = [item.get("name", "") for item in self.archetypes]
-        dlg = GuideEntryDialog(self, names, data=data)
-        if dlg.ShowModal() == wx.ID_OK:
-            updated = dlg.get_data()
-            if updated.get("archetype"):
-                self.sideboard_guide_entries[index] = updated
-                self._persist_guide_for_current()
-                self._refresh_guide_view()
-        dlg.Destroy()
-
-    def _on_remove_guide_entry(self) -> None:
-        index = self.sideboard_guide_panel.get_selected_index()
-        if index is None:
-            wx.MessageBox(
-                "Select an entry to remove.", "Sideboard Guide", wx.OK | wx.ICON_INFORMATION
-            )
-            return
-        del self.sideboard_guide_entries[index]
-        self._persist_guide_for_current()
-        self._refresh_guide_view()
-
-    def _on_edit_exclusions(self) -> None:
-        archetype_names = [item.get("name", "") for item in self.archetypes]
-        dlg = wx.MultiChoiceDialog(
-            self,
-            "Select archetypes to exclude from the printed guide.",
-            "Sideboard Guide",
-            archetype_names,
-        )
-        selected_indices = [
-            archetype_names.index(name)
-            for name in self.sideboard_exclusions
-            if name in archetype_names
-        ]
-        dlg.SetSelections(selected_indices)
-        if dlg.ShowModal() == wx.ID_OK:
-            selections = dlg.GetSelections()
-            self.sideboard_exclusions = [archetype_names[idx] for idx in selections]
-            self._persist_guide_for_current()
-            self._refresh_guide_view()
-        dlg.Destroy()


### PR DESCRIPTION
## Summary
- extract deck selector handlers into dedicated mixins (DeckSelectorHandlers, CardTablePanelHandler, SideboardGuideHandlers) and add ui/store helpers so MTGDeckSelectionFrame only wires UI
- move card notes/outboard/guide persistence to StoreService-backed helpers and repositories (DeckRepository.get_current_deck_key, CardRepository.ensure_card_data_loaded, CollectionService.get_owned_status)
- update deck notes panel/tests plus wiring throughout widgets, format with Black/Ruff

## Testing
- python3 -m black .
- python3 -m ruff check .
- ./run_pytest_on_host.sh tests *(remote Windows host: pytest reported 27 passed, 3 skipped in 2.13s; wrapper exited 29 but suite succeeded)*