### PR TITLE
docs: streamline CLAUDE.md, add CHANGES.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,19 +11,21 @@ A Python tool for Magic: The Gathering Online that combines web scraping, log fi
 - **Hypergeometric Calculator:** Built-in probability calculator for draw odds (e.g., "chance to draw a 4-of in opening hand")
 - **Metagame Research:** Browse and analyze MTGGoldfish archetype data, deck lists, and tournament results
 - **Match History:** Parse MTGO GameLog files to extract historical match data, opponent names, and results
-- **Deck Editor:** Interactive deck list editor with card adjustment, averaging, and export capabilities
+- **Deck Editor:** Interactive deck list editor with card adjustment, averaging, export, and MongoDB storage
 - **Challenge Timer Alerts:** Monitor and alert on MTGO challenge timer countdowns
 
 **Key Modules:**
 - `widgets/identify_opponent.py` - Real-time opponent tracking overlay with hypergeometric calculator
 - `widgets/deck_selector_wx.py` - Deck browser and editor GUI
 - `navigators/mtggoldfish.py` - MTGGoldfish web scraping
-- `utils/find_opponent_names.py` - Simple opponent detection via MTGO window titles
+- `utils/find_opponent_names.py` - Opponent detection via MTGO window titles ("vs." pattern)
 - `utils/math_utils.py` - Hypergeometric probability calculations for draw odds
 - `utils/metagame.py` - Player lookup and metagame data processing
 - `utils/gamelog_parser.py` - MTGO GameLog parsing for match history
+- `utils/dbq.py` - MongoDB deck storage (save/load/delete/update)
+- `utils/deck.py` - Deck parsing and analysis (`analyze_deck()`)
 - `dotnet/MTGOBridge/Program.cs` - C# bridge to MTGOSDK for MTGO client interaction
-- `scripts/mtgosdk_repl.py` - PythonNET scratchpad for exploring MTGOSDK API surface (loads bridge assemblies for interactive inspection)
+- `scripts/mtgosdk_repl.py` - PythonNET scratchpad for exploring MTGOSDK API surface
 
 **Use Case:** Helps competitive MTGO players by providing intelligence on opponents' recent decks and facilitating metagame research, all through passive observation and web scraping (no gameplay automation).
 
@@ -33,1013 +35,162 @@ python main.py
 
 # Standalone Widget Entry Points
 
-All MTGO-related widgets can now be launched independently without running the main GUI.
-
-## Running as Python Modules
-
-Each widget can be executed directly using Python's module syntax:
+Each widget can be executed directly as a Python module:
 
 ```bash
-# Opponent Tracker - Real-time opponent detection and deck lookup
-python -m widgets.identify_opponent
-
-# Match History - View MTGO match history from GameLog files
-python -m widgets.match_history
-
-# Timer Alert - Challenge timer countdown alerts
-python -m widgets.timer_alert
-
-# Metagame Analysis - Archetype distribution visualization
-python -m widgets.metagame_analysis
+python -m widgets.identify_opponent   # Opponent Tracker
+python -m widgets.match_history       # Match History viewer
+python -m widgets.timer_alert         # Challenge timer alerts
+python -m widgets.metagame_analysis   # Metagame analysis
 ```
 
-## Console Scripts (After Installation)
-
-When the package is installed via `pip install -e .`, these console commands become available:
-
+Console scripts (after `pip install -e .`):
 ```bash
-mtgo-opponent-tracker    # Launch opponent tracking widget
-mtgo-match-history       # Launch match history viewer
-mtgo-timer-alert         # Launch timer alert widget
-mtgo-metagame            # Launch metagame analysis
+mtgo-opponent-tracker
+mtgo-match-history
+mtgo-timer-alert
+mtgo-metagame
 ```
 
-## Requirements by Widget
+**Requirements by widget:**
+- `mtgo-opponent-tracker`: MTGO running with an active match window
+- `mtgo-match-history`: GameLog files (MTGO creates these automatically)
+- `mtgo-timer-alert`: MTGO running + MTGOBridge.exe compiled
+- `mtgo-metagame`: No MTGO required (web scraping only)
 
-- **mtgo-opponent-tracker**: Requires MTGO to be running with an active match window
-- **mtgo-match-history**: Requires GameLog files (MTGO creates these automatically)
-- **mtgo-timer-alert**: Requires MTGO to be running + MTGOBridge.exe compiled
-- **mtgo-metagame**: No MTGO required (web scraping only)
-
-## Implementation
-
-Each widget has a `main()` function that:
-1. Ensures base directories exist (`ensure_base_dirs()`)
-2. Configures logging to `logs/` directory
-3. Creates wxPython application instance
-4. Instantiates the widget frame
-5. Runs the event loop
-
-See the bootstrap pattern in each widget's `if __name__ == "__main__"` block.
+Each widget has a `main()` function that initializes base dirs, configures logging, creates a wxPython app, and runs the event loop.
 
 # CI/PR Workflow
 
 When creating a PR:
 1. After `gh pr create`, poll `gh pr checks <PR#>` every **1 minute**
-2. If checks fail, fix the issues locally, commit, push, and continue polling
-3. **Stop polling** when either:
-   - All checks have passed, OR
-   - 3 consecutive polls show no status changes (checks may be stuck/slow)
+2. If checks fail, fix locally, commit, push, and continue polling
+3. **Stop polling** when either all checks pass OR 3 consecutive polls show no status changes
 4. Common CI checks: Linting & Formatting (ruff/black), Type Checking, Compilation, Security Scanning, .NET Build
-5. Run `black <file>` and `ruff check <file> --fix` locally before pushing to catch formatting issues early
+5. Run `black <file>` and `ruff check <file> --fix` locally before pushing
 
-# Performance Improvements - Lazy Loading (DONE BY CLAUDE)
+# Architecture
 
-## Problem
-The Deck Research Browser was taking 5-10+ seconds to open because it scraped MTGGoldfish for all archetypes synchronously before showing the window.
+## Opponent Detection
 
-## Solution
-Implemented **lazy loading with background threading** for all network operations.
+Opponent names are detected by scanning MTGO window titles for the "vs." pattern using `pygetwindow.getAllTitles()`. The widget polls every 2 seconds. No MTGOSDK bridge is required for opponent tracking.
 
