### PR TITLE
feat: add any-word name match mode to deck builder search

### DIFF
--- a/services/search_service.py
+++ b/services/search_service.py
@@ -156,6 +156,7 @@ class SearchService:
 
         Filter keys expected:
             - name: str - Card name filter
+            - name_match: str - Name match mode: "contains" (default substring) or "any_word" (any space-separated word)
             - type: str - Type line filter
             - text: str - Oracle text filter
             - mana: str - Mana cost pattern
@@ -197,7 +198,12 @@ class SearchService:
             # Name filter
             if filters.get("name"):
                 name_lower = card.get("name_lower", "")
-                if filters["name"].lower() not in name_lower:
+                name_query = filters["name"].lower()
+                if filters.get("name_match") == "any_word":
+                    words = name_query.split()
+                    if not words or not any(w in name_lower for w in words):
+                        continue
+                elif name_query not in name_lower:
                     continue
 
             # Type filter

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -266,6 +266,128 @@ def test_get_card_suggestions_success():
     assert "Lightning Bolt" in suggestions
 
 
+# ============= Name Match Mode Tests =============
+
+
+def _make_builder_filters(**kwargs) -> dict:
+    """Create a minimal builder filters dict with defaults."""
+    defaults = {
+        "name": "",
+        "name_match": "contains",
+        "type": "",
+        "text": "",
+        "mana": "",
+        "mana_exact": False,
+        "mv_comparator": "Any",
+        "mv_value": "",
+        "formats": [],
+        "color_mode": "Any",
+        "selected_colors": [],
+        "radar_enabled": False,
+        "radar_cards": set(),
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _make_card_manager_mock(cards: list[dict]) -> Mock:
+    manager = Mock()
+    manager.search_cards = Mock(return_value=cards)
+    return manager
+
+
+def test_name_match_contains_finds_substring():
+    """Default 'contains' mode matches the whole query as a substring."""
+    mock_repo = SimpleNamespace()
+    service = SearchService(card_repository=mock_repo)
+
+    cards = [
+        create_mock_card(name="Clock of Omens"),
+        create_mock_card(name="Lightning Bolt"),
+    ]
+    manager = _make_card_manager_mock(cards)
+    for c in cards:
+        c["name_lower"] = c["name"].lower()
+
+    filters = _make_builder_filters(name="clock of omens")
+    results = service.search_with_builder_filters(filters, manager)
+    assert len(results) == 1
+    assert results[0]["name"] == "Clock of Omens"
+
+
+def test_name_match_contains_rejects_non_substring():
+    """Default 'contains' mode rejects queries that aren't exact substrings."""
+    mock_repo = SimpleNamespace()
+    service = SearchService(card_repository=mock_repo)
+
+    cards = [create_mock_card(name="Clock of Omens")]
+    manager = _make_card_manager_mock(cards)
+    for c in cards:
+        c["name_lower"] = c["name"].lower()
+
+    # "clock omens" skips "of", so it's not a substring of "clock of omens"
+    filters = _make_builder_filters(name="clock omens")
+    results = service.search_with_builder_filters(filters, manager)
+    assert results == []
+
+
+def test_name_match_any_word_finds_card_by_partial_name():
+    """'any_word' mode finds 'Clock of Omens' when any typed word appears in the name."""
+    mock_repo = SimpleNamespace()
+    service = SearchService(card_repository=mock_repo)
+
+    cards = [
+        create_mock_card(name="Clock of Omens"),
+        create_mock_card(name="Lightning Bolt"),
+    ]
+    manager = _make_card_manager_mock(cards)
+    for c in cards:
+        c["name_lower"] = c["name"].lower()
+
+    # "clock omens" — both words appear in "clock of omens"
+    filters = _make_builder_filters(name="clock omens", name_match="any_word")
+    results = service.search_with_builder_filters(filters, manager)
+    assert any(r["name"] == "Clock of Omens" for r in results)
+
+
+def test_name_match_any_word_or_logic():
+    """'any_word' mode returns cards matching ANY of the typed words."""
+    mock_repo = SimpleNamespace()
+    service = SearchService(card_repository=mock_repo)
+
+    cards = [
+        create_mock_card(name="Clock of Omens"),
+        create_mock_card(name="Lightning Bolt"),
+        create_mock_card(name="Island"),
+    ]
+    manager = _make_card_manager_mock(cards)
+    for c in cards:
+        c["name_lower"] = c["name"].lower()
+
+    # "clock lightning" matches both Clock of Omens and Lightning Bolt
+    filters = _make_builder_filters(name="clock lightning", name_match="any_word")
+    results = service.search_with_builder_filters(filters, manager)
+    names = {r["name"] for r in results}
+    assert "Clock of Omens" in names
+    assert "Lightning Bolt" in names
+    assert "Island" not in names
+
+
+def test_name_match_any_word_case_insensitive():
+    """'any_word' mode is case-insensitive."""
+    mock_repo = SimpleNamespace()
+    service = SearchService(card_repository=mock_repo)
+
+    cards = [create_mock_card(name="Clock of Omens")]
+    manager = _make_card_manager_mock(cards)
+    for c in cards:
+        c["name_lower"] = c["name"].lower()
+
+    filters = _make_builder_filters(name="CLOCK", name_match="any_word")
+    results = service.search_with_builder_filters(filters, manager)
+    assert len(results) == 1
+
+
 # ============= Deck Search Tests =============
 
 

--- a/widgets/panels/deck_builder_panel.py
+++ b/widgets/panels/deck_builder_panel.py
@@ -205,6 +205,7 @@ class DeckBuilderPanel(wx.Panel):
 
         # State variables
         self.inputs: dict[str, wx.TextCtrl] = {}
+        self.name_any_word_cb: wx.CheckBox | None = None
         self.mana_exact_cb: wx.CheckBox | None = None
         self.mv_comparator: wx.Choice | None = None
         self.mv_value: wx.TextCtrl | None = None
@@ -261,6 +262,20 @@ class DeckBuilderPanel(wx.Panel):
             ctrl.Bind(wx.EVT_TEXT, self._on_filters_changed)
             sizer.Add(ctrl, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
             self.inputs[key] = ctrl
+
+            # Name field gets "Any Word" match mode checkbox
+            if key == "name":
+                name_match_row = wx.BoxSizer(wx.HORIZONTAL)
+                any_word_cb = wx.CheckBox(self, label="Any word match")
+                any_word_cb.SetForegroundColour(LIGHT_TEXT)
+                any_word_cb.SetBackgroundColour(DARK_PANEL)
+                any_word_cb.SetToolTip(
+                    "When checked, finds cards where any space-separated word appears in the name."
+                )
+                any_word_cb.Bind(wx.EVT_CHECKBOX, self._on_filters_changed)
+                self.name_any_word_cb = any_word_cb
+                name_match_row.Add(any_word_cb, 0)
+                sizer.Add(name_match_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
 
             # Mana cost field gets extra controls
             if key == "mana":
@@ -512,6 +527,11 @@ class DeckBuilderPanel(wx.Panel):
     def get_filters(self) -> dict[str, Any]:
         """Get all current filter values."""
         filters = {key: ctrl.GetValue().strip() for key, ctrl in self.inputs.items()}
+        filters["name_match"] = (
+            "any_word"
+            if (self.name_any_word_cb and self.name_any_word_cb.IsChecked())
+            else "contains"
+        )
         filters["mana_exact"] = self.mana_exact_cb.IsChecked() if self.mana_exact_cb else False
         filters["mv_comparator"] = (
             self.mv_comparator.GetStringSelection() if self.mv_comparator else "Any"
@@ -550,6 +570,8 @@ class DeckBuilderPanel(wx.Panel):
 
         if self.status_label:
             self.status_label.SetLabel("Filters cleared.")
+        if self.name_any_word_cb:
+            self.name_any_word_cb.SetValue(False)
         if self.mana_exact_cb:
             self.mana_exact_cb.SetValue(False)
         if self.mv_comparator:


### PR DESCRIPTION
## Summary
- Adds an **"Any word match"** checkbox below the Card Name field in the deck builder
- When checked, each space-separated word is matched independently (OR logic) against the card name — e.g. typing `clock omens` finds **Clock of Omens**
- Default behavior (entire query must be a substring of the name) is unchanged
- New `name_match` filter key (`"contains"` | `"any_word"`) propagated from panel → `search_with_builder_filters`

Closes #246

## Test plan
- [ ] 5 new unit tests in `tests/test_search_service.py` covering: contains (pass/fail), any_word OR logic, multi-word match, case-insensitivity
- [ ] All 356 existing tests still pass
- [ ] Manually: open deck builder, type `clock omens` with checkbox unchecked → no results; check box → Clock of Omens appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)