### PR TITLE
feat: msgpack cache layer for faster JSON startup times

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+msgpack>=1.0
 requests==2.32.5
 loguru==0.7.3
 wxPython==4.2.4; platform_system == "Windows"

--- a/scripts/convert_to_msgpack.py
+++ b/scripts/convert_to_msgpack.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Convert JSON cache files to msgpack sidecars for faster startup.
+
+Run this once after your cache files have been downloaded or rebuilt to create
+``.msgpack`` sidecars.  The app will then prefer the faster binary format on
+subsequent startups.  The original ``.json`` files are preserved as a fallback.
+
+Files converted
+---------------
+- ``data/atomic_cards_index.json``  → ``data/atomic_cards_index.msgpack``
+- ``cache/card_images/bulk_data.json``  → ``cache/card_images/bulk_data.msgpack``
+- ``cache/card_images/printings_v2.json``  → ``cache/card_images/printings_v2.msgpack``
+
+Usage::
+
+    python scripts/convert_to_msgpack.py
+    python scripts/convert_to_msgpack.py --only atomic
+    python scripts/convert_to_msgpack.py --only bulk
+    python scripts/convert_to_msgpack.py --only printings
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from loguru import logger
+
+from utils.atomic_io import atomic_write_msgpack
+from utils.card_images import BULK_DATA_CACHE, PRINTING_INDEX_CACHE
+from utils.constants import CARD_DATA_DIR
+
+_ATOMIC_INDEX = CARD_DATA_DIR / "atomic_cards_index.json"
+
+TARGETS: dict[str, Path] = {
+    "atomic": _ATOMIC_INDEX,
+    "bulk": BULK_DATA_CACHE,
+    "printings": PRINTING_INDEX_CACHE,
+}
+
+
+def _convert_file(json_path: Path) -> bool:
+    """Convert *json_path* to a ``.msgpack`` sidecar.
+
+    Returns *True* on success, *False* when the source file is missing or the
+    conversion fails.
+    """
+    if not json_path.exists():
+        logger.warning("JSON file not found, skipping: {}", json_path)
+        return False
+
+    msg_path = json_path.with_suffix(".msgpack")
+    size_mb = json_path.stat().st_size / (1024 * 1024)
+    logger.info("Converting {} ({:.1f} MB) …", json_path.name, size_mb)
+
+    t0 = time.perf_counter()
+    try:
+        data = json.loads(json_path.read_bytes())
+    except Exception as exc:
+        logger.error("Failed to read {}: {}", json_path.name, exc)
+        return False
+    load_ms = (time.perf_counter() - t0) * 1000
+
+    t1 = time.perf_counter()
+    try:
+        atomic_write_msgpack(msg_path, data)
+    except Exception as exc:
+        logger.error("Failed to write {}: {}", msg_path.name, exc)
+        return False
+    write_ms = (time.perf_counter() - t1) * 1000
+
+    msg_size_mb = msg_path.stat().st_size / (1024 * 1024)
+    ratio = (1 - msg_path.stat().st_size / json_path.stat().st_size) * 100
+    logger.info(
+        "  {} → {}: {:.1f} MB ({:.0f}% smaller) | json_load={:.0f}ms msg_write={:.0f}ms",
+        json_path.name,
+        msg_path.name,
+        msg_size_mb,
+        ratio,
+        load_ms,
+        write_ms,
+    )
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--only",
+        choices=list(TARGETS.keys()),
+        metavar="TARGET",
+        help="Convert only the specified target (%(choices)s).",
+    )
+    args = parser.parse_args()
+
+    targets = {args.only: TARGETS[args.only]} if args.only else TARGETS
+
+    t_start = time.perf_counter()
+    successes = sum(_convert_file(path) for path in targets.values())
+    elapsed = time.perf_counter() - t_start
+
+    logger.info(
+        "Done: {}/{} files converted in {:.1f}s",
+        successes,
+        len(targets),
+        elapsed,
+    )
+    return 0 if successes == len(targets) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_data_cache_io.py
+++ b/tests/test_data_cache_io.py
@@ -1,0 +1,168 @@
+"""Tests for utils/data_cache_io.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from utils.data_cache_io import (
+    AutoCacheLoader,
+    DataCacheLoader,
+    JsonCacheLoader,
+    MsgpackCacheLoader,
+    get_loader,
+    load_cache,
+    set_loader,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE: dict[str, Any] = {
+    "cards": [{"name": "Lightning Bolt", "mana_cost": "{R}"}],
+    "cards_by_name": {"lightning bolt": {"name": "Lightning Bolt"}},
+}
+
+
+def _write_json(path: Path, data: Any) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_msgpack(path: Path, data: Any) -> None:
+    import msgpack
+
+    path.write_bytes(msgpack.packb(data, use_bin_type=True))
+
+
+# ---------------------------------------------------------------------------
+# JsonCacheLoader
+# ---------------------------------------------------------------------------
+
+
+def test_json_loader_loads_dict(tmp_path: Path) -> None:
+    p = tmp_path / "data.json"
+    _write_json(p, _SAMPLE)
+    result = JsonCacheLoader().load(p)
+    assert result["cards"][0]["name"] == "Lightning Bolt"
+
+
+def test_json_loader_loads_list(tmp_path: Path) -> None:
+    p = tmp_path / "list.json"
+    _write_json(p, [1, 2, 3])
+    assert JsonCacheLoader().load(p) == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# MsgpackCacheLoader
+# ---------------------------------------------------------------------------
+
+
+def test_msgpack_loader_loads_dict(tmp_path: Path) -> None:
+    p = tmp_path / "data.msgpack"
+    _write_msgpack(p, _SAMPLE)
+    result = MsgpackCacheLoader().load(p)
+    assert result["cards"][0]["name"] == "Lightning Bolt"
+
+
+def test_msgpack_loader_loads_list(tmp_path: Path) -> None:
+    p = tmp_path / "list.msgpack"
+    _write_msgpack(p, [10, 20, 30])
+    assert MsgpackCacheLoader().load(p) == [10, 20, 30]
+
+
+# ---------------------------------------------------------------------------
+# AutoCacheLoader
+# ---------------------------------------------------------------------------
+
+
+def test_auto_loader_falls_back_to_json_when_no_msgpack(tmp_path: Path) -> None:
+    p = tmp_path / "data.json"
+    _write_json(p, _SAMPLE)
+    result = AutoCacheLoader().load(p)
+    assert result["cards"][0]["name"] == "Lightning Bolt"
+
+
+def test_auto_loader_prefers_msgpack_when_sidecar_exists(tmp_path: Path) -> None:
+    json_path = tmp_path / "data.json"
+    msg_path = tmp_path / "data.msgpack"
+    _write_json(json_path, {"source": "json"})
+    _write_msgpack(msg_path, {"source": "msgpack"})
+
+    result = AutoCacheLoader().load(json_path)
+    assert result["source"] == "msgpack"
+
+
+def test_auto_loader_falls_back_to_json_on_corrupt_msgpack(tmp_path: Path) -> None:
+    json_path = tmp_path / "data.json"
+    msg_path = tmp_path / "data.msgpack"
+    _write_json(json_path, {"source": "json"})
+    msg_path.write_bytes(b"not valid msgpack content!!!")
+
+    result = AutoCacheLoader(warn_on_fallback=False).load(json_path)
+    assert result["source"] == "json"
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_loaders_satisfy_protocol() -> None:
+    assert isinstance(JsonCacheLoader(), DataCacheLoader)
+    assert isinstance(MsgpackCacheLoader(), DataCacheLoader)
+    assert isinstance(AutoCacheLoader(), DataCacheLoader)
+
+
+# ---------------------------------------------------------------------------
+# Module-level set_loader / get_loader / load_cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_loader():
+    """Restore the module-level loader after each test."""
+    original = get_loader()
+    yield
+    set_loader(original)
+
+
+def test_get_loader_returns_auto_by_default() -> None:
+    assert isinstance(get_loader(), AutoCacheLoader)
+
+
+def test_set_loader_replaces_default(tmp_path: Path) -> None:
+    json_path = tmp_path / "data.json"
+    msg_path = tmp_path / "data.msgpack"
+    _write_json(json_path, {"source": "json"})
+    _write_msgpack(msg_path, {"source": "msgpack"})
+
+    # Force JSON loader — should ignore the sidecar
+    set_loader(JsonCacheLoader())
+    result = load_cache(json_path)
+    assert result["source"] == "json"
+
+
+def test_load_cache_uses_current_loader_msgpack(tmp_path: Path) -> None:
+    json_path = tmp_path / "data.json"
+    msg_path = tmp_path / "data.msgpack"
+    _write_json(json_path, {"source": "json"})
+    _write_msgpack(msg_path, {"source": "msgpack"})
+
+    # Default AutoCacheLoader should prefer msgpack
+    result = load_cache(json_path)
+    assert result["source"] == "msgpack"
+
+
+def test_set_loader_accepts_custom_implementation(tmp_path: Path) -> None:
+    class AlwaysEmpty:
+        def load(self, path: Path) -> Any:
+            return {}
+
+    set_loader(AlwaysEmpty())
+    json_path = tmp_path / "data.json"
+    _write_json(json_path, {"key": "value"})
+    assert load_cache(json_path) == {}

--- a/utils/atomic_io.py
+++ b/utils/atomic_io.py
@@ -103,3 +103,11 @@ def atomic_write_json(
 ) -> None:
     data = json.dumps(payload, indent=indent, ensure_ascii=ensure_ascii, separators=separators)
     atomic_write_text(path, data)
+
+
+def atomic_write_msgpack(path: Path, payload: Any) -> None:
+    """Serialise *payload* to msgpack and write atomically."""
+    import msgpack  # lazy import – optional dependency
+
+    data = msgpack.packb(payload, use_bin_type=True)
+    atomic_write_bytes(path, data)

--- a/utils/card_data.py
+++ b/utils/card_data.py
@@ -10,13 +10,14 @@ from typing import Any
 from curl_cffi import requests
 from loguru import logger
 
-from utils.atomic_io import atomic_write_json
+from utils.atomic_io import atomic_write_json, atomic_write_msgpack
 from utils.constants import (
     ATOMIC_DATA_DOWNLOAD_TIMEOUT_SECONDS,
     ATOMIC_DATA_HEAD_TIMEOUT_SECONDS,
     ATOMIC_DATA_URL,
     CARD_DATA_DIR,
 )
+from utils.data_cache_io import load_cache
 
 
 def load_card_manager(data_dir: Path | str = CARD_DATA_DIR, force: bool = False) -> CardDataManager:
@@ -177,6 +178,7 @@ class CardDataManager:
                 raw = json.load(source)
         index = self._build_index(raw.get("data", {}))
         atomic_write_json(self.index_path, index, ensure_ascii=False)
+        atomic_write_msgpack(self.index_path.with_suffix(".msgpack"), index)
         meta_to_store: dict[str, Any] = remote_meta.copy() if remote_meta else {}
         meta_to_store.setdefault("sha512", digest)
         headers = {k.lower(): v for k, v in resp.headers.items()}  # type: ignore[arg-type]
@@ -191,7 +193,13 @@ class CardDataManager:
         self._cards_by_name = index["cards_by_name"]
 
     def _load_index(self) -> None:
-        data = self._load_json(self.index_path)
+        msg_path = self.index_path.with_suffix(".msgpack")
+        if not self.index_path.exists() and not msg_path.exists():
+            raise RuntimeError("Card data index missing or invalid")
+        try:
+            data = load_cache(self.index_path)
+        except Exception as exc:
+            raise RuntimeError("Card data index missing or invalid") from exc
         if not data:
             raise RuntimeError("Card data index missing or invalid")
         self._cards = data["cards"]

--- a/utils/card_images.py
+++ b/utils/card_images.py
@@ -16,7 +16,6 @@ Architecture:
 
 from __future__ import annotations
 
-import json
 import os
 import sqlite3
 import threading
@@ -37,6 +36,7 @@ from loguru import logger
 from utils.atomic_io import (
     atomic_write_bytes,
     atomic_write_json,
+    atomic_write_msgpack,
     atomic_write_stream,
     locked_path,
 )
@@ -45,6 +45,7 @@ from utils.constants import (
     CACHE_DIR,
     SQLITE_CONNECTION_TIMEOUT_SECONDS,
 )
+from utils.data_cache_io import load_cache
 from utils.perf import timed
 
 # Image cache configuration
@@ -800,7 +801,7 @@ class BulkImageDownloader:
 
         try:
             with locked_path(BULK_DATA_CACHE):
-                cards_data = json.loads(BULK_DATA_CACHE.read_text(encoding="utf-8"))
+                cards_data = load_cache(BULK_DATA_CACHE)
             if max_cards:
                 cards_data = cards_data[:max_cards]
 
@@ -916,12 +917,11 @@ def build_printing_index(
 
 def _load_printing_index_payload() -> dict[str, Any] | None:
     """Load the cached card printings index if available."""
-    if not PRINTING_INDEX_CACHE.exists():
+    msg_path = PRINTING_INDEX_CACHE.with_suffix(".msgpack")
+    if not PRINTING_INDEX_CACHE.exists() and not msg_path.exists():
         return None
     try:
-        with locked_path(PRINTING_INDEX_CACHE):
-            with PRINTING_INDEX_CACHE.open("r", encoding="utf-8") as fh:
-                payload = json.load(fh)
+        payload = load_cache(PRINTING_INDEX_CACHE)
     except Exception as exc:
         logger.warning(f"Failed to read printings index cache: {exc}")
         return None
@@ -950,8 +950,7 @@ def ensure_printing_index_cache(force: bool = False) -> dict[str, Any]:
 
     logger.info("Building card printings index from bulk data…")
     with locked_path(BULK_DATA_CACHE):
-        with BULK_DATA_CACHE.open("r", encoding="utf-8") as fh:
-            cards = json.load(fh)
+        cards = load_cache(BULK_DATA_CACHE)
 
     by_name, stats = build_printing_index(cards)
 
@@ -966,6 +965,7 @@ def ensure_printing_index_cache(force: bool = False) -> dict[str, Any]:
 
     try:
         atomic_write_json(PRINTING_INDEX_CACHE, payload, separators=(",", ":"))
+        atomic_write_msgpack(PRINTING_INDEX_CACHE.with_suffix(".msgpack"), payload)
         logger.info(
             "Cached card printings index ({unique_names} names, {total_printings} printings)",
             unique_names=payload["unique_names"],

--- a/utils/card_images_workers.py
+++ b/utils/card_images_workers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -13,12 +12,13 @@ except ImportError:  # Python 3.10
 
     UTC = timezone.utc  # noqa: F811,UP017
 
-from utils.atomic_io import atomic_write_json, locked_path
+from utils.atomic_io import atomic_write_json, atomic_write_msgpack, locked_path
 from utils.card_images import (
     BulkImageDownloader,
     CardImageCache,
     build_printing_index,
 )
+from utils.data_cache_io import load_cache
 
 __all__ = ["build_printing_index_worker", "download_bulk_metadata_worker"]
 
@@ -45,8 +45,7 @@ def build_printing_index_worker(
         raise FileNotFoundError("Bulk data cache not found; cannot build printings index")
 
     with locked_path(bulk_path):
-        with bulk_path.open("r", encoding="utf-8") as fh:
-            cards = json.load(fh)
+        cards = load_cache(bulk_path)
 
     by_name, stats = build_printing_index(cards)
     payload = {
@@ -58,6 +57,7 @@ def build_printing_index_worker(
         "data": by_name,
     }
     atomic_write_json(printings_cache, payload, separators=(",", ":"))
+    atomic_write_msgpack(printings_cache.with_suffix(".msgpack"), payload)
     return {
         "unique_names": payload["unique_names"],
         "total_printings": payload["total_printings"],

--- a/utils/data_cache_io.py
+++ b/utils/data_cache_io.py
@@ -1,0 +1,125 @@
+"""Swappable cache loader interface for JSON and msgpack data files.
+
+Provides a protocol-based loader interface and an ``AutoCacheLoader`` that
+prefers msgpack (``.msgpack``) sidecars when available, falling back to the
+original ``.json`` source transparently.
+
+Usage::
+
+    from pathlib import Path
+    from utils.data_cache_io import load_cache, set_loader, JsonCacheLoader
+
+    # Default: AutoCacheLoader (msgpack if available, else JSON)
+    data = load_cache(Path("data/atomic_cards_index.json"))
+
+    # Force JSON only (e.g. for debugging):
+    set_loader(JsonCacheLoader())
+
+    # Restore default auto behaviour:
+    set_loader(AutoCacheLoader())
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DataCacheLoader(Protocol):
+    """Protocol for interchangeable data cache loaders."""
+
+    def load(self, path: Path) -> Any:
+        """Load and return deserialised data from *path*."""
+        ...
+
+
+class JsonCacheLoader:
+    """Loads data from ``.json`` files."""
+
+    def load(self, path: Path) -> Any:
+        return json.loads(path.read_bytes())
+
+
+class MsgpackCacheLoader:
+    """Loads data from ``.msgpack`` files."""
+
+    def load(self, path: Path) -> Any:
+        import msgpack  # lazy import – optional in environments without msgpack
+
+        return msgpack.unpackb(path.read_bytes(), raw=False, strict_map_key=False)
+
+
+class AutoCacheLoader:
+    """Prefers a ``.msgpack`` sidecar when one exists; falls back to ``.json``.
+
+    The sidecar path is derived by replacing the source file's suffix with
+    ``.msgpack``.  For example, ``data/atomic_cards_index.json`` is tried as
+    ``data/atomic_cards_index.msgpack`` first.
+
+    Args:
+        warn_on_fallback: If *True*, log a warning whenever the msgpack load
+            fails and the loader falls back to JSON.
+    """
+
+    def __init__(self, *, warn_on_fallback: bool = True) -> None:
+        self._warn_on_fallback = warn_on_fallback
+
+    def load(self, path: Path) -> Any:
+        msg_path = path.with_suffix(".msgpack")
+        if msg_path.exists():
+            try:
+                return MsgpackCacheLoader().load(msg_path)
+            except Exception as exc:
+                if self._warn_on_fallback:
+                    from loguru import logger
+
+                    logger.warning(
+                        "msgpack load failed for %s, falling back to JSON: %s",
+                        msg_path,
+                        exc,
+                    )
+        return JsonCacheLoader().load(path)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+_default_loader: DataCacheLoader = AutoCacheLoader()
+
+
+def get_loader() -> DataCacheLoader:
+    """Return the current module-level cache loader."""
+    return _default_loader
+
+
+def set_loader(loader: DataCacheLoader) -> None:
+    """Replace the module-level cache loader.
+
+    Use this to force a specific format (e.g. ``JsonCacheLoader()`` for
+    debugging) or to restore the default ``AutoCacheLoader()``.
+    """
+    global _default_loader
+    _default_loader = loader
+
+
+def load_cache(path: Path) -> Any:
+    """Load data from *path* using the current default loader.
+
+    The default loader is ``AutoCacheLoader``, which transparently uses a
+    ``.msgpack`` sidecar when one is present alongside the JSON source.
+    """
+    return _default_loader.load(path)
+
+
+__all__ = [
+    "DataCacheLoader",
+    "JsonCacheLoader",
+    "MsgpackCacheLoader",
+    "AutoCacheLoader",
+    "get_loader",
+    "set_loader",
+    "load_cache",
+]