-## Changes Made
+Example: `"MTGO - Match vs. PlayerName"` → extracts `"PlayerName"`
 
-### 1. **Instant Window Opening** 
-- Window now appears immediately with a loading indicator
-- Initial archetype loading happens in background (100ms after window opens)
+## GameLog Parsing (Hybrid Architecture)
 
-### 2. **Async Archetype Loading**
-```
-Before: [------- BLOCKING 10s -------] → Window opens
-After:  Window opens → [Background loading] → Data appears
-```
+Historical match data is extracted by parsing MTGO's GameLog files directly (bypassing MTGOSDK, which has a broken `HistoricalMatch.Opponents` API).
 
-### 3. **Progress Indicators**
-- ⏳ Loading messages in listbox during data fetch
-- Button states disabled during loading to prevent double-clicks
-- Error messages with retry functionality
+- **MTGOSDK / C# MTGOBridge**: challenge timer, collection export, log file location
+- **GameLog parsing (Python)**: match history, opponent names, match results
 
-### 4. **All Network Calls Now Async**
-- ✅ Initial archetype list loading
-- ✅ Deck list loading when selecting archetype  
-- ✅ Individual deck download when clicking
-- ✅ Daily average deck compilation (with progress counter)
+GameLog files use pipe-delimited format with `@PPlayerName@` markers. `MTGOBridge.exe logfiles` returns JSON with file paths; filesystem search is used as a fallback.
 
-### 5. **Error Handling**
-- Network failures show user-friendly error messages
-- "Click to retry" functionality
-- Graceful degradation - app doesn't crash on errors
+See `docs/GAMELOG_PARSING.md` for full format details.
 
-## Technical Implementation
+## Deck Research Browser
 
-**Threading Strategy:**
-- Background threads for all network I/O
-- `root.after(0, callback)` to update UI from worker threads (thread-safe)
-- Daemon threads that don't block app shutdown
+All network operations (MTGGoldfish scraping, database queries) are async via background threads. UI updates use `wx.CallAfter` / `root.after(0, callback)` to stay thread-safe. The window opens instantly; data loads in the background.
 
-**User Experience:**
-```
-Load Time:
-  Before: 5-10 seconds (blocking)
-  After:  <100ms (instant window, background loading)
+Two browsing modes:
+- **Browse MTGGoldfish**: scrape tournament decks by archetype
+- **Saved Decks**: browse your local MongoDB collection
 
-Perceived Performance:
-  Before: Unresponsive, appears frozen
-  After:  Immediate feedback, shows progress
-```
+# Database (MongoDB)
 
-## Files Modified
-- `widgets/deck_selector.py` - Added threading and async loading
-- `main.py` - Improved launcher button feedback
-
-## Usage
-```bash
-python main.py
-# Click "📚 Deck Research Browser"
-# Window opens instantly!
-# Archetypes load in background with progress indicator
-```
-
-No configuration needed - lazy loading is automatic!
-
-# Database Integration for Deck Selector
-
-## Overview
-
-The Deck Research Browser now integrates with MongoDB to save, browse, load, and manage decks. This addresses the TODO from `widgets/deck_selector.py:15`.
-
-## Features Added
-
-### 1. **Save Decks to Database**
-- Decks are automatically saved to both MongoDB and files (backup)
-- When saving MTGGoldfish decks: metadata includes player, archetype, tournament info
-- When saving edited/manual decks: prompts for custom name
-- Saved decks include: name, content, format, archetype, player, source, timestamps, metadata
-
-### 2. **Browse Saved Decks**
-- New "Saved Decks" button in UI
-- Lists all saved decks for the selected format
-- Shows deck name, archetype, and player
-- Automatically filters by current format (Modern, Standard, etc.)
-- Loads asynchronously with progress indicators
-
-### 3. **Load Saved Decks**
-- Click any saved deck to instantly display it
-- Shows deck metadata (archetype, player, source, date saved)
-- Full editing capabilities (increment/decrement/remove cards)
-
-### 4. **Delete Saved Decks**
-- Red "Delete Deck" button when in Saved Decks mode
-- Confirmation dialog before deletion
-- Permanently removes from database
-
-### 5. **Mode Switching**
-- **"Browse MTGGoldfish"** mode: Original functionality for scraping decks
-- **"Saved Decks"** mode: Browse your local deck collection
-- Active mode is highlighted in the UI
-
-## Database Schema
-
-MongoDB collection: `decks` in database `lm_scraper`
+MongoDB database: `lm_scraper`, collection: `decks`.
 
 ```javascript
 {
   _id: ObjectId,
   name: "2025-01-15 PlayerName MTGO Challenge 5-0",
-  content: "4 Lightning Bolt\n4 Counterspell\n...",
+  content: "4 Lightning Bolt\n...",
   format: "Modern",
   archetype: "UR Murktide",
   player: "PlayerName",
   source: "mtggoldfish" | "manual" | "averaged",
-  date_saved: ISODate("2025-01-15T..."),
-  date_modified: ISODate("2025-01-16T..."),
-  metadata: {
-    date: "2025-01-15",
-    event: "MTGO Challenge",
-    result: "5-0",
-    deck_number: "6548639"
-  }
+  date_saved: ISODate,
+  date_modified: ISODate,
+  metadata: { date, event, result, deck_number }
 }
 ```
 
-## API Functions (utils/dbq.py)
+**API (`utils/dbq.py`):**
+- `save_deck_to_db(name, content, format, archetype, player, source, metadata)` → ObjectId
+- `get_saved_decks(format_type, archetype, sort_by)` → list of docs
+- `load_deck_from_db(deck_id)` → doc or None
+- `delete_saved_deck(deck_id)` → bool
+- `update_deck_in_db(deck_id, content, name, metadata)` → bool
 
-### `save_deck_to_db(deck_name, deck_content, format_type, archetype, player, source, metadata)`
-Saves a deck to the database. Returns the MongoDB ObjectId.
+**Troubleshooting:**
+- "Connection refused": verify MongoDB is running on port 27017
+- "No module named 'pymongo'": `pip install -r requirements.txt`
 
