### PR TITLE
Add diagnostics export flow and opt-in event logging

### DIFF
--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,13 +1,19 @@
 """Controllers module - Application-level controllers for coordinating business logic."""
 
-from controllers.app_controller import (
-    AppController,
-    get_deck_selector_controller,
-    reset_deck_selector_controller,
-)
+try:  # wxPython may be missing in headless environments
+    from controllers.app_controller import (
+        AppController,
+        get_deck_selector_controller,
+        reset_deck_selector_controller,
+    )
+except Exception:  # pragma: no cover - UI controller unavailable without wx
+    AppController = None
 
-__all__ = [
-    "AppController",
-    "get_deck_selector_controller",
-    "reset_deck_selector_controller",
-]
+    def get_deck_selector_controller():
+        raise RuntimeError("AppController is unavailable (wxPython not installed)")
+
+    def reset_deck_selector_controller():
+        return None
+
+
+__all__ = ["AppController", "get_deck_selector_controller", "reset_deck_selector_controller"]

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -22,7 +22,16 @@ except Exception:  # pragma: no cover - collection service not available without
 from services.deck_research_service import DeckResearchService
 from services.deck_service import DeckService, ZoneUpdateResult, get_deck_service
 from services.image_service import ImageService, get_image_service
-from services.search_service import SearchService, get_search_service
+
+try:  # wxPython may be missing in headless environments
+    from services.search_service import SearchService, get_search_service
+except Exception:  # pragma: no cover - search service not available without wx
+    SearchService = None
+
+    def get_search_service():
+        raise RuntimeError("SearchService is unavailable (wxPython not installed)")
+
+
 from services.state_service import StateService
 from services.store_service import StoreService, get_store_service
 

