### PR TITLE
Add tests for card image cache

### DIFF
--- a/tests/test_card_images_cache.py
+++ b/tests/test_card_images_cache.py
@@ -58,9 +58,7 @@ def test_card_image_cache_migrates_face_index_column(tmp_path):
     with sqlite3.connect(db_path) as conn:
         columns = {row[1] for row in conn.execute("PRAGMA table_info(card_images)")}
         assert "face_index" in columns
-        migrated_row = conn.execute(
-            "SELECT uuid, face_index, name FROM card_images"
-        ).fetchone()
+        migrated_row = conn.execute("SELECT uuid, face_index, name FROM card_images").fetchone()
 
     assert migrated_row == ("uuid-old", 0, "Legacy Entry")
 

--- a/utils/card_images.py
+++ b/utils/card_images.py
@@ -27,7 +27,7 @@ try:  # Python 3.10 fallback for datetime.UTC
 except ImportError:  # pragma: no cover - compatibility shim
     from datetime import timezone as _timezone
 
-    UTC = _timezone.utc
+    UTC = _timezone.utc  # noqa: UP017
 from pathlib import Path, PureWindowsPath
 from typing import Any
 


### PR DESCRIPTION
## Summary
- add python 3.10-compatible UTC fallback
- add tests for cache migration, path normalization, and bulk metadata freshness

## Testing
- pytest tests/test_card_images_cache.py tests/test_card_images_aliases.py