-**Parameters:**
-- `deck_name` (str): Display name for the deck
-- `deck_content` (str): Full deck list text
-- `format_type` (str, optional): MTG format (Modern, Standard, etc.)
-- `archetype` (str, optional): Deck archetype name
-- `player` (str, optional): Player name
-- `source` (str): "mtggoldfish", "manual", or "averaged"
-- `metadata` (dict, optional): Additional data (tournament info, etc.)
+# Hypergeometric Calculator
 
-### `get_saved_decks(format_type=None, archetype=None, sort_by="date_saved")`
-Retrieves saved decks from database with optional filters.
+Built into the Opponent Tracker widget (collapsible panel). Calculates draw probabilities using the hypergeometric distribution (`math.comb()`).
 
-**Returns:** List of deck documents (dicts)
+Inputs: Deck Size, Copies in Deck, Cards Drawn, Target Copies. Presets for opening hand (60-card, 40-card) and turn 3 (play/draw).
 
-### `load_deck_from_db(deck_id)`
-Loads a specific deck by MongoDB ObjectId or string ID.
+- `utils/math_utils.py` - calculation functions
+- `tests/test_math_utils.py` - unit tests
+- `widgets/identify_opponent.py` - UI integration
 
-**Returns:** Deck document or None
+# UI Automation (WSL Testing)
 
-### `delete_saved_deck(deck_id)`
-Deletes a deck from the database.
+The app runs in Windows but can be launched and controlled entirely from WSL. The `automation` package exposes a socket server (port 19847); WSL2 localhost forwarding (on by default) makes `127.0.0.1` in WSL reach the Windows-side server transparently.
 
-**Returns:** True if deleted, False if not found
+## Launching the app from WSL
 
-### `update_deck_in_db(deck_id, deck_content=None, deck_name=None, metadata=None)`
-Updates an existing deck.
-
-**Returns:** True if updated, False if not found
-
-## Usage
-
-### Prerequisites
-1. **Install MongoDB** (if not already installed):
-   - Ubuntu/Debian: `sudo apt install mongodb`
-   - macOS: `brew install mongodb-community`
-   - Windows: Download from https://www.mongodb.com/
-
-2. **Start MongoDB**:
-   - Ubuntu/Debian: `sudo systemctl start mongod`
-   - macOS: `brew services start mongodb-community`
-   - Windows: `net start MongoDB`
-
-3. **Verify MongoDB is running**:
-   ```bash
-   pgrep -x mongod  # Should show a process ID
-   ```
-
-### Running the Deck Selector
+Use `cmd.exe` to start the Windows Python process in the background:
 
 ```bash
-# Launch from main menu
-python main.py
-# Then click "📚 Deck Research Browser"
-
-# Or run directly
-python -m widgets.deck_selector
+cmd.exe /c "start python C:\Users\Pedro\Documents\GitHub\mtgo_tools\main.py --automation"
 ```
 
-### Workflow Examples
+Then wait for the server to come up before sending commands:
 
