### PR TITLE
Standardize error handling strategy

### DIFF
--- a/tests/test_collection_service.py
+++ b/tests/test_collection_service.py
@@ -133,9 +133,8 @@ def test_load_from_cached_file_success(collection_service, tmp_path):
     filepath = tmp_path / "collection_full_trade_20240101.json"
     filepath.write_text(json.dumps(collection_data), encoding="utf-8")
 
-    success, info = collection_service.load_from_cached_file(tmp_path)
+    info = collection_service.load_from_cached_file(tmp_path)
 
-    assert success is True
     assert info["card_count"] == 2
     assert info["filepath"] == filepath
     assert "age_hours" in info
@@ -144,10 +143,9 @@ def test_load_from_cached_file_success(collection_service, tmp_path):
 
 def test_load_from_cached_file_no_files(collection_service, tmp_path):
     """Test loading from cached file when none exist."""
-    success, info = collection_service.load_from_cached_file(tmp_path)
+    with pytest.raises(FileNotFoundError, match="No cached collection files found"):
+        collection_service.load_from_cached_file(tmp_path)
 
-    assert success is False
-    assert "error" in info
     assert collection_service.get_collection_size() == 0
 
 
@@ -158,9 +156,8 @@ def test_load_from_card_list(collection_service):
         {"name": "Island", "quantity": 20},
     ]
 
-    success, info = collection_service.load_from_card_list(cards)
+    info = collection_service.load_from_card_list(cards)
 
-    assert success is True
     assert info["card_count"] == 2
     assert collection_service.get_owned_count("lightning bolt") == 4
     assert collection_service.get_owned_count("island") == 20
@@ -173,9 +170,8 @@ def test_export_to_file(collection_service, tmp_path):
         {"name": "Island", "quantity": 20},
     ]
 
-    success, filepath = collection_service.export_to_file(cards, tmp_path)
+    filepath = collection_service.export_to_file(cards, tmp_path)
 
-    assert success is True
     assert filepath is not None
     assert filepath.exists()
     assert "collection_full_trade_" in filepath.name

--- a/utils/result.py
+++ b/utils/result.py
@@ -1,0 +1,45 @@
+"""Result type for operations that may succeed or fail."""
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+E = TypeVar("E")
+
+
+@dataclass
+class Result(Generic[T, E]):
+    """Result type for operations that may succeed or fail."""
+
+    value: T | None = None
+    error: E | None = None
+
+    @property
+    def is_success(self) -> bool:
+        """Check if the result is successful."""
+        return self.error is None
+
+    @property
+    def is_error(self) -> bool:
+        """Check if the result is an error."""
+        return self.error is not None
+
+    @classmethod
+    def success(cls, value: T) -> "Result[T, E]":
+        """Create a successful result."""
+        return cls(value=value, error=None)
+
+    @classmethod
+    def failure(cls, error: E) -> "Result[T, E]":
+        """Create a failed result."""
+        return cls(value=None, error=error)
+
+    def unwrap(self) -> T:
+        """Unwrap the value, raising if error."""
+        if self.is_error:
+            raise ValueError(f"Cannot unwrap error result: {self.error}")
+        return self.value  # type: ignore
+
+    def unwrap_or(self, default: T) -> T:
+        """Unwrap the value or return default if error."""
+        return self.value if self.is_success else default

--- a/widgets/deck_selector.py
+++ b/widgets/deck_selector.py
@@ -733,9 +733,10 @@ class MTGDeckSelectionFrame(
 
     def _load_collection_from_cache(self) -> bool:
         """Load collection from cached file without calling bridge. Returns True if loaded."""
-        success, info = self.collection_service.load_from_cached_file(DECK_SAVE_DIR)
-
-        if not success:
+        try:
+            info = self.collection_service.load_from_cached_file(DECK_SAVE_DIR)
+        except (FileNotFoundError, ValueError) as exc:
+            logger.debug(f"Could not load collection from cache: {exc}")
             self.collection_status_label.SetLabel(
                 "No collection found. Click 'Refresh Collection' to fetch from MTGO."
             )

--- a/widgets/handlers/deck_selector_handlers.py
+++ b/widgets/handlers/deck_selector_handlers.py
@@ -247,12 +247,13 @@ class DeckSelectorHandlers:
     def _on_collection_fetched(self: MTGDeckSelectionFrame, filepath: Path, cards: list) -> None:
         """Handle successful collection fetch."""
         if cards:
-            success, info = self.collection_service.load_from_card_list(cards, filepath)
-            if not success:
-                error = info.get("error", "Unknown error")
-                self.collection_status_label.SetLabel(f"Collection load failed: {error}")
+            try:
+                info = self.collection_service.load_from_card_list(cards, filepath)
+                card_count = info["card_count"]
+            except ValueError as exc:
+                logger.error(f"Failed to load collection: {exc}")
+                self.collection_status_label.SetLabel(f"Collection load failed: {exc}")
                 return
-            card_count = info["card_count"]
         else:
             card_count = len(self.collection_service.get_inventory())
 


### PR DESCRIPTION
Addresses issue #22 by standardizing error handling patterns across the codebase.

Changes synchronous operations in services to raise exceptions instead of returning success tuples. Async operations continue using callbacks as appropriate. Created Result type for future data validation operations.

Key changes:
- collection_service methods now raise FileNotFoundError, ValueError, or OSError instead of returning (success, data) tuples
- Widgets updated to handle exceptions with try-except blocks
- Added utils/result.py for validation operations
- Updated tests to expect exceptions

This improves code clarity and follows Python conventions for error handling.