### PR TITLE
Issue 185: toggle card inspector selection

### DIFF
--- a/widgets/handlers/app_event_handlers.py
+++ b/widgets/handlers/app_event_handlers.py
@@ -382,10 +382,15 @@ class AppEventHandlers:
     def _on_builder_clear(self: AppFrame) -> None:
         self.builder_panel.clear_filters()
 
-    def _on_builder_result_selected(self: AppFrame, idx: int) -> None:
+    def _on_builder_result_selected(self: AppFrame, idx: int | None) -> None:
+        if idx is None:
+            if self.card_inspector_panel.active_zone is None:
+                self.card_inspector_panel.reset()
+            return
         meta = self.builder_panel.get_result_at_index(idx)
         if not meta:
             return
+        self._clear_zone_selections()
         faux_card = {"name": meta.get("name", "Unknown"), "qty": 1}
         self.card_inspector_panel.update_card(faux_card, zone=None, meta=meta)
 

--- a/widgets/panels/card_table_panel.py
+++ b/widgets/panels/card_table_panel.py
@@ -134,6 +134,7 @@ class CardTablePanel(wx.Panel):
 
     def _handle_card_click(self, zone: str, card: dict[str, Any], panel: CardBoxPanel) -> None:
         if self.active_panel is panel:
+            self.clear_selection()
             return
         if self.active_panel:
             self.active_panel.set_active(False)


### PR DESCRIPTION
## Summary\n- allow clicking the same card to deselect in deck tables and search results\n- lock hover previews when any card is selected to keep inspector focused\n- clear other selections when picking a search result or table card\n\n## Testing\n- python3 -m ruff check .\n- python3 -m black --check .