-#### Saving a Tournament Deck
-1. Browse MTGGoldfish → Select format → Choose archetype
-2. Select a deck from the list (it loads in the textbox)
-3. Click "Save deck" → Automatically saved with tournament metadata
-4. Confirmation dialog shows database ID and filename
-
-#### Creating and Saving a Custom Deck
-1. Type or paste your deck into the textbox
-2. Click "Save deck"
-3. Enter a custom name when prompted
-4. Deck saved as "manual" source
-
-#### Creating an Average Deck from Multiple Decks
-1. Browse MTGGoldfish → Select archetype
-2. Click "Add deck to buffer" for each deck you want to average
-3. Click "Mean of buffer" → Creates averaged deck
-4. Click "Save deck" → Saves the averaged deck with source "averaged"
-
-#### Browsing Your Saved Decks
-1. Click "Saved Decks" button (turns yellow/highlighted)
-2. All saved decks for current format appear in list
-3. Click any deck to view it
-4. Use +/- buttons to adjust card quantities
-5. Click "Save deck" again to save edits as a new deck
-
-#### Deleting a Saved Deck
-1. Switch to "Saved Decks" mode
-2. Select the deck to delete
-3. Click red "Delete Deck" button
-4. Confirm deletion in dialog
-
-## Technical Details
-
-### Thread-Safe Async Loading
-- All database operations run in background threads
-- UI updates happen on main thread via `root.after(0, callback)`
-- Loading indicators (⏳) shown during operations
-- Error messages displayed if operations fail
-
-### Data Integrity
-- Decks saved to both database AND files (dual storage)
-- File backups in: `CONFIG["deck_selector_save_path"]`
-- Database failures don't prevent file saves
-- Graceful error handling with user-friendly messages
-
-### Robots.txt Compliance Fix (Bonus)
-The robots.txt check revealed a violation:
-- **Old:** Used `/deck/download/{deck_num}` (disallowed)
-- **New:** Scrapes `/deck/{deck_num}` page (allowed)
-- Extracts deck data from embedded JavaScript
-- No functionality lost, fully compliant now
-
-## Files Modified
-
-1. **utils/dbq.py** - Added 5 new deck management functions
-2. **widgets/deck_selector.py** - Added database integration UI and logic
-3. **navigators/mtggoldfish.py** - Fixed robots.txt compliance
-4. **test_deck_db.py** - Test script for database functions (NEW)
-5. **DATABASE_INTEGRATION.md** - This documentation (NEW)
-
-## Troubleshooting
-
-### "MongoDB not running" error
-- Start MongoDB with system-specific command (see Prerequisites)
-- Verify with: `pgrep -x mongod`
-
-### "Connection refused" error
-- Check if MongoDB is listening on port 27017: `netstat -an | grep 27017`
-- Ensure no firewall blocking localhost:27017
-
-### "No module named 'pymongo'"
-- Install dependencies: `pip install -r requirements.txt`
-- Or: `pip install pymongo`
-
-### Deck not appearing in saved list
-- Check format filter matches (deck format must match selected format)
-- Try switching to "Browse MTGGoldfish" and back to "Saved Decks" to refresh
-
-### "Empty Deck" warning when saving
-- Ensure deck textbox has content before clicking "Save deck"
-- Check that deck format is valid (numbers + card names)
-
-## Future Enhancements
-
-Possible additions (not implemented yet):
-- [ ] Export saved decks to various formats (.txt, .dec, .mwDeck)
-- [ ] Import decks from files into database
-- [ ] Deck tagging/categorization system
-- [ ] Search/filter saved decks by card names
-- [ ] Deck statistics (card frequency, mana curve)
-- [ ] Deck comparison tool
-- [ ] Auto-save edited decks
-- [ ] Deck versioning/history
-- [ ] Share decks (export as JSON)
-- [ ] Backup/restore entire deck collection
-
-## Summary
-
-✅ **Completed:**
-- Database utility functions in utils/dbq.py
-- Full deck CRUD operations (Create, Read, Update, Delete)
-- UI integration with mode switching
-- Async/threaded loading with progress indicators
-- Dual storage (database + files)
-- Format filtering
-- Metadata preservation
-- robots.txt compliance fix
-
-The deck_selector now provides a complete deck management system backed by MongoDB!
-
-# Deck Visualization and Statistics Panel
-
-## Overview
-
-Enhanced the Deck Research Browser with comprehensive deck visualization and statistics features. When browsing saved decks, users can now view detailed analytics including card counts, composition breakdowns, metadata, and top cards.
-
-## Features Added
-
-### 1. **Deck Statistics Panel**
-A collapsible statistics panel that displays comprehensive deck information:
-
-**Deck Metadata:**
-- 📦 Archetype (e.g., "UR Murktide")
-- 👤 Player name
-- 🎯 Format (Modern, Standard, etc.)
-- 📍 Source (MTGGoldfish, Manual, Averaged)
-- 💾 Date saved (timestamp)
-- 🏆 Tournament event (if applicable)
-- 🎖️ Tournament result (if applicable)
-
-**Deck Composition:**
-- Mainboard card count (total and unique)
-- Sideboard card count (total and unique)
-- Total cards in deck
-- 🏔️ Estimated lands count
-- ⚡ Estimated spells count
-- 🔝 Top 5 most-played cards
-
-### 2. **Interactive Statistics Toggle**
-- **"📊 Show Stats" button** - Toggle visibility of statistics panel
-- Button changes to "📊 Hide Stats" when panel is visible
-- Only appears when in "Saved Decks" mode
-- Works for any deck in the textbox (saved or browsed)
-
-### 3. **Enhanced Saved Decks Display**
-- Deck list now shows save date: `[MM/DD] Deck Name`
-- Automatic statistics display when selecting a saved deck
-- Statistics automatically hide when switching back to Browse mode
-- Statistics panel positioned above deck list for easy viewing
-
-### 4. **Improved Deck Analysis**
-Added `analyze_deck()` function in `utils/deck.py`:
-- Parses mainboard and sideboard separately
-- Counts unique cards and total quantities
-- Estimates lands using heuristic matching
-- Returns structured statistics dict
-- Handles fractional amounts from averaged decks
-- Robust error handling for malformed deck lists
-
-### 5. **Visual Delete Button Enhancement**
-- Changed from "Delete Deck" to **"❌ Delete Deck"** with emoji
-- More visually prominent red button
-- Appears only in Saved Decks mode
-
-## Technical Implementation
-
-### New Functions
-
-#### `utils/deck.py:analyze_deck(deck_content)`
-```python
-Returns: {
-    'mainboard_count': int,       # Total mainboard cards
-    'sideboard_count': int,       # Total sideboard cards
-    'total_cards': int,           # Combined total
-    'unique_mainboard': int,      # Unique mainboard cards
-    'unique_sideboard': int,      # Unique sideboard cards
-    'mainboard_cards': [(name, count), ...],
-    'sideboard_cards': [(name, count), ...],
-    'estimated_lands': int        # Lands based on heuristics
-}
-```
-
-#### `deck_selector.py:update_deck_statistics(deck_content, deck_doc)`
-- Analyzes deck using `analyze_deck()`
-- Formats statistics into readable text with emoji indicators
-- Updates the statistics label
-- Shows the statistics panel
-- Handles errors gracefully
-
-#### `deck_selector.py:toggle_statistics_panel()`
-- Shows/hides statistics panel
-- Re-analyzes current deck when toggling on
-- Updates button text appropriately
-- Works in both Browse and Saved modes
-
-#### `deck_selector.py:hide_deck_statistics()`
-- Hides the statistics panel
-- Resets button text to "Show Stats"
-- Called when switching modes
-
-### UI Changes
-
-**New Components:**
-- `F_stats` - Statistics panel frame (row 0 in F_top_right)
-- `stats_label` - Multi-line label for statistics text
-- `visualize_button` - Toggle button for statistics panel
-
-**Layout:**
-```
-┌─────────────────────────────────────────┐
-│ [Statistics Panel]                      │  <- New! Row 0
-├─────────────────────────────────────────┤
-│ [Save] [Add to Buffer] [Mean] [📊 Stats]│  <- Row 1 (added Stats button)
-├─────────────────────────────────────────┤
-│ [Deck Textbox]                          │  <- Row 2
-└─────────────────────────────────────────┘
-```
-
-## Example Statistics Display
-
-```
-📦 Archetype: UR Murktide
-👤 Player: aspiringspike
-🎯 Format: Modern
-📍 Source: Mtggoldfish
-💾 Saved: 2025-01-15 14:32
-🏆 Event: MTGO Challenge
-🎖️ Result: 5-0
-
-📊 DECK COMPOSITION
-━━━━━━━━━━━━━━━━━━━━
-Mainboard: 60 cards (42 unique)
-Sideboard: 15 cards (15 unique)
-Total: 75 cards
-
-🏔️ Estimated Lands: 18
-⚡ Estimated Spells: 42
-
-🔝 TOP CARDS
-  4x Murktide Regent
-  4x Dragon's Rage Channeler
-  4x Counterspell
-  4x Lightning Bolt
-  3x Expressive Iteration
-```
-
-## Usage
-
-### Viewing Statistics for Saved Decks
-1. Click "Saved Decks" to enter saved decks mode
-2. Select any deck from the list
-3. Statistics panel automatically appears above the deck list
-4. View comprehensive deck information and composition
-
-### Toggling Statistics Panel
-1. Click **"📊 Show Stats"** button to display statistics
-2. Click **"📊 Hide Stats"** to hide the panel
-3. Works for any deck currently in the textbox
-
-### Statistics in Browse Mode
-1. Browse MTGGoldfish and load any deck
-2. Click **"📊 Show Stats"** (button appears when deck is loaded)
-3. View statistics for MTGGoldfish decks too!
-4. Statistics automatically hide when switching modes
-
-## Files Modified
-
-1. **utils/deck.py**
-   - Added `analyze_deck()` function for comprehensive deck analysis
-   - Improved error handling in `deck_to_dictionary()`
-   - Support for fractional card amounts (from averaged decks)
-
-2. **widgets/deck_selector.py**
-   - Added statistics panel (`F_stats`, `stats_label`)
-   - Added "📊 Show Stats" toggle button
-   - Implemented `update_deck_statistics()` method
-   - Implemented `toggle_statistics_panel()` method
-   - Implemented `hide_deck_statistics()` method
-   - Enhanced `display_saved_deck()` to show statistics automatically
-   - Enhanced `on_saved_decks_loaded()` to show date in deck list
-   - Updated mode switching to manage statistics panel visibility
-   - Changed delete button to "❌ Delete Deck" with emoji
-
-## Benefits
-
-**For Deck Analysis:**
-- Quickly assess deck composition without counting manually
-- Identify most-played cards at a glance
-- Verify deck legality (60 mainboard, 15 sideboard)
-- See land/spell ratio estimates
-
-**For Deck Management:**
-- Track when decks were saved
-- View tournament performance data
-- Identify deck sources (scraped vs manual vs averaged)
-- Compare deck statistics across your collection
-
-**For Tournament Research:**
-- Analyze successful tournament decks
-- Study top-performing players' choices
-- Track deck evolution over time
-- Compare card choices between similar archetypes
-
-## Testing
-
-All modified files have valid Python syntax:
-- ✓ `utils/deck.py`
-- ✓ `widgets/deck_selector.py`
-
-### Test Cases
-1. ✅ Statistics panel displays correctly for saved decks
-2. ✅ Toggle button shows/hides panel
-3. ✅ Statistics hide when switching to Browse mode
-4. ✅ Statistics work for MTGGoldfish decks
-5. ✅ Date displays correctly in saved decks list
-6. ✅ Emoji icons render properly in statistics
-7. ✅ Error handling for malformed deck lists
-8. ✅ Fractional amounts handled (from averaged decks)
-
-## Summary
-
-✅ **Visualization Features Completed:**
-- Comprehensive deck statistics panel
-- Interactive toggle button
-- Automatic statistics display for saved decks
-- Enhanced metadata display with emoji icons
-- Top cards breakdown
-- Card composition analysis
-- Visual delete button with emoji
-- Date-stamped deck listings
-- Mode-aware panel visibility
-
-The Deck Research Browser now provides powerful visualization tools for analyzing both saved decks and MTGGoldfish tournament results!
-
-# Bug Fixes - Mode Switching
-
-## Fixed: Browse Mode Button Disabled After Returning from Saved Decks
-
-### Problem
-After clicking "Saved Decks" and then switching back to "Browse MTGGoldfish", the "Select archetype" button was greyed out (disabled) and users couldn't select any new decks from MTGGoldfish.
-
-### Root Cause
-The button state wasn't being explicitly reset when switching back to browse mode. Additionally, if archetypes hadn't been loaded yet, the listbox would be empty but the button would remain disabled from the previous mode.
-
-### Solution
-**Fixed in `widgets/deck_selector.py`:**
-
-1. **`ui_reset_to_archetype_selection()`:**
-   - Explicitly sets button state to `"normal"` when resetting to browse mode
-   - Checks if archetypes are loaded before populating listbox
-   - Triggers `lazy_load_archetypes()` if archetypes haven't been loaded yet
-   - Shows loading indicator while fetching data
-
-2. **`switch_to_saved_mode()`:**
-   - Cleans up browse mode UI elements before switching
-   - Unbinds browse mode listbox events
-   - Removes temporary buttons (reset, daily average)
-
-3. **`on_archetypes_loaded()`:**
-   - Only updates UI if still in browse mode (prevents race conditions)
-   - Explicitly sets button text, command, and state
-   - Prevents mode confusion when switching quickly
-
-4. **`on_archetypes_error()`:**
-   - Only shows error in browse mode
-   - Properly resets button state for retry
-
-### Changes Made
-
-**Before:**
-```python
-self.listbox_button.config(text="Select archetype", command=self.select_archetype)
-# Button state not explicitly set - could remain disabled
-```
-
-**After:**
-```python
-self.listbox_button.config(text="Select archetype", command=self.select_archetype, state="normal")
-# Explicitly enables button
-
-# Check if archetypes are loaded
-if self.archetypes:
-    repopulate_listbox(self.listbox, [archetype["name"] for archetype in self.archetypes])
-else:
-    # Archetypes not loaded yet, trigger loading
-    self.listbox.delete(0, tk.END)
-    self.listbox.insert(0, "⏳ Loading archetypes...")
-    self.lazy_load_archetypes()
-```
-
-### Testing
-
-✅ **Verified scenarios:**
-1. Start in Browse mode → Switch to Saved Decks → Switch back to Browse mode → Button is enabled
-2. Switch modes multiple times rapidly → No race conditions, UI updates correctly
-3. Switch to Browse before archetypes load → Loading indicator shows, button enables when loaded
-4. Error during archetype loading → Error message shows, retry button is enabled
-
-### Files Modified
-- `widgets/deck_selector.py` - Fixed button state management and mode switching logic
-
-The mode switching now works smoothly and reliably!
-
-
-# GameLog Parsing for Match History (ARCHITECTURE CHANGE)
-
-## Problem: MTGOSDK HistoricalMatch.Opponents Bug
-
-The MTGOSDK's `HistoricalMatch.Opponents` property is fundamentally broken:
-
-```csharp
-// MTGOSDK source code
-public IList<User> Opponents =>
-    field ??= Map<IList, User>(Unbind(this).Opponents);
-```
-
-**Issue:** Raw MTGO data stores opponents as **strings** (player names), but the SDK tries to convert them to `User` objects via `Map<>`. This conversion fails with:
-```
-InvalidCastException: Unable to cast String to User
-```
-
-This made it impossible to reliably extract opponent names from historical matches.
-
-## Solution: Direct GameLog Parsing
-
-We switched to parsing MTGO's GameLog files directly, bypassing the broken SDK API.
-
-### Architecture Decision
-
-**Hybrid Approach:**
-1. **MTGOSDK (C# MTGOBridge)** - For live features:
-   - Challenge timer tracking
-   - Collection export  
-   - Log file location (`HistoryManager.GetGameHistoryFiles()`)
-   - Real-time match detection
-
-2. **GameLog Parsing (Python)** - For historical data:
-   - Match history extraction
-   - Opponent name tracking
-   - Match result analysis
-   - Historical statistics
-
-### Why This Works
-
-✅ **Reliable opponent extraction** - No SDK type conversion bugs
-✅ **Complete historical access** - Parse any log file from any time period  
-✅ **Offline processing** - Don't need MTGO running to parse
-✅ **Proven approach** - Based on cderickson/MTGO-Tracker
-✅ **Simple implementation** - Regex patterns vs complex reflection
-
-## Implementation
-
-### New Files
-
-**`utils/gamelog_parser.py`** - Core parsing module
-- `locate_gamelog_directory()` - Find log files via SDK or filesystem search
-- `parse_gamelog_file(file_path)` - Extract match data from single log
-- `parse_all_gamelogs(directory, limit)` - Batch processing
-- `extract_players(content)` - Player name extraction
-- `determine_winner(content, players)` - Match result analysis
-
-**`docs/GAMELOG_PARSING.md`** - Complete technical documentation
-
-**`ATTRIBUTIONS.md`** - Credits to cderickson and other projects
-
-### Modified Files
-
-**`dotnet/MTGOBridge/Program.cs`** - Added `logfiles` mode:
 ```bash
-MTGOBridge.exe logfiles
-# Returns: {"files": ["C:\...\GameLog_123.dat", ...]}
+python -m automation ping   # retry until this succeeds (takes a few seconds)
 ```
 
-**`CLAUDE.md`** - Updated feature list and architecture docs
+The `AutomationClient.wait_for_server(timeout=30)` method can be used in scripts to poll automatically.
 
-### Log File Format
+## CLI commands
 
-GameLog files use pipe-delimited format with player markers:
-
-```
-Wed Dec 04 14:23:10 PST 2024
-@PPlayerName1@ joined the game.
-@PPlayerName2@ joined the game.
-@PPlayerName1@ chooses to play first.
-Turn 1: @PPlayerName1@
-@PPlayerName1@ plays @[Island]@.
-...
-@PPlayerName2@ has conceded from the game.
-```
-
-### Usage Example
-
-```python
-from utils.gamelog_parser import parse_all_gamelogs
-
-# Parse recent matches
-matches = parse_all_gamelogs(limit=100)
-
-for match in matches:
-    print(f"{match['timestamp']} - vs {match['opponent']}")
-    print(f"  Winner: {match['winner']}")
-```
-
-Returns:
-```python
-{
-    "match_id": "20241204142310",
-    "timestamp": datetime(2024, 12, 4, 14, 23),
-    "players": ["PlayerName1", "PlayerName2"],
-    "opponent": "PlayerName2",
-    "winner": "PlayerName1",
-    "format": "Unknown",
-    "notes": ""
-}
-```
-
-### Locating Log Files
-
-Two-step strategy:
-
-1. **SDK Method** (if MTGO running):
-```python
-# Calls MTGOBridge.exe logfiles
-# Uses HistoryManager.GetGameHistoryFiles()
-path = locate_gamelog_directory_via_bridge()
-```
-
-2. **Filesystem Search** (fallback):
-```python
-# Searches common locations:
-# - C:\Users\{USER}\AppData\Local\Apps\2.0\...\GameLogs\
-# - Steam installation paths
-# - Standard install paths
-path = locate_gamelog_directory_fallback()
-```
-
-### Integration Points
-
-**Database Storage:** Use existing `utils/dbq.py` patterns:
-```python
-# Store parsed matches in MongoDB
-save_match_to_db(
-    match_id=match['match_id'],
-    timestamp=match['timestamp'],
-    opponent=match['opponent'],
-    winner=match['winner']
-)
-```
-
-**UI Integration:** Add to `main.py` or create new widget:
-```python
-# Match history viewer widget
-python -m widgets.match_history
-```
-
-## Attribution
-
-**Primary source:** cderickson/MTGO-Tracker
-- Repository: https://github.com/cderickson/MTGO-Tracker
-- Original file: `modo.py`
-- Parsing patterns, player extraction, winner detection adapted from this codebase
-
-**SDK assistance:** videre-project/MTGOSDK  
-- Provided `HistoryManager.GetGameHistoryFiles()` method
-- Helped identify the HistoricalMatch.Opponents bug
-
-See [ATTRIBUTIONS.md](ATTRIBUTIONS.md) for complete credits.
-
-## Testing
-
-**Manual test:**
 ```bash
-python utils/gamelog_parser.py
+# Verify connection
+python -m automation ping
+
+# Take a screenshot and view the result
+python -m automation screenshot --path /tmp/screen.png
+
+# Typical workflow: set format → load archetypes → select one → inspect decks
+python -m automation set-format Modern
+python -m automation list-archetypes
+python -m automation select-archetype --name "UR Murktide"
+python -m automation list-decks
+python -m automation select-deck 0
+python -m automation get-deck
+
+# Other useful commands
+python -m automation status          # Read the status bar
+python -m automation window-info     # Window geometry and visibility
+python -m automation list-widgets    # Enumerate registered widgets
+python -m automation click <widget> --label <button>
+python -m automation switch-tab "Stats"
+python -m automation wait 500        # Wait 500ms (e.g. after triggering async load)
+python -m automation builder-search "Lightning Bolt"
 ```
 
-Expected output:
-```
-MTGO GameLog Parser Test
-==================================================
-Found GameLog directory: C:\Users\...\GameLogs
-Parsed 10 matches from 10 log files
+All commands accept `--json` for machine-readable output and `--timeout <seconds>` (default 30).
 
-Found 10 recent matches:
-  2024-12-04 14:23 - PlayerName1 vs PlayerName2 - Winner: PlayerName1
-  ...
-```
+**Key files:**
+- `automation/server.py` — socket server embedded in the app (`AutomationServer`, default port 19847)
+- `automation/client.py` — Python client (`AutomationClient`, `wait_for_server()`)
+- `automation/cli.py` — CLI entry point (`python -m automation`)
+- `automation/test_runner.py` — example automated test suite
 
-## Future Enhancements
+# Notes
 
-Potential additions:
-- [ ] Format detection from game rules
-- [ ] Deck archetype inference from cards played
-- [ ] Game-by-game breakdown (G1/G2/G3 results)
-- [ ] Sideboard change tracking
-- [ ] Tournament event linking
-- [ ] Export formats (.csv, .json, .txt)
-
-## Files Summary
-
-**New:**
-- `utils/gamelog_parser.py` - Core parsing logic
-- `docs/GAMELOG_PARSING.md` - Technical documentation
-- `ATTRIBUTIONS.md` - Credits and licenses
-
-**Modified:**
-- `dotnet/MTGOBridge/Program.cs` - Added logfiles mode
-- `CLAUDE.md` - This documentation
-
-**Ready for Integration:**
-- Database storage (via `utils/dbq.py`)
-- UI widgets (add to `main.py`)
-- Match history viewer (new widget)
-
-The match history system is now reliable and maintainable!
-
-# Opponent Tracker Fix - Window Title Detection
-
-## Problem: wx.PyDeadObjectError and MTGOSDK Complexity
-
-The wxPython opponent tracker (`widgets/identify_opponent_wx.py`) was failing with errors:
-- `wx.PyDeadObjectError` exceptions (not accessible as `wx.PyDeadObjectError`)
-- Complex MTGOSDK bridge integration with unreliable state management
-- Widget lifecycle issues during window cleanup
-
-## Solution: Simplified Window Title Detection
-
-Replaced the MTGOSDK bridge approach with a simpler window title parsing method.
-
-### Changes Made
-
-**1. Moved `scripts/find_opponent_names.py` → `utils/find_opponent_names.py`**
-   - Simple function that scans window titles for "vs." pattern
-   - Uses `pygetwindow.getAllTitles()` to detect MTGO match windows
-   - Example: "MTGO - Match vs. PlayerName" → extracts "PlayerName"
-
-**2. Rewrote `widgets/identify_opponent_wx.py`**
-   - Removed all MTGOSDK bridge dependencies
-   - Removed `BridgeWatcher` and `start_watch()` integration
-   - Replaced with simple polling timer (2-second interval)
-   - Fixed widget lifecycle issues with proper exception handling
-
-**3. Fixed wx Exception Handling**
-   - Replaced `wx.PyDeadObjectError` catches with `RuntimeError`
-   - Added `_is_widget_ok()` helper to safely check widget validity
-   - Wrapped all widget access in try/except RuntimeError blocks
-
-### New Implementation
-
-```python
-# Old: MTGOSDK bridge
-self._watcher = start_watch(interval_ms=1000)
-snapshot = self._watcher.latest()
-opponent = snapshot['activeMatch']['players'][0]['name']
-
-# New: Window title detection
-opponents = find_opponent_names()
-opponent = opponents[0] if opponents else None
-```
-
-### Polling Strategy
-- **Interval:** 2 seconds (configurable via `POLL_INTERVAL_MS`)
-- **Detection:** Scans all window titles for "vs." pattern
-- **Caching:** 30-minute TTL for deck lookups
-- **Format:** User-selectable (Modern, Standard, etc.)
-
-### Benefits
-
-✅ **Simpler:** No bridge process, no MTGOSDK dependencies for opponent tracking
-✅ **More Reliable:** Direct window title parsing, no complex state management
-✅ **Faster:** Lightweight polling vs. continuous bridge communication
-✅ **No Crashes:** Fixed all widget lifecycle exception handling
-✅ **Platform Agnostic:** Works on any OS with pygetwindow support
-
-### Files Modified
-- `utils/find_opponent_names.py` - Moved from scripts/ (now actively used)
-- `widgets/identify_opponent_wx.py` - Complete rewrite using window title detection
-
-### Usage
-
-The opponent tracker now works out of the box:
-```bash
-python main.py
-# Opens deck builder → Click "Opponent Tracker" button
-# Widget automatically detects when you join a match
-```
-
-**Match Window Format:**
-```
-MTGO - Match vs. OpponentName
-     ↓
-Extracts: "OpponentName"
-     ↓
-Looks up recent decks from MTGGoldfish
-```
-
-### Testing
-
-✅ Syntax validated
-✅ No more wx.PyDeadObjectError exceptions
-✅ Proper widget cleanup on close
-✅ Window title detection functional
-
-The opponent tracker is now stable and works reliably without MTGOSDK dependencies!
-
-# Hypergeometric Calculator (Issue #151)
-
-## Overview
-
-Added a built-in hypergeometric probability calculator to the Opponent Tracker widget. This helps players calculate draw probabilities during matches (e.g., "What's the chance my opponent has drawn their combo piece?").
-
-## Features
-
-- **Collapsible Panel:** Toggle with "Calculator" / "Hide Calc" button
-- **Input Fields:**
-  - Deck Size (1-250, default: 60)
-  - Copies in Deck (0-60, default: 4)
-  - Cards Drawn (0-60, default: 7)
-  - Target Copies (0-60, default: 1)
-- **Preset Buttons:** Quick access to common scenarios
-  - "Open 60" - Opening hand in 60-card deck (7 cards)
-  - "Open 40" - Opening hand in 40-card limited deck
-  - "T3 Play" - Turn 3 on the play (9 cards seen)
-  - "T3 Draw" - Turn 3 on the draw (10 cards seen)
-- **Results:** Shows both exact probability and "at least" probability
-- **Persistence:** Calculator visibility state saved across sessions
-
-## Usage Example
-
-To calculate the probability of drawing at least 1 Lightning Bolt in your opening hand:
-1. Open Opponent Tracker
-2. Click "Calculator" to show the panel
-3. Set: Deck=60, Copies=4, Drawn=7, Target=1
-4. Click "Calculate"
-5. Result: ~39.95% exact, ~39.95% at least 1
-
-## Mathematical Approach
-
-Uses the hypergeometric distribution formula:
-```
-P(X = k) = [C(K, k) × C(N-K, n-k)] / C(N, n)
-```
-
-Where:
-- N = deck size
-- K = copies of target card in deck
-- n = cards drawn
-- k = target number of copies to draw
-
-Implementation uses Python's `math.comb()` for efficient computation without external dependencies.
-
-## Files
-
-- `utils/math_utils.py` - Hypergeometric calculation functions
-- `tests/test_math_utils.py` - 27 unit tests for probability functions
-- `widgets/identify_opponent.py` - Calculator panel UI integration
-
-- This project runs in Windows, but Claude Code is being run in WSL, therefore there is no way to test UI features directly, we must iterate back and forth.
+- MTGGoldfish scraping uses `/deck/{deck_num}` (robots.txt compliant); the `/deck/download/` endpoint is disallowed and must not be used.

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,0 +1,88 @@
+# Change History
+
+Historical record of significant changes, fixes, and architectural decisions.
+
+---
+
+## Hypergeometric Calculator
+
+Added a built-in hypergeometric probability calculator to the Opponent Tracker widget (Issue #151). Helps players calculate draw probabilities during matches.
+
+**Features:**
+- Collapsible panel toggled via "Calculator" / "Hide Calc" button
+- Inputs: Deck Size (default 60), Copies in Deck (default 4), Cards Drawn (default 7), Target Copies (default 1)
+- Presets: "Open 60", "Open 40", "T3 Play", "T3 Draw"
+- Shows exact probability and cumulative "at least N" probability
+- Panel visibility persists across sessions
+
+**Files:** `utils/math_utils.py`, `tests/test_math_utils.py`, `widgets/identify_opponent.py`
+
+---
+
+## Opponent Tracker Rewrite — Window Title Detection
+
+The wxPython opponent tracker was failing with `wx.PyDeadObjectError` and had unreliable state management via the MTGOSDK bridge.
+
+**Fix:** Replaced MTGOSDK bridge integration with simple window title polling. `utils/find_opponent_names.py` scans all window titles every 2 seconds for the "vs." pattern. All widget lifecycle exceptions are caught as `RuntimeError`.
+
+Before: `BridgeWatcher` + MTGOSDK `activeMatch.players`
+After: `pygetwindow.getAllTitles()` + regex on "MTGO - Match vs. PlayerName"
+
+---
+
+## GameLog Parsing — Architecture Change
+
+`MTGOSDK.HistoricalMatch.Opponents` throws `InvalidCastException` because raw MTGO data stores opponents as strings but the SDK tries to cast them to `User` objects.
+
+**Fix:** Parse MTGO GameLog files directly in Python, bypassing the broken API. Log files use a pipe-delimited format with `@PPlayerName@` markers. Parsing logic adapted from [cderickson/MTGO-Tracker](https://github.com/cderickson/MTGO-Tracker).
+
+`MTGOBridge.exe logfiles` was added to return GameLog file paths via JSON. Filesystem search is used as a fallback when MTGO is not running.
+
+See `docs/GAMELOG_PARSING.md` for the full log format spec.
+
+---
+
+## Deck Browser — Statistics Panel
+
+Added a collapsible statistics panel to the Deck Research Browser showing:
+- Metadata: archetype, player, format, source, date saved, tournament event/result
+- Composition: mainboard/sideboard counts (total and unique), estimated lands/spells
+- Top 5 most-played cards
+
+`utils/deck.py:analyze_deck()` was added to parse mainboard/sideboard separately, handle fractional quantities from averaged decks, and estimate land counts heuristically.
+
+The saved decks list now shows a `[MM/DD]` date prefix. Statistics display automatically when selecting a saved deck and hide when switching to Browse mode.
+
+---
+
+## Deck Browser — MongoDB Integration
+
+Added full deck CRUD operations via MongoDB (`utils/dbq.py`). Decks are saved to both the database and the filesystem (dual storage). Database failures do not prevent file saves.
+
+Two browsing modes were added to the UI:
+- **Browse MTGGoldfish**: original scraping functionality
+- **Saved Decks**: browse, load, edit, and delete your local collection
+
+Decks are filtered by format in the saved decks list. All database operations run in background threads.
+
+---
+
+## Deck Browser — Lazy Loading
+
+The Deck Research Browser previously blocked for 5–10 seconds on open while scraping MTGGoldfish synchronously.
+
+**Fix:** All network I/O moved to background threads. The window now opens in <100ms; archetypes load 100ms after open. Progress indicators (⏳) are shown during loading. UI updates use `root.after(0, callback)` for thread safety.
+
+---
+
+## Deck Browser — Mode Switching Bug Fix
+
+After switching from "Saved Decks" back to "Browse MTGGoldfish", the "Select archetype" button remained disabled.
+
+**Fix:** `ui_reset_to_archetype_selection()` now explicitly sets `state="normal"` and calls `lazy_load_archetypes()` if archetypes have not yet been loaded. `on_archetypes_loaded()` guards against updating UI if the mode has changed since the background thread started.
+
+---
+
+## robots.txt Compliance Fix
+
+MTGGoldfish's `robots.txt` disallows `/deck/download/{deck_num}`. The scraper was updated to use `/deck/{deck_num}` instead, extracting deck data from the embedded JavaScript on that page.


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Reduced from ~1,045 lines to ~160. Removed change history, before/after comparisons, files-modified lists, and summary sections. Kept architecture notes, module map, API signatures, database schema, and CI workflow.
- **docs/CHANGES.md**: New file with the historical content moved out of CLAUDE.md.
- **UI Automation section**: Corrected the note about WSL — the app can be launched directly from WSL via `cmd.exe`, and WSL2 localhost forwarding allows the CLI to connect to the Windows-side server on `127.0.0.1` without any extra configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)