### PR DESCRIPTION
## Summary

- **`utils/data_cache_io.py`** – New protocol-based loader interface with `DataCacheLoader`, `JsonCacheLoader`, `MsgpackCacheLoader`, and `AutoCacheLoader`. The `AutoCacheLoader` is the default: it checks for a `.msgpack` sidecar alongside any `.json` path and loads it if present, falling back to JSON transparently. Swap the default loader via `set_loader()` when needed.
- **`utils/atomic_io.py`** – Added `atomic_write_msgpack()` for safe binary writes.
- **`utils/card_data.py`** – `_load_index()` now uses `load_cache()` (auto format); `_download_and_rebuild()` writes a `.msgpack` sidecar after writing `atomic_cards_index.json`.
- **`utils/card_images.py`** – `_load_printing_index_payload()` and `download_all_images()` use `load_cache()`; `ensure_printing_index_cache()` writes a `printings_v2.msgpack` sidecar.
- **`utils/card_images_workers.py`** – `build_printing_index_worker()` uses `load_cache()` for bulk data and writes a `.msgpack` sidecar for the printings index.
- **`scripts/convert_to_msgpack.py`** – One-shot CLI to pre-bake `.msgpack` sidecars from existing `.json` files (useful for `bulk_data.json` which isn't re-serialised on every download).
- **`requirements.txt`** – Added `msgpack>=1.0`.
- **`tests/test_data_cache_io.py`** – 12 unit tests covering all loaders, fallback behaviour, protocol conformance, and the module-level helpers.

## Test plan
- [ ] `python3 -m pytest tests/test_data_cache_io.py` – all 12 new tests pass
- [ ] `python3 -m pytest tests/test_card_data_refresh.py tests/test_card_data_aliases.py tests/test_card_images_cache.py tests/test_card_images_aliases.py tests/test_card_repository.py` – existing 48 tests still pass
- [ ] Run `python scripts/convert_to_msgpack.py` after caches exist to pre-bake sidecars
- [ ] Verify the app starts faster after sidecars are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)