### PR TITLE
fix: add sys.path bootstrap to widget entry points for direct execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,11 @@ ignore = [
 # Ignore complexity in test files
 "test_*.py" = ["C901"]
 "**/tests/**" = ["C901"]
+# Widget entry points insert project root into sys.path before other imports
+"widgets/identify_opponent.py" = ["E402"]
+"widgets/match_history.py" = ["E402"]
+"widgets/timer_alert.py" = ["E402"]
+"widgets/metagame_analysis.py" = ["E402"]
 
 [tool.black]
 line-length = 100

--- a/widgets/identify_opponent.py
+++ b/widgets/identify_opponent.py
@@ -2,6 +2,16 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+# Ensure the project root is on sys.path when the file is run directly
+# (e.g. `python widgets/identify_opponent.py`).  Has no effect when the
+# package is imported normally or via the installed console script.
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
 import json
 import threading
 import time

--- a/widgets/match_history.py
+++ b/widgets/match_history.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
 import threading
 from datetime import datetime
 from typing import Any

--- a/widgets/metagame_analysis.py
+++ b/widgets/metagame_analysis.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
 import threading
 from collections import Counter
 from datetime import datetime, timedelta

--- a/widgets/timer_alert.py
+++ b/widgets/timer_alert.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
 import re
 import threading
 from typing import Any


### PR DESCRIPTION
## Summary
- Running `python widgets/<widget>.py` directly sets `sys.path[0]` to the `widgets/` dir, so top-level packages (`repositories`, `services`, etc.) cannot be resolved
- Each of the four console-script entry-point widgets (`identify_opponent`, `match_history`, `timer_alert`, `metagame_analysis`) now inserts the project root into `sys.path` at startup
- The guard (`if str(_project_root) not in sys.path`) makes it a no-op when already on the path — no impact on `main.py`, `python -m widgets.*`, or installed console scripts
- Added `E402` to `per-file-ignores` in `pyproject.toml` for these four files (the sys.path manipulation must precede project imports)

## Test plan
- [ ] `python widgets/identify_opponent.py` — should no longer raise `ModuleNotFoundError`
- [ ] `python widgets/match_history.py` — same
- [ ] `python widgets/timer_alert.py` — same
- [ ] `python widgets/metagame_analysis.py` — same
- [ ] `python main.py` — unaffected, still works normally
- [ ] `ruff check` passes on all four widgets
- [ ] `black` reports no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)