### PR TITLE
Standardize service access patterns

### DIFF
--- a/widgets/deck_selector.py
+++ b/widgets/deck_selector.py
@@ -435,13 +435,20 @@ class MTGDeckSelectionFrame(
 
         self.sideboard_guide_panel = SideboardGuidePanel(
             self.deck_tabs,
-            deck_selector_frame=self,
+            on_add_entry=self._on_add_guide_entry,
+            on_edit_entry=self._on_edit_guide_entry,
+            on_remove_entry=self._on_remove_guide_entry,
+            on_edit_exclusions=self._on_edit_exclusions,
         )
         self.deck_tabs.AddPage(self.sideboard_guide_panel, "Sideboard Guide")
 
         self.deck_notes_panel = DeckNotesPanel(
             self.deck_tabs,
-            deck_selector_frame=self,
+            deck_repo=self.deck_repo,
+            store_service=self.store_service,
+            notes_store=self.deck_notes_store,
+            notes_store_path=self.notes_store_path,
+            on_status_update=self._set_status,
         )
         self.deck_tabs.AddPage(self.deck_notes_panel, "Deck Notes")
 

--- a/widgets/panels/sideboard_guide_panel.py
+++ b/widgets/panels/sideboard_guide_panel.py
@@ -7,16 +7,13 @@ to side in/out and matchup notes.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 import wx
 import wx.dataview as dv
 
 from utils.stylize import stylize_button
 from utils.ui_constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
-
-if TYPE_CHECKING:
-    from widgets.deck_selector import MTGDeckSelectionFrame
 
 
 class SideboardGuidePanel(wx.Panel):
@@ -25,19 +22,28 @@ class SideboardGuidePanel(wx.Panel):
     def __init__(
         self,
         parent: wx.Window,
-        deck_selector_frame: MTGDeckSelectionFrame,
+        on_add_entry: Callable[[], None],
+        on_edit_entry: Callable[[], None],
+        on_remove_entry: Callable[[], None],
+        on_edit_exclusions: Callable[[], None],
     ):
         """
         Initialize the sideboard guide panel.
 
         Args:
             parent: Parent window
-            deck_selector_frame: Reference to the main deck selector frame
+            on_add_entry: Callback for adding a new guide entry
+            on_edit_entry: Callback for editing selected entry
+            on_remove_entry: Callback for removing selected entry
+            on_edit_exclusions: Callback for editing archetype exclusions
         """
         super().__init__(parent)
         self.SetBackgroundColour(DARK_PANEL)
 
-        self.deck_selector_frame = deck_selector_frame
+        self.on_add_entry = on_add_entry
+        self.on_edit_entry = on_edit_entry
+        self.on_remove_entry = on_remove_entry
+        self.on_edit_exclusions = on_edit_exclusions
 
         self.entries: list[dict[str, str]] = []
         self.exclusions: list[str] = []
@@ -160,16 +166,16 @@ class SideboardGuidePanel(wx.Panel):
 
     def _on_add_clicked(self, _event: wx.Event) -> None:
         """Handle Add Entry button click."""
-        self.deck_selector_frame._on_add_guide_entry()
+        self.on_add_entry()
 
     def _on_edit_clicked(self, _event: wx.Event) -> None:
         """Handle Edit Entry button click."""
-        self.deck_selector_frame._on_edit_guide_entry()
+        self.on_edit_entry()
 
     def _on_remove_clicked(self, _event: wx.Event) -> None:
         """Handle Remove Entry button click."""
-        self.deck_selector_frame._on_remove_guide_entry()
+        self.on_remove_entry()
 
     def _on_exclusions_clicked(self, _event: wx.Event) -> None:
         """Handle Exclude Archetypes button click."""
-        self.deck_selector_frame._on_edit_exclusions()
+        self.on_edit_exclusions()


### PR DESCRIPTION
Replaces frame references with dependency injection in DeckNotesPanel and SideboardGuidePanel to eliminate tight coupling and align with refactoring goal of separating UI from business logic.

Changes:
- DeckNotesPanel now receives deck_repo, store_service, notes_store, notes_store_path, and status callback
- SideboardGuidePanel now receives action callbacks instead of frame reference
- Updated panel instantiations in deck_selector.py

Fixes #13