--- a/services/diagnostics_service.py
+++ b/services/diagnostics_service.py
@@ -1,0 +1,154 @@
+"""Diagnostics and feedback utilities: opt-in event logging and export packaging."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from collections.abc import Iterable
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from utils.constants import (
+    DIAGNOSTICS_EVENT_LOG,
+    DIAGNOSTICS_SETTINGS_FILE,
+    LOGS_DIR,
+    ensure_base_dirs,
+)
+
+
+class DiagnosticsService:
+    """Manage lightweight event logging and diagnostics export."""
+
+    def __init__(
+        self,
+        *,
+        logs_dir: Path | None = None,
+        settings_path: Path | None = None,
+        event_log_path: Path | None = None,
+    ) -> None:
+        ensure_base_dirs()
+        self.logs_dir = Path(logs_dir or LOGS_DIR)
+        self.settings_path = Path(settings_path or DIAGNOSTICS_SETTINGS_FILE)
+        self.event_log_path = Path(event_log_path or DIAGNOSTICS_EVENT_LOG)
+        self._settings = self._load_settings()
+
+    # ------------------------------------------------------------------ settings ------------------------------------------------------------------
+    def _load_settings(self) -> dict[str, Any]:
+        default = {"event_logging_enabled": False}
+        if not self.settings_path.exists():
+            return default
+        try:
+            data = json.loads(self.settings_path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                return default
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(f"Unable to read diagnostics settings: {exc}")
+            return default
+        return {**default, **data}
+
+    def _persist_settings(self) -> None:
+        try:
+            self.settings_path.parent.mkdir(parents=True, exist_ok=True)
+            self.settings_path.write_text(
+                json.dumps(self._settings, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+        except OSError as exc:
+            logger.warning(f"Failed to persist diagnostics settings: {exc}")
+
+    @property
+    def event_logging_enabled(self) -> bool:
+        return bool(self._settings.get("event_logging_enabled", False))
+
+    def set_event_logging_enabled(self, enabled: bool) -> None:
+        if self._settings.get("event_logging_enabled") == enabled:
+            return
+        self._settings["event_logging_enabled"] = bool(enabled)
+        self._persist_settings()
+
+    # ------------------------------------------------------------------ event logging ------------------------------------------------------------------
+    def log_event(self, name: str, *, metadata: dict[str, Any] | None = None) -> None:
+        """Append an anonymized event entry if opt-in is enabled."""
+        if not self.event_logging_enabled:
+            return
+        payload = {
+            "ts": datetime.utcnow().isoformat() + "Z",
+            "event": name,
+            "data": metadata or {},
+        }
+        try:
+            self.event_log_path.parent.mkdir(parents=True, exist_ok=True)
+            with self.event_log_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        except OSError as exc:
+            logger.debug(f"Failed to write event log: {exc}")
+
+    # ------------------------------------------------------------------ export ------------------------------------------------------------------
+    def export_diagnostics(
+        self,
+        *,
+        feedback: str = "",
+        include_logs: bool = True,
+        include_event_log: bool = True,
+        extra_files: Iterable[Path] | None = None,
+        destination: Path | None = None,
+    ) -> Path:
+        """
+        Package feedback + diagnostics into a zip file.
+
+        Args:
+            feedback: User-provided notes
+            include_logs: Whether to include standard log files
+            include_event_log: Whether to include anonymized event log
+            extra_files: Additional files to include
+            destination: Optional destination path for the zip
+        """
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        dest_path = destination or (self.logs_dir / f"mtgo_tools_diagnostics_{timestamp}.zip")
+
+        files_to_add: list[tuple[Path, str]] = []
+        if include_logs and self.logs_dir.exists():
+            for path in sorted(self.logs_dir.glob("*.log")):
+                files_to_add.append((path, f"logs/{path.name}"))
+        if include_event_log and self.event_log_path.exists():
+            files_to_add.append((self.event_log_path, "events/event_log.jsonl"))
+        if extra_files:
+            for file_path in extra_files:
+                if file_path and Path(file_path).exists():
+                    files_to_add.append((Path(file_path), f"extras/{Path(file_path).name}"))
+
+        feedback_body = feedback.strip() or "No feedback provided."
+        metadata = {
+            "generated_at": timestamp,
+            "event_logging_enabled": self.event_logging_enabled,
+            "logs_included": include_logs,
+            "event_log_included": include_event_log and self.event_log_path.exists(),
+        }
+
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(dest_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("feedback.txt", feedback_body)
+            zf.writestr("metadata.json", json.dumps(metadata, indent=2))
+            for file_path, arcname in files_to_add:
+                try:
+                    zf.write(file_path, arcname)
+                except OSError as exc:
+                    logger.debug(f"Skipped file {file_path}: {exc}")
+
+        return dest_path
+
+
+_default_diagnostics_service: DiagnosticsService | None = None
+
+
+def get_diagnostics_service() -> DiagnosticsService:
+    """Return singleton diagnostics service."""
+    global _default_diagnostics_service
+    if _default_diagnostics_service is None:
+        _default_diagnostics_service = DiagnosticsService()
+    return _default_diagnostics_service
+
+
+__all__ = ["DiagnosticsService", "get_diagnostics_service"]

--- a/tests/test_diagnostics_service.py
+++ b/tests/test_diagnostics_service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import zipfile
+
+from services.diagnostics_service import DiagnosticsService
+
+
+def test_event_logging_opt_in_and_export(tmp_path):
+    logs_dir = tmp_path / "logs"
+    config_file = tmp_path / "config" / "diagnostics_settings.json"
+    event_log = logs_dir / "events.jsonl"
+
+    service = DiagnosticsService(
+        logs_dir=logs_dir,
+        settings_path=config_file,
+        event_log_path=event_log,
+    )
+
+    # Logging is disabled by default
+    service.log_event("should_not_persist")
+    assert not event_log.exists()
+
+    # Opt-in and record an event
+    service.set_event_logging_enabled(True)
+    service.log_event("test_event", metadata={"foo": "bar"})
+    lines = event_log.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["event"] == "test_event"
+    assert payload["data"] == {"foo": "bar"}
+
+    # Include an app log and export diagnostics
+    log_file = logs_dir / "app.log"
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    log_file.write_text("log contents", encoding="utf-8")
+
+    archive_path = service.export_diagnostics(
+        feedback="This broke when clicking save.",
+        include_logs=True,
+        include_event_log=True,
+        destination=tmp_path / "diag.zip",
+    )
+
+    with zipfile.ZipFile(archive_path) as zf:
+        names = set(zf.namelist())
+        assert "feedback.txt" in names
+        assert "metadata.json" in names
+        assert "logs/app.log" in names
+        assert "events/event_log.jsonl" in names
+        feedback = zf.read("feedback.txt").decode("utf-8")
+        assert "clicking save" in feedback
+
+    saved_settings = json.loads(config_file.read_text(encoding="utf-8"))
+    assert saved_settings["event_logging_enabled"] is True

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -97,6 +97,7 @@ def ui_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         "CONFIG_DIR": config,
         "CACHE_DIR": cache,
         "DECKS_DIR": decks,
+        "LOGS_DIR": root / "logs",
         "CONFIG_FILE": config / "config.json",
         "DECK_SELECTOR_SETTINGS_FILE": config / "deck_selector_settings.json",
         "DECK_MONITOR_CONFIG_FILE": config / "deck_monitor_config.json",
@@ -109,6 +110,8 @@ def ui_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         "ARCHETYPE_DECKS_CACHE_FILE": cache / "archetype_decks_cache.json",
         "DECK_CACHE_FILE": cache / "deck_cache.json",
         "CURR_DECK_FILE": decks / "curr_deck.txt",
+        "DIAGNOSTICS_EVENT_LOG": cache / "event_log.jsonl",
+        "DIAGNOSTICS_SETTINGS_FILE": config / "diagnostics_settings.json",
     }
     for attr, value in replacements.items():
         monkeypatch.setattr(constants, attr, value, raising=False)

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -45,6 +45,8 @@ DECKS_DIR = BASE_DATA_DIR / "decks"
 DECK_SAVE_DIR = DECKS_DIR
 LOGS_DIR = BASE_DATA_DIR / "logs"
 CARD_DATA_DIR = BASE_DATA_DIR / "data"
+DIAGNOSTICS_SETTINGS_FILE = CONFIG_DIR / "diagnostics_settings.json"
+DIAGNOSTICS_EVENT_LOG = LOGS_DIR / "event_log.jsonl"
 
 
 def ensure_base_dirs() -> None:
@@ -77,6 +79,8 @@ __all__ = [
     "CONFIG_DIR",
     "CACHE_DIR",
     "DECKS_DIR",
+    "DIAGNOSTICS_EVENT_LOG",
+    "DIAGNOSTICS_SETTINGS_FILE",
     "CONFIG_FILE",
     "DECK_MONITOR_CONFIG_FILE",
     "DECK_MONITOR_CACHE_FILE",

--- a/widgets/app_frame.py
+++ b/widgets/app_frame.py
@@ -208,6 +208,7 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
                 self, self.image_cache, self.image_downloader, self._set_status
             ),
             on_update_card_database=lambda: self.controller.force_bulk_data_update(),
+            on_open_feedback=self.open_feedback_dialog,
         )
 
     def _build_card_data_controls(self, parent: wx.Window) -> wx.Panel:

--- a/widgets/buttons/toolbar_buttons.py
+++ b/widgets/buttons/toolbar_buttons.py
@@ -22,6 +22,7 @@ class ToolbarButtons(wx.Panel):
         on_load_collection: Callable[[], None] | None = None,
         on_download_card_images: Callable[[], None] | None = None,
         on_update_card_database: Callable[[], None] | None = None,
+        on_open_feedback: Callable[[], None] | None = None,
     ):
         """
         Initialize the toolbar button panel.
