### PR TITLE
Retry card image requests after bulk data load

### DIFF
--- a/widgets/panels/card_inspector_panel.py
+++ b/widgets/panels/card_inspector_panel.py
@@ -246,6 +246,8 @@ class CardInspectorPanel(wx.Panel):
     def set_bulk_data(self, bulk_data_by_name: dict[str, list[dict[str, Any]]]) -> None:
         """Set the bulk data index for fast printing lookups."""
         self.bulk_data_by_name = bulk_data_by_name
+        if self.inspector_current_card_name:
+            self._load_card_image_and_printings(self.inspector_current_card_name)
 
     def set_image_request_handlers(
         self,
@@ -309,6 +311,10 @@ class CardInspectorPanel(wx.Panel):
             else:
                 self.card_image_display.show_placeholder("Not cached")
                 self.nav_panel.Hide()
+                logger.info(
+                    "No printings data available for %s; image download cannot be queued yet.",
+                    self.inspector_current_card_name,
+                )
             self._notify_selection(active_request)
             self._set_display_mode(image_available)
             return


### PR DESCRIPTION
## Summary\n- when bulk data arrives, refresh the current inspector selection so image requests are queued\n- log when no printings data is available to queue a download\n\n## Testing\n- python3 -m ruff check .\n- python3 -m black --check .