### PR TITLE
feat: replace stdlib json with msgspec for faster large-file loading

### DIFF
--- a/navigators/mtggoldfish.py
+++ b/navigators/mtggoldfish.py
@@ -20,15 +20,15 @@ from utils.constants import (
     ONE_DAY_SECONDS,
 )
 from utils.deck_text_cache import get_deck_cache
+from utils.json_io import fast_load
 
 
 def _load_cached_archetypes(mtg_format: str, max_age: int = METAGAME_CACHE_TTL_SECONDS):
     if not ARCHETYPE_LIST_CACHE_FILE.exists():
         return None
     try:
-        with ARCHETYPE_LIST_CACHE_FILE.open("r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except json.JSONDecodeError as exc:
+        data = fast_load(ARCHETYPE_LIST_CACHE_FILE)
+    except Exception as exc:
         logger.warning(f"Cached archetype list invalid: {exc}")
         return None
     entry = data.get(mtg_format)
@@ -41,12 +41,8 @@ def _load_cached_archetypes(mtg_format: str, max_age: int = METAGAME_CACHE_TTL_S
 
 def _save_cached_archetypes(mtg_format: str, items: list[dict]):
     try:
-        if ARCHETYPE_LIST_CACHE_FILE.exists():
-            with ARCHETYPE_LIST_CACHE_FILE.open("r", encoding="utf-8") as fh:
-                data = json.load(fh)
-        else:
-            data = {}
-    except json.JSONDecodeError:
+        data = fast_load(ARCHETYPE_LIST_CACHE_FILE) if ARCHETYPE_LIST_CACHE_FILE.exists() else {}
+    except Exception:
         data = {}
     data[mtg_format] = {"timestamp": time.time(), "items": items}
     ARCHETYPE_LIST_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -115,9 +111,8 @@ def _load_cached_archetype_decks(archetype: str, max_age: int = METAGAME_CACHE_T
     if not ARCHETYPE_DECKS_CACHE_FILE.exists():
         return None
     try:
-        with ARCHETYPE_DECKS_CACHE_FILE.open("r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except json.JSONDecodeError as exc:
+        data = fast_load(ARCHETYPE_DECKS_CACHE_FILE)
+    except Exception as exc:
         logger.warning(f"Cached archetype decks invalid: {exc}")
         return None
     entry = data.get(archetype)
@@ -131,12 +126,8 @@ def _load_cached_archetype_decks(archetype: str, max_age: int = METAGAME_CACHE_T
 def _save_cached_archetype_decks(archetype: str, items: list[dict]):
     """Save archetype deck list to cache."""
     try:
-        if ARCHETYPE_DECKS_CACHE_FILE.exists():
-            with ARCHETYPE_DECKS_CACHE_FILE.open("r", encoding="utf-8") as fh:
-                data = json.load(fh)
-        else:
-            data = {}
-    except json.JSONDecodeError:
+        data = fast_load(ARCHETYPE_DECKS_CACHE_FILE) if ARCHETYPE_DECKS_CACHE_FILE.exists() else {}
+    except Exception:
         data = {}
     data[archetype] = {"timestamp": time.time(), "items": items}
     ARCHETYPE_DECKS_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -194,9 +185,8 @@ def get_archetype_stats(mtg_format: str):
     stats = {}
     if cache_path.exists():
         try:
-            with cache_path.open("r", encoding="utf-8") as f:
-                stats = json.load(f)
-        except json.JSONDecodeError as exc:
+            stats = fast_load(cache_path)
+        except Exception as exc:
             logger.warning(f"Invalid archetype cache at {cache_path}: {exc}")
             stats = {}
         if (

--- a/navigators/mtgo_decklists.py
+++ b/navigators/mtgo_decklists.py
@@ -18,6 +18,7 @@ from utils.constants import (
     MTGO_DECKLISTS_ENABLED,
     MTGO_DECKLISTS_REQUEST_TIMEOUT_SECONDS,
 )
+from utils.json_io import fast_decode, fast_load
 
 BASE_URL = "https://www.mtgo.com"
 DECKLIST_INDEX_URL = "https://www.mtgo.com/decklists/{year}/{month:02d}"
@@ -27,9 +28,8 @@ def _load_cache() -> dict[str, Any]:
     if not MTGO_DECK_CACHE_FILE.exists():
         return {}
     try:
-        with MTGO_DECK_CACHE_FILE.open("r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except json.JSONDecodeError as exc:
+        return fast_load(MTGO_DECK_CACHE_FILE)
+    except Exception as exc:
         logger.warning(f"Invalid MTGO deck cache JSON ({MTGO_DECK_CACHE_FILE}): {exc}")
         return {}
 
@@ -133,7 +133,7 @@ def _parse_deck_event(html: str) -> dict[str, Any]:
     match = DETAIL_RE.search(html)
     if not match:
         raise ValueError("Could not locate deck JSON payload")
-    payload = json.loads(match.group(1))
+    payload = fast_decode(match.group(1))
     return payload
 
 

--- a/repositories/card_repository.py
+++ b/repositories/card_repository.py
@@ -8,11 +8,12 @@ This module handles all card-related data access including:
 - Printing information
 """
 
-import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+import msgspec
+import msgspec.json
 from loguru import logger
 
 from utils.card_data import CardDataManager
@@ -22,6 +23,25 @@ from utils.card_images import (
     ensure_printing_index_cache,
     get_card_image,
 )
+
+# ---------------------------------------------------------------------------
+# msgspec schema for collection files
+# ---------------------------------------------------------------------------
+
+
+class _CollectionEntry(msgspec.Struct, gc=False):
+    """A single card entry in a collection JSON file.
+
+    Only the three fields we actually need are declared; all other keys in
+    the JSON object are silently ignored by msgspec.
+    """
+
+    name: str
+    quantity: float  # Accept int or float; we coerce to int after decoding.
+    id: Any = None  # Optional UUID / numeric card ID
+
+
+_collection_any_decoder: msgspec.json.Decoder[Any] = msgspec.json.Decoder(Any)
 
 
 class CardRepository:
@@ -264,7 +284,7 @@ class CardRepository:
             return []
 
         try:
-            raw_data = filepath.read_text(encoding="utf-8")
+            raw_data = filepath.read_bytes()
         except FileNotFoundError:
             logger.info(f"Collection file {filepath} does not exist")
             return []
@@ -272,19 +292,21 @@ class CardRepository:
             logger.error(f"Unable to read collection file {filepath}: {exc}")
             return []
 
+        # Decode the outer wrapper (may be a list or a dict with a nested list)
+        # using the untyped Any decoder so the existing _extract_cards logic works.
         try:
-            payload = json.loads(raw_data)
-        except json.JSONDecodeError as exc:
+            payload = _collection_any_decoder.decode(raw_data)
+        except msgspec.DecodeError as exc:
             logger.error(f"Invalid JSON in collection file {filepath}: {exc}")
             return []
 
-        card_entries = _extract_cards(payload)
-        if not card_entries:
+        raw_entries = _extract_cards(payload)
+        if not raw_entries:
             logger.warning(f"No card entries found in collection file {filepath}")
             return []
 
         parsed_cards: list[dict[str, Any]] = []
-        for entry in card_entries:
+        for entry in raw_entries:
             if not isinstance(entry, dict):
                 continue
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+msgspec>=0.18.6
 requests==2.32.5
 loguru==0.7.3
 wxPython==4.2.4; platform_system == "Windows"

--- a/scripts/benchmark_json_caches.py
+++ b/scripts/benchmark_json_caches.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Benchmark the card metadata caches to understand their load times."""
+"""Benchmark the card metadata caches to understand their load times.
+
+Compares stdlib ``json`` against ``msgspec`` (with and without schemas) so the
+speed improvement from the msgspec migration is clearly visible.
+"""
 
 from __future__ import annotations
 
@@ -12,7 +16,13 @@ from pathlib import Path
 
 from loguru import logger
 
-from utils.card_images import BULK_DATA_CACHE, PRINTING_INDEX_CACHE
+from utils.card_images import (
+    BULK_DATA_CACHE,
+    PRINTING_INDEX_CACHE,
+    _bulk_cards_decoder,
+    _printing_index_decoder,
+)
+from utils.json_io import fast_load
 
 
 def _format_duration(seconds: float) -> str:
@@ -21,37 +31,97 @@ def _format_duration(seconds: float) -> str:
     return f"{seconds:.2f} s"
 
 
+def _benchmark_variant(
+    path: Path,
+    iterations: int,
+    label: str,
+    loader,
+) -> list[float]:
+    """Run *loader* against *path* for *iterations* and return elapsed times."""
+    durations: list[float] = []
+    for i in range(iterations):
+        start = time.perf_counter()
+        try:
+            loader(path)
+        except Exception as exc:
+            logger.error(f"{label}: failed on iteration {i + 1}: {exc}")
+            return []
+        durations.append(time.perf_counter() - start)
+        logger.info(f"  {label} iter {i + 1}: {_format_duration(durations[-1])}")
+    return durations
+
+
+def _summarise(label: str, durations: list[float]) -> None:
+    if not durations:
+        return
+    logger.info(
+        "{label}: min={min}  avg={avg}  max={max}",
+        label=label,
+        min=_format_duration(min(durations)),
+        avg=_format_duration(statistics.mean(durations)),
+        max=_format_duration(max(durations)),
+    )
+
+
 def _benchmark(path: Path, iterations: int, label: str) -> None:
     if not path.exists():
         logger.warning(f"{label} cache not found at {path}")
         return
 
     size_mb = path.stat().st_size / (1024 * 1024)
-    logger.info(f"{label} cache size: {size_mb:.1f} MB")
+    logger.info(f"\n{'='*60}")
+    logger.info(f"{label} ({size_mb:.1f} MB)  —  {iterations} iteration(s)")
+    logger.info(f"{'='*60}")
 
-    durations: list[float] = []
-    for iteration in range(iterations):
-        start = time.perf_counter()
-        try:
-            with path.open("rb") as fh:
-                json.load(fh)
-        except json.JSONDecodeError as exc:
-            logger.error(f"Failed to parse {label} cache: {exc}")
-            return
-        elapsed = time.perf_counter() - start
-        durations.append(elapsed)
-        logger.info(f"{label} iteration {iteration + 1}: {_format_duration(elapsed)}")
-
-    summary = {
-        "min": durations and _format_duration(min(durations)),
-        "max": durations and _format_duration(max(durations)),
-        "avg": durations and _format_duration(statistics.mean(durations)),
-    }
-    logger.info(
-        "{label} summary: min={min}, max={max}, avg={avg}",
-        label=label,
-        **summary,  # type: ignore[arg-type]
+    # stdlib json
+    logger.info("--- stdlib json ---")
+    stdlib_times = _benchmark_variant(
+        path,
+        iterations,
+        "stdlib",
+        lambda p: json.loads(p.read_bytes()),
     )
+    _summarise("stdlib json", stdlib_times)
+
+    # msgspec Any (no schema)
+    logger.info("--- msgspec Any (no schema) ---")
+    msgspec_any_times = _benchmark_variant(
+        path,
+        iterations,
+        "msgspec[Any]",
+        fast_load,
+    )
+    _summarise("msgspec Any", msgspec_any_times)
+
+    # msgspec typed (only available for known schemas)
+    if path == PRINTING_INDEX_CACHE:
+        logger.info("--- msgspec PrintingIndexPayload (typed schema) ---")
+        typed_times = _benchmark_variant(
+            path,
+            iterations,
+            "msgspec[schema]",
+            lambda p: _printing_index_decoder.decode(p.read_bytes()),
+        )
+        _summarise("msgspec typed", typed_times)
+    elif path == BULK_DATA_CACHE:
+        logger.info("--- msgspec list[BulkCard] (typed schema, partial fields) ---")
+        typed_times = _benchmark_variant(
+            path,
+            iterations,
+            "msgspec[schema]",
+            lambda p: _bulk_cards_decoder.decode(p.read_bytes()),
+        )
+        _summarise("msgspec typed", typed_times)
+    else:
+        typed_times = []
+
+    # Speedup summary
+    if stdlib_times and msgspec_any_times:
+        speedup_any = statistics.mean(stdlib_times) / statistics.mean(msgspec_any_times)
+        logger.info(f"msgspec Any speedup: {speedup_any:.2f}x")
+    if stdlib_times and typed_times:
+        speedup_typed = statistics.mean(stdlib_times) / statistics.mean(typed_times)
+        logger.info(f"msgspec typed speedup: {speedup_typed:.2f}x")
 
 
 def main() -> int:

--- a/services/mtgo_background_service.py
+++ b/services/mtgo_background_service.py
@@ -1,6 +1,5 @@
 """Background service for fetching MTGO data."""
 
-import json
 import time
 from datetime import datetime, timedelta
 
@@ -21,6 +20,7 @@ from utils.constants import (
     MTGO_METADATA_CACHE_FILE,
 )
 from utils.deck_text_cache import get_deck_cache
+from utils.json_io import fast_load
 
 MTGO_METADATA_CACHE = MTGO_METADATA_CACHE_FILE
 
@@ -117,9 +117,8 @@ def save_mtgo_deck_metadata(archetype: str, mtg_format: str, deck_metadata: dict
         with locked_path(MTGO_METADATA_CACHE):
             if MTGO_METADATA_CACHE.exists():
                 try:
-                    with MTGO_METADATA_CACHE.open("r", encoding="utf-8") as fh:
-                        data = json.load(fh)
-                except json.JSONDecodeError:
+                    data = fast_load(MTGO_METADATA_CACHE)
+                except Exception:
                     logger.warning("MTGO metadata cache invalid JSON; resetting file")
                     data = {}
             else:
@@ -162,9 +161,8 @@ def load_mtgo_deck_metadata(archetype: str, mtg_format: str) -> list[dict]:
 
         try:
             with locked_path(MTGO_METADATA_CACHE):
-                with MTGO_METADATA_CACHE.open("r", encoding="utf-8") as fh:
-                    data = json.load(fh)
-        except json.JSONDecodeError:
+                data = fast_load(MTGO_METADATA_CACHE)
+        except Exception:
             logger.warning("MTGO metadata cache invalid JSON; returning empty results")
             return []
 

--- a/services/state_service.py
+++ b/services/state_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +8,7 @@ from loguru import logger
 from utils import constants
 from utils.atomic_io import atomic_write_json, locked_path
 from utils.deck import sanitize_zone_cards
+from utils.json_io import fast_load
 
 
 class StateService:
@@ -22,9 +22,8 @@ class StateService:
             return {}
         try:
             with locked_path(self.settings_path):
-                with self.settings_path.open("r", encoding="utf-8") as fh:
-                    return json.load(fh)
-        except json.JSONDecodeError as exc:  # pragma: no cover - defensive logging
+                return fast_load(self.settings_path)
+        except Exception as exc:  # pragma: no cover - defensive logging
             logger.warning(f"Failed to load deck selector settings: {exc}")
             return {}
 

--- a/services/store_service.py
+++ b/services/store_service.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
 from utils.atomic_io import atomic_write_json, locked_path
+from utils.json_io import fast_load
 
 
 class StoreService:
@@ -28,12 +28,12 @@ class StoreService:
             return {}
         try:
             with locked_path(path):
-                return json.loads(path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            logger.warning(f"Invalid JSON at {path}; ignoring store")
-            return {}
-        except OSError as exc:
-            logger.warning(f"Failed to read {path}: {exc}")
+                return fast_load(path)
+        except Exception as exc:
+            if isinstance(exc, OSError):
+                logger.warning(f"Failed to read {path}: {exc}")
+            else:
+                logger.warning(f"Invalid JSON at {path}; ignoring store")
             return {}
 
     def save_store(self, path: Path, data: dict[str, Any]) -> None:

--- a/utils/atomic_io.py
+++ b/utils/atomic_io.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import tempfile
 import threading
@@ -10,6 +9,8 @@ from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+
+import msgspec.json
 
 _lock_registry: dict[Path, threading.RLock] = {}
 _lock_registry_lock = threading.Lock()
@@ -101,5 +102,13 @@ def atomic_write_json(
     ensure_ascii: bool = False,
     separators: tuple[str, str] | None = None,
 ) -> None:
-    data = json.dumps(payload, indent=indent, ensure_ascii=ensure_ascii, separators=separators)
-    atomic_write_text(path, data)
+    # msgspec.json.encode always produces compact UTF-8 bytes (no ASCII escaping).
+    # The ``ensure_ascii`` parameter is accepted for API compatibility but ignored
+    # because msgspec always uses UTF-8 encoding (never escapes non-ASCII chars).
+    raw: bytes = msgspec.json.encode(payload)
+    if indent is not None:
+        raw = msgspec.json.format(raw, indent=indent)
+    # When callers explicitly request compact output via ``separators``,
+    # ``indent`` is typically None so the branch above is skipped and we
+    # already have compact bytes – nothing more to do.
+    atomic_write_bytes(path, raw)

--- a/utils/card_data.py
+++ b/utils/card_data.py
@@ -7,6 +7,8 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+import msgspec
+import msgspec.json
 from curl_cffi import requests
 from loguru import logger
 
@@ -17,6 +19,61 @@ from utils.constants import (
     ATOMIC_DATA_URL,
     CARD_DATA_DIR,
 )
+
+# ---------------------------------------------------------------------------
+# msgspec schemas for the atomic-cards index
+# ---------------------------------------------------------------------------
+
+
+class CardEntry(msgspec.Struct, gc=False):
+    """A single card record as stored in the local atomic-cards index.
+
+    ``gc=False`` disables cyclic-garbage-collection tracking for this type,
+    which measurably reduces parse time when decoding large lists of structs.
+    """
+
+    name: str
+    name_lower: str
+    aliases: list[str]
+    colors: list[str]
+    color_identity: list[str]
+    legalities: dict[str, str]
+    mana_cost: str | None = None
+    mana_value: float | None = None
+    type_line: str | None = None
+    oracle_text: str | None = None
+    power: str | None = None
+    toughness: str | None = None
+    loyalty: str | None = None
+
+    # ------------------------------------------------------------------
+    # Dict-compatible accessors so that existing callers that treat the
+    # returned value as a dict continue to work without modification.
+    # ------------------------------------------------------------------
+
+    def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        return getattr(self, key, default)
+
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key) from None
+
+    def __contains__(self, key: object) -> bool:
+        return isinstance(key, str) and hasattr(self, key)
+
+
+class CardIndex(msgspec.Struct):
+    """Root structure of the saved atomic-cards index file."""
+
+    cards: list[CardEntry]
+    cards_by_name: dict[str, CardEntry]
+
+
+# Pre-instantiated decoder – reusing it avoids re-building the decoder on
+# every call, which matters for repeat loads (e.g. force-refresh).
+_card_index_decoder: msgspec.json.Decoder[CardIndex] = msgspec.json.Decoder(CardIndex)
 
 
 def load_card_manager(data_dir: Path | str = CARD_DATA_DIR, force: bool = False) -> CardDataManager:
@@ -47,13 +104,13 @@ class CardDataManager:
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.index_path = self.data_dir / "atomic_cards_index.json"
         self.meta_path = self.data_dir / "atomic_cards_meta.json"
-        self._cards: list[dict[str, Any]] | None = None
-        self._cards_by_name: dict[str, dict[str, Any]] | None = None
+        self._cards: list[CardEntry] | None = None
+        self._cards_by_name: dict[str, CardEntry] | None = None
 
     def ensure_latest(self, force: bool = False) -> None:
 
         remote_meta = self._fetch_remote_meta()
-        local_meta = self._load_json(self.meta_path) or {}
+        local_meta = self._load_meta_json() or {}
         missing_index = not self.index_path.exists()
         needs_refresh = force or missing_index
         if not needs_refresh and remote_meta:
@@ -87,17 +144,17 @@ class CardDataManager:
         type_filter: str | None = None,
         color_identity: list[str] | None = None,
         limit: int | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> list[CardEntry]:
         self._require_cards()
         query = (query or "").strip().lower()
         fmt = (format_filter or "").strip().lower()
         type_filter = (type_filter or "").strip().lower()
         color_identity = [c.upper() for c in (color_identity or [])]
-        results: list[dict[str, Any]] = []
+        results: list[CardEntry] = []
         for card in self._cards or []:
-            name_lower = card["name_lower"]
-            type_line = (card.get("type_line") or "").lower()
-            oracle_text = (card.get("oracle_text") or "").lower()
+            name_lower = card.name_lower
+            type_line = (card.type_line or "").lower()
+            oracle_text = (card.oracle_text or "").lower()
             if query:
                 haystacks = (
                     name_lower,
@@ -106,12 +163,12 @@ class CardDataManager:
                 )
                 if not any(query in h for h in haystacks if h):
                     continue
-            if fmt and card.get("legalities", {}).get(fmt) != "Legal":
+            if fmt and card.legalities.get(fmt) != "Legal":
                 continue
             if type_filter and type_filter not in type_line:
                 continue
             if color_identity:
-                identity = card.get("color_identity", [])
+                identity = card.color_identity
                 if not all(c in identity for c in color_identity):
                     continue
             results.append(card)
@@ -119,7 +176,7 @@ class CardDataManager:
                 break
         return results
 
-    def get_card(self, name: str) -> dict[str, Any] | None:
+    def get_card(self, name: str) -> CardEntry | None:
         self._require_cards()
         return (self._cards_by_name or {}).get(name.lower())
 
@@ -128,7 +185,7 @@ class CardDataManager:
         seen = set()
         formats: list[str] = []
         for card in self._cards or []:
-            for fmt, state in (card.get("legalities") or {}).items():
+            for fmt, state in card.legalities.items():
                 if state != "Legal" or fmt in seen:
                     continue
                 seen.add(fmt)
@@ -191,19 +248,25 @@ class CardDataManager:
         self._cards_by_name = index["cards_by_name"]
 
     def _load_index(self) -> None:
-        data = self._load_json(self.index_path)
-        if not data:
+        """Load the card index using a typed msgspec decoder for maximum speed."""
+        if not self.index_path.exists():
             raise RuntimeError("Card data index missing or invalid")
-        self._cards = data["cards"]
-        self._cards_by_name = data["cards_by_name"]
+        try:
+            data = self.index_path.read_bytes()
+            card_index = _card_index_decoder.decode(data)
+        except (msgspec.DecodeError, OSError) as exc:
+            raise RuntimeError(f"Card data index missing or invalid: {exc}") from exc
+        self._cards = card_index.cards
+        self._cards_by_name = card_index.cards_by_name
 
-    def _load_json(self, path: Path) -> dict[str, Any] | None:
-        if not path.exists():
+    def _load_meta_json(self) -> dict[str, Any] | None:
+        """Load the small metadata sidecar file (stdlib json is fine at ~260 bytes)."""
+        if not self.meta_path.exists():
             return None
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
+            return json.loads(self.meta_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
-            logger.warning(f"Invalid JSON at {path}: {exc}")
+            logger.warning(f"Invalid JSON at {self.meta_path}: {exc}")
             return None
 
     def _build_index(self, atomic_cards: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
@@ -296,4 +359,4 @@ class CardDataManager:
         return merged
 
 
-__all__ = ["CardDataManager", "load_card_manager"]
+__all__ = ["CardDataManager", "CardEntry", "load_card_manager"]

--- a/utils/card_images.py
+++ b/utils/card_images.py
@@ -16,13 +16,15 @@ Architecture:
 
 from __future__ import annotations
 
-import json
 import os
 import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timezone
+
+import msgspec
+import msgspec.json
 
 try:  # Python 3.11+ has UTC
     from datetime import UTC
@@ -69,6 +71,91 @@ SCRYFALL_CARD_SEARCH_URL = "https://api.scryfall.com/cards/search"
 MAX_WORKERS = 10  # Concurrent download threads
 CHUNK_SIZE = 8192  # Download chunk size
 REQUEST_TIMEOUT = 30  # Seconds
+
+
+# ---------------------------------------------------------------------------
+# msgspec schemas for fast JSON loading
+# ---------------------------------------------------------------------------
+
+
+class BulkCardFace(msgspec.Struct, gc=False):
+    """Minimal face entry from Scryfall bulk data (only fields we use)."""
+
+    name: str | None = None
+    image_uris: dict[str, str] | None = None
+
+    def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        return getattr(self, key, default)
+
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key) from None
+
+
+class BulkCard(msgspec.Struct, gc=False):
+    """Minimal Scryfall bulk-data card record containing only the fields
+    required by :func:`build_printing_index`.  msgspec silently skips all
+    other fields present in the JSON, which makes parsing even faster.
+
+    Dict-compatible accessors are provided so that the existing
+    ``card.get(...)`` call sites continue to work unchanged.
+    """
+
+    name: str | None = None
+    id: str | None = None
+    set: str | None = None
+    set_name: str | None = None
+    collector_number: str | None = None
+    released_at: str | None = None
+    card_faces: list[BulkCardFace] | None = None
+
+    def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        return getattr(self, key, default)
+
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key) from None
+
+
+class PrintingEntry(msgspec.Struct, gc=False):
+    """A single card printing record stored in the printings index."""
+
+    id: str
+    set: str
+    set_name: str
+    collector_number: str
+    released_at: str
+
+    def get(self, key: str, default: Any = None) -> Any:  # noqa: ANN401
+        return getattr(self, key, default)
+
+    def __getitem__(self, key: str) -> Any:  # noqa: ANN401
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key) from None
+
+
+class PrintingIndexPayload(msgspec.Struct):
+    """Root structure of the saved printing index cache file."""
+
+    version: int
+    generated_at: str
+    bulk_mtime: float
+    unique_names: int
+    total_printings: int
+    data: dict[str, list[PrintingEntry]]
+
+
+# Pre-instantiated decoders – reusing avoids re-building on every call.
+_bulk_cards_decoder: msgspec.json.Decoder[list[BulkCard]] = msgspec.json.Decoder(list[BulkCard])
+_printing_index_decoder: msgspec.json.Decoder[PrintingIndexPayload] = msgspec.json.Decoder(
+    PrintingIndexPayload
+)
 
 
 @dataclass(frozen=True)
@@ -799,8 +886,10 @@ class BulkImageDownloader:
             }
 
         try:
+            from utils.json_io import fast_load
+
             with locked_path(BULK_DATA_CACHE):
-                cards_data = json.loads(BULK_DATA_CACHE.read_text(encoding="utf-8"))
+                cards_data = fast_load(BULK_DATA_CACHE)
             if max_cards:
                 cards_data = cards_data[:max_cards]
 
@@ -920,15 +1009,16 @@ def _load_printing_index_payload() -> dict[str, Any] | None:
         return None
     try:
         with locked_path(PRINTING_INDEX_CACHE):
-            with PRINTING_INDEX_CACHE.open("r", encoding="utf-8") as fh:
-                payload = json.load(fh)
-    except Exception as exc:
+            raw = PRINTING_INDEX_CACHE.read_bytes()
+        payload = _printing_index_decoder.decode(raw)
+    except (msgspec.DecodeError, OSError) as exc:
         logger.warning(f"Failed to read printings index cache: {exc}")
         return None
-    if payload.get("version") != PRINTING_INDEX_VERSION:
+    if payload.version != PRINTING_INDEX_VERSION:
         logger.info("Discarding printings index cache due to version mismatch")
         return None
-    return payload
+    # Convert to plain dict so callers can use .get() / [] as before.
+    return msgspec.to_builtins(payload)
 
 
 def load_printing_index_payload() -> dict[str, Any] | None:
@@ -950,8 +1040,8 @@ def ensure_printing_index_cache(force: bool = False) -> dict[str, Any]:
 
     logger.info("Building card printings index from bulk data…")
     with locked_path(BULK_DATA_CACHE):
-        with BULK_DATA_CACHE.open("r", encoding="utf-8") as fh:
-            cards = json.load(fh)
+        raw = BULK_DATA_CACHE.read_bytes()
+    cards = _bulk_cards_decoder.decode(raw)
 
     by_name, stats = build_printing_index(cards)
 

--- a/utils/card_images_workers.py
+++ b/utils/card_images_workers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +16,7 @@ from utils.atomic_io import atomic_write_json, locked_path
 from utils.card_images import (
     BulkImageDownloader,
     CardImageCache,
+    _bulk_cards_decoder,
     build_printing_index,
 )
 
@@ -45,8 +45,8 @@ def build_printing_index_worker(
         raise FileNotFoundError("Bulk data cache not found; cannot build printings index")
 
     with locked_path(bulk_path):
-        with bulk_path.open("r", encoding="utf-8") as fh:
-            cards = json.load(fh)
+        raw = bulk_path.read_bytes()
+    cards = _bulk_cards_decoder.decode(raw)
 
     by_name, stats = build_printing_index(cards)
     payload = {

--- a/utils/json_io.py
+++ b/utils/json_io.py
@@ -1,0 +1,85 @@
+"""Fast JSON I/O utilities backed by msgspec.
+
+Drop-in replacements for stdlib ``json.load`` / ``json.loads`` that use
+msgspec's C-level parser.  Pre-instantiated :class:`msgspec.json.Decoder`
+objects are reused across calls so there is no per-call overhead from
+building a decoder.
+
+Usage::
+
+    from utils.json_io import fast_load, fast_decode
+
+    # Untyped (produces regular Python dicts/lists)
+    data = fast_load(some_path)
+    data = fast_decode(raw_bytes_or_str)
+
+    # Typed (msgspec validates structure against the given type)
+    from typing import Any
+    import msgspec
+
+    class MyStruct(msgspec.Struct):
+        name: str
+        value: int
+
+    obj = fast_load(some_path, type=MyStruct)
+    obj = fast_decode(raw_bytes, type=list[MyStruct])
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, TypeVar
+
+import msgspec
+import msgspec.json
+
+__all__ = ["fast_load", "fast_decode"]
+
+T = TypeVar("T")
+
+# Re-usable decoder for the common ``Any`` case (avoids rebuilding every call)
+_decoder_any: msgspec.json.Decoder[Any] = msgspec.json.Decoder(Any)
+
+
+def fast_load(path: Path, *, type: type = Any) -> Any:  # noqa: A002
+    """Read *path* as bytes and decode the JSON content.
+
+    Parameters
+    ----------
+    path:
+        File to read.
+    type:
+        Optional msgspec type annotation.  When omitted (or ``Any``) the
+        result is plain Python built-ins (``dict``, ``list``, …).  Pass a
+        :class:`msgspec.Struct` subclass or a composite type such as
+        ``list[MyStruct]`` to get typed, validated output.
+
+    Returns
+    -------
+    Any
+        Decoded JSON value.
+    """
+    data = path.read_bytes()
+    return fast_decode(data, type=type)
+
+
+def fast_decode(data: bytes | str | bytearray, *, type: type = Any) -> Any:  # noqa: A002
+    """Decode *data* as JSON.
+
+    Parameters
+    ----------
+    data:
+        Raw JSON bytes, bytearray, or UTF-8 string.
+    type:
+        Optional msgspec type annotation (see :func:`fast_load`).
+
+    Returns
+    -------
+    Any
+        Decoded JSON value.
+    """
+    if isinstance(data, str):
+        data = data.encode()
+    if type is Any:
+        return _decoder_any.decode(data)
+    return msgspec.json.decode(data, type=type)

--- a/utils/metagame_stats.py
+++ b/utils/metagame_stats.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import time
 from collections import Counter, defaultdict
 from collections.abc import Iterable
@@ -16,6 +15,7 @@ from navigators.mtgo_decklists import fetch_deck_event, fetch_decklist_index
 from utils.archetype_classifier import ArchetypeClassifier
 from utils.atomic_io import atomic_write_json, locked_path
 from utils.constants import MTGO_DECK_CACHE_FILE, MTGO_DECKLISTS_ENABLED
+from utils.json_io import fast_load
 
 try:
     from datetime import UTC
@@ -30,9 +30,8 @@ def _load_cache() -> dict[str, Any]:
         return {}
     try:
         with locked_path(MTGO_DECK_CACHE_FILE):
-            with MTGO_DECK_CACHE_FILE.open("r", encoding="utf-8") as fh:
-                return json.load(fh)
-    except json.JSONDecodeError as exc:
+            return fast_load(MTGO_DECK_CACHE_FILE)
+    except Exception as exc:
         logger.warning(f"Invalid deck cache JSON: {exc}")
         return {}
 


### PR DESCRIPTION
## Summary

- Add `msgspec>=0.18.6` dependency and a central `utils/json_io.py` helper module (`fast_load`, `fast_decode`) backed by a reusable `msgspec.json.Decoder` instance
- Define pre-typed msgspec.Struct schemas for the performance-critical data files and replace all `json.load()`/`json.loads()` calls across the codebase with the faster msgspec parser
- Replace `json.dumps()` in `atomic_write_json()` with `msgspec.json.encode()` + `msgspec.json.format()` for the write path

## Files changed

| Module | Schema / approach |
|--------|-------------------|
| `utils/card_data.py` | `CardEntry` + `CardIndex` typed schemas; `_load_index()` uses typed decoder for the **59 MB** atomic-cards index |
| `utils/card_images.py` | `BulkCardFace`, `BulkCard` (partial — only fields used by `build_printing_index`, so unused Scryfall fields are skipped), `PrintingEntry`, `PrintingIndexPayload` typed schemas for the **17 MB** printings index and **496 MB** bulk data |
| `utils/card_images_workers.py` | Reuses `BulkCard` typed decoder |
| `repositories/card_repository.py` | `_CollectionEntry` schema; collection-file outer wrapper decoded with fast Any decoder |
| `utils/atomic_io.py` | Write path: `json.dumps` → `msgspec.json.encode` + `msgspec.json.format` |
| `navigators/mtggoldfish.py`, `navigators/mtgo_decklists.py`, `utils/metagame_stats.py`, `services/state_service.py`, `services/store_service.py`, `services/mtgo_background_service.py` | All `json.load(fh)` → `fast_load(path)` (untyped Any — still uses msgspec's C parser) |
| `scripts/benchmark_json_caches.py` | Updated to compare stdlib json vs msgspec Any vs msgspec typed for the printings and bulk-data caches |

## Backward compatibility

`CardEntry` (and `BulkCard`, `BulkCardFace`) expose `.get()` and `__getitem__()` so all existing call sites that treat the return value as a `dict` continue to work without modification.

## Test plan

- [x] 346 unit tests pass (3 pre-existing wx-import failures on WSL unchanged)
- [x] App launched with `--automation` flag; verified: card database loads, archetypes list, deck selection, zone editing, add-card all work correctly
- [x] Checked logs for msgspec/decode errors — none found
- [x] `black` + `ruff --fix` applied to all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)