@@ -35,6 +36,7 @@ class ToolbarButtons(wx.Panel):
             on_load_collection: Callback for "Load Collection"
             on_download_card_images: Callback for "Download Card Images"
             on_update_card_database: Callback for "Update Card Database"
+            on_open_feedback: Callback for "Send Feedback / Export Diagnostics"
         """
         super().__init__(parent)
 
@@ -55,6 +57,9 @@ class ToolbarButtons(wx.Panel):
         )
         self.update_database_button = self._add_button(
             "Update Card Database", on_update_card_database
+        )
+        self.feedback_button = self._add_button(
+            "Send Feedback / Export Diagnostics", on_open_feedback
         )
 
         self._button_row.AddStretchSpacer(1)

--- a/widgets/dialogs/__init__.py
+++ b/widgets/dialogs/__init__.py
@@ -1,8 +1,11 @@
 """Dialog windows for the MTG deck selector application."""
 
+from widgets.dialogs.feedback_dialog import FeedbackDialog, show_feedback_dialog
 from widgets.dialogs.image_download_dialog import ImageDownloadDialog, show_image_download_dialog
 
 __all__ = [
+    "FeedbackDialog",
     "ImageDownloadDialog",
+    "show_feedback_dialog",
     "show_image_download_dialog",
 ]

--- a/widgets/dialogs/feedback_dialog.py
+++ b/widgets/dialogs/feedback_dialog.py
@@ -1,0 +1,177 @@
+"""Dialog for gathering user feedback and exporting diagnostics."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import wx
+
+from services.diagnostics_service import DiagnosticsService
+from utils.constants import DARK_BG, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+
+
+class FeedbackDialog(wx.Dialog):
+    """Collect feedback and produce a diagnostics zip file (no network calls)."""
+
+    def __init__(self, parent: wx.Window, diagnostics_service: DiagnosticsService):
+        super().__init__(parent, title="Send Feedback / Export Diagnostics", size=(540, 520))
+        self.diagnostics_service = diagnostics_service
+        self.SetBackgroundColour(DARK_BG)
+        self._build_ui()
+        self.CentreOnParent()
+
+    # ------------------------------------------------------------------ UI ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        panel = wx.Panel(self)
+        panel.SetBackgroundColour(DARK_BG)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        panel.SetSizer(sizer)
+
+        intro = wx.StaticText(
+            panel,
+            label=(
+                "Share what happened and export diagnostics to a zip file. "
+                "Nothing is uploaded automatically."
+            ),
+        )
+        intro.SetForegroundColour(SUBDUED_TEXT)
+        intro.Wrap(500)
+        sizer.Add(intro, 0, wx.ALL, 10)
+
+        feedback_label = wx.StaticText(panel, label="Feedback (what were you doing?):")
+        feedback_label.SetForegroundColour(LIGHT_TEXT)
+        sizer.Add(feedback_label, 0, wx.LEFT | wx.RIGHT, 10)
+
+        self.feedback_text = wx.TextCtrl(
+            panel, style=wx.TE_MULTILINE | wx.TE_WORDWRAP, size=(-1, 140)
+        )
+        self.feedback_text.SetBackgroundColour(DARK_PANEL)
+        self.feedback_text.SetForegroundColour(LIGHT_TEXT)
+        sizer.Add(self.feedback_text, 0, wx.EXPAND | wx.ALL, 10)
+
+        options_box = wx.StaticBox(panel, label="Include")
+        options_box.SetForegroundColour(LIGHT_TEXT)
+        options_box.SetBackgroundColour(DARK_BG)
+        options_sizer = wx.StaticBoxSizer(options_box, wx.VERTICAL)
+
+        self.include_logs_cb = wx.CheckBox(panel, label="Application logs")
+        self.include_logs_cb.SetValue(True)
+        self.include_logs_cb.SetForegroundColour(LIGHT_TEXT)
+        options_sizer.Add(self.include_logs_cb, 0, wx.ALL, 6)
+
+        self.include_events_cb = wx.CheckBox(panel, label="Usage events (anonymized)")
+        self.include_events_cb.SetValue(self.diagnostics_service.event_logging_enabled)
+        self.include_events_cb.SetForegroundColour(LIGHT_TEXT)
+        options_sizer.Add(self.include_events_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
+        self.enable_events_cb = wx.CheckBox(panel, label="Enable future event logging (opt-in)")
+        self.enable_events_cb.SetValue(self.diagnostics_service.event_logging_enabled)
+        self.enable_events_cb.SetForegroundColour(LIGHT_TEXT)
+        self.enable_events_cb.Bind(wx.EVT_CHECKBOX, self._on_toggle_event_logging)
+        options_sizer.Add(self.enable_events_cb, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+
+        sizer.Add(options_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+
+        destination_row = wx.BoxSizer(wx.HORIZONTAL)
+        dest_label = wx.StaticText(panel, label="Save zip to:")
+        dest_label.SetForegroundColour(LIGHT_TEXT)
+        destination_row.Add(dest_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 6)
+
+        self.destination_ctrl = wx.TextCtrl(panel, value=str(self._default_destination()))
+        self.destination_ctrl.SetBackgroundColour(DARK_PANEL)
+        self.destination_ctrl.SetForegroundColour(LIGHT_TEXT)
+        destination_row.Add(self.destination_ctrl, 1, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 6)
+
+        browse_btn = wx.Button(panel, label="Browse…")
+        browse_btn.Bind(wx.EVT_BUTTON, self._on_browse)
+        destination_row.Add(browse_btn, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        sizer.Add(destination_row, 0, wx.EXPAND | wx.ALL, 10)
+
+        self.status_text = wx.StaticText(panel, label="")
+        self.status_text.SetForegroundColour(SUBDUED_TEXT)
+        sizer.Add(self.status_text, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
+        btn_sizer = wx.StdDialogButtonSizer()
+        ok_btn = wx.Button(panel, wx.ID_OK, label="Export")
+        cancel_btn = wx.Button(panel, wx.ID_CANCEL, label="Cancel")
+        btn_sizer.AddButton(ok_btn)
+        btn_sizer.AddButton(cancel_btn)
+        btn_sizer.Realize()
+        sizer.Add(btn_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 10)
+
+        ok_btn.Bind(wx.EVT_BUTTON, self._on_export)
+
+        panel.SetSizerAndFit(sizer)
+        self.SetSizerAndFit(sizer)
+
+    # ------------------------------------------------------------------ helpers ------------------------------------------------------------------
+    def _default_destination(self) -> Path:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        return self.diagnostics_service.logs_dir / f"mtgo_tools_diagnostics_{ts}.zip"
+
+    def _on_browse(self, _event: wx.CommandEvent) -> None:
+        with wx.FileDialog(
+            self,
+            "Save diagnostics zip",
+            wildcard="Zip files (*.zip)|*.zip",
+            style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+            defaultFile=Path(self.destination_ctrl.GetValue()).name,
+            defaultDir=str(Path(self.destination_ctrl.GetValue()).parent),
+        ) as dlg:
+            if dlg.ShowModal() == wx.ID_OK:
+                self.destination_ctrl.SetValue(dlg.GetPath())
+
+    def _on_toggle_event_logging(self, _event: wx.CommandEvent) -> None:
+        enabled = self.enable_events_cb.GetValue()
+        self.diagnostics_service.set_event_logging_enabled(enabled)
+        if enabled:
+            self.include_events_cb.SetValue(True)
+        self.status_text.SetLabel(
+            "Usage events will be recorded locally." if enabled else "Usage event logging disabled."
+        )
+
+    def _on_export(self, _event: wx.CommandEvent) -> None:
+        destination = Path(self.destination_ctrl.GetValue()).expanduser()
+        include_logs = self.include_logs_cb.GetValue()
+        include_events = self.include_events_cb.GetValue()
+        feedback = self.feedback_text.GetValue()
+
+        try:
+            zip_path = self.diagnostics_service.export_diagnostics(
+                feedback=feedback,
+                include_logs=include_logs,
+                include_event_log=include_events,
+                destination=destination,
+            )
+            self.diagnostics_service.log_event(
+                "diagnostics_exported",
+                metadata={
+                    "include_logs": include_logs,
+                    "include_events": include_events,
+                },
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            self.status_text.SetLabel(f"Export failed: {exc}")
+            wx.MessageBox(
+                f"Could not export diagnostics:\n{exc}", "Export Error", wx.OK | wx.ICON_ERROR
+            )
+            return
+
+        self.status_text.SetLabel(f"Saved diagnostics to {zip_path}")
+        wx.MessageBox(
+            f"Diagnostics exported to:\n{zip_path}",
+            "Diagnostics Exported",
+            wx.OK | wx.ICON_INFORMATION,
+        )
+        self.EndModal(wx.ID_OK)
+
+
+def show_feedback_dialog(parent: wx.Window, diagnostics_service: DiagnosticsService) -> None:
+    dialog = FeedbackDialog(parent, diagnostics_service)
+    dialog.ShowModal()
+    dialog.Destroy()
+
+
+__all__ = ["FeedbackDialog", "show_feedback_dialog"]

--- a/widgets/handlers/app_event_handlers.py
+++ b/widgets/handlers/app_event_handlers.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from utils.card_data import CardDataManager
 from utils.ui_helpers import open_child_window, widget_exists
+from widgets.dialogs.feedback_dialog import show_feedback_dialog
 from widgets.identify_opponent import MTGOpponentDeckSpy
 from widgets.match_history import MatchHistoryFrame
 from widgets.metagame_analysis import MetagameAnalysisFrame
@@ -491,6 +492,10 @@ class AppEventHandlers:
             "Metagame Analysis",
             self._handle_child_close,
         )
+
+    def open_feedback_dialog(self) -> None:
+        show_feedback_dialog(self, self.controller.diagnostics_service)
+        self.controller.log_event("feedback_dialog_opened")
 
     def _handle_child_close(self, event: wx.CloseEvent, attr: str) -> None:
         setattr(self, attr, None)


### PR DESCRIPTION
## Summary\n- add diagnostics service with opt-in event logging and export packaging to zip bundles\n- surface a toolbar entry that opens a feedback/diagnostics dialog with logging toggle and export options\n- add regression coverage for diagnostics export and guard headless imports for tests\n\n## Testing\n- python3 -m pytest tests/test_diagnostics_service.py tests/test_session_manager.py tests/test_deck_workflow_service.py\n- python3 -m ruff check .\n- python3 -m black --check .