### PR TITLE
Extract hard-coded cache ttl defaults

### DIFF
--- a/repositories/metagame_repository.py
+++ b/repositories/metagame_repository.py
@@ -22,12 +22,13 @@ from utils.paths import (
     ARCHETYPE_LIST_CACHE_FILE,
     DECK_CACHE_FILE,
 )
+from utils.service_config import METAGAME_CACHE_TTL_SECONDS
 
 
 class MetagameRepository:
     """Repository for metagame data access operations."""
 
-    def __init__(self, cache_ttl: int = 3600):
+    def __init__(self, cache_ttl: int = METAGAME_CACHE_TTL_SECONDS):
         """
         Initialize the metagame repository.
 

--- a/services/collection_service.py
+++ b/services/collection_service.py
@@ -19,6 +19,10 @@ import wx
 from loguru import logger
 
 from repositories.card_repository import CardRepository, get_card_repository
+from utils.service_config import (
+    COLLECTION_CACHE_MAX_AGE_SECONDS,
+    ONE_HOUR_SECONDS,
+)
 from utils.ui_constants import SUBDUED_TEXT
 
 
@@ -156,7 +160,7 @@ class CollectionService:
 
             # Calculate file age
             file_age_seconds = datetime.now().timestamp() - latest.stat().st_mtime
-            age_hours = int(file_age_seconds / 3600)
+            age_hours = int(file_age_seconds / ONE_HOUR_SECONDS)
 
             logger.info(
                 f"Loaded collection from cache: {len(mapping)} unique cards from {latest.name}"
@@ -248,7 +252,7 @@ class CollectionService:
         force: bool = False,
         on_success: Callable[[Path, list], None] | None = None,
         on_error: Callable[[str], None] | None = None,
-        cache_max_age_seconds: int = 3600,
+        cache_max_age_seconds: int = COLLECTION_CACHE_MAX_AGE_SECONDS,
     ) -> bool:
         """
         Fetch collection from MTGO Bridge and export to file (async).

--- a/services/image_service.py
+++ b/services/image_service.py
@@ -21,6 +21,7 @@ from utils.card_images import (
     ensure_printing_index_cache,
     get_cache,
 )
+from utils.service_config import BULK_DATA_CACHE_FRESHNESS_SECONDS
 
 
 class ImageService:
@@ -66,7 +67,7 @@ class ImageService:
             # Fallback to age-based check
             try:
                 age_seconds = datetime.now().timestamp() - BULK_DATA_CACHE.stat().st_mtime
-                if age_seconds < 86400:  # Less than 24 hours
+                if age_seconds < BULK_DATA_CACHE_FRESHNESS_SECONDS:
                     reason = f"Bulk data cache is recent ({age_seconds/3600:.1f}h old)"
                     logger.info(reason)
                     return False, reason

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -16,6 +16,7 @@ import utils.paths as paths
 import widgets.deck_selector as deck_selector
 import widgets.identify_opponent as identify_opponent
 from utils.card_data import CardDataManager
+from utils.service_config import METAGAME_CACHE_TTL_SECONDS
 from widgets.deck_selector import MTGDeckSelectionFrame
 
 wx = pytest.importorskip("wx")
@@ -271,7 +272,9 @@ def ui_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         {"name": "Azorius Control", "href": "azorius-control"},
     ]
 
-    def fake_archetypes(fmt: str, cache_ttl: int = 3600, allow_stale: bool = True):
+    def fake_archetypes(
+        fmt: str, cache_ttl: int = METAGAME_CACHE_TTL_SECONDS, allow_stale: bool = True
+    ):
         return archetype_list
 
     def fake_archetype_decks(archetype: str):

--- a/utils/card_images.py
+++ b/utils/card_images.py
@@ -28,6 +28,7 @@ import requests
 from loguru import logger
 
 from utils.paths import CACHE_DIR
+from utils.service_config import BULK_DATA_CACHE_FRESHNESS_SECONDS
 
 # Image cache configuration
 IMAGE_CACHE_DIR = CACHE_DIR / "card_images"
@@ -332,7 +333,7 @@ class BulkImageDownloader:
         # Fallback to age-based check when the vendor metadata lacks timestamps/URIs
         try:
             age_seconds = datetime.now().timestamp() - BULK_DATA_CACHE.stat().st_mtime
-            if age_seconds < 86400:
+            if age_seconds < BULK_DATA_CACHE_FRESHNESS_SECONDS:
                 return False, metadata
         except OSError:
             pass

--- a/utils/service_config.py
+++ b/utils/service_config.py
@@ -1,0 +1,21 @@
+"""Service-level configuration defaults shared across modules."""
+
+ONE_HOUR_SECONDS = 60 * 60
+ONE_DAY_SECONDS = 24 * 60 * 60
+
+# Collection inventory refresh settings
+COLLECTION_CACHE_MAX_AGE_SECONDS = ONE_HOUR_SECONDS
+
+# Metagame scraping cache TTL
+METAGAME_CACHE_TTL_SECONDS = ONE_HOUR_SECONDS
+
+# Card image bulk data refresh thresholds
+BULK_DATA_CACHE_FRESHNESS_SECONDS = ONE_DAY_SECONDS
+
+__all__ = [
+    "ONE_HOUR_SECONDS",
+    "ONE_DAY_SECONDS",
+    "COLLECTION_CACHE_MAX_AGE_SECONDS",
+    "METAGAME_CACHE_TTL_SECONDS",
+    "BULK_DATA_CACHE_FRESHNESS_SECONDS",
+]

--- a/widgets/deck_selector.py
+++ b/widgets/deck_selector.py
@@ -30,6 +30,7 @@ from utils.paths import (
     DECK_SELECTOR_SETTINGS_FILE,
     DECKS_DIR,
 )
+from utils.service_config import COLLECTION_CACHE_MAX_AGE_SECONDS
 from utils.stylize import stylize_listbox, stylize_textctrl
 from utils.ui_constants import (
     DARK_BG,
@@ -759,7 +760,7 @@ class MTGDeckSelectionFrame(
                 self._on_collection_fetched, filepath, cards
             ),
             on_error=lambda error_msg: wx.CallAfter(self._on_collection_fetch_failed, error_msg),
-            cache_max_age_seconds=3600,  # 1 hour
+            cache_max_age_seconds=COLLECTION_CACHE_MAX_AGE_SECONDS,
         )
 
     def _check_and_download_bulk_data(self) -> None:


### PR DESCRIPTION
## Summary
- centralize collection, metagame, and bulk data cache thresholds in utils/service_config
- wire services, repositories, widgets, and tests to the shared configuration so values stay consistent

## Testing
- Not run (GitHub Actions will execute the Windows-required pytest workflow)