### PR TITLE
fix: treat lands as colorless in color identity search filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ build/
 .worktrees/
 # local install
 *.egg-info/
+issues/

--- a/services/search_service.py
+++ b/services/search_service.py
@@ -229,10 +229,10 @@ class SearchService:
                 if not matches_mana_value(card.get("mana_value"), mv_value, mv_cmp):
                     continue
 
-            # Color identity filter
+            # Color identity filter (lands are treated as colorless)
             if selected_colors and color_mode != "Any":
                 if not matches_color_filter(
-                    card.get("color_identity") or [], selected_colors, color_mode
+                    self._get_card_colors_for_filter(card), selected_colors, color_mode
                 ):
                     continue
 
@@ -257,10 +257,18 @@ class SearchService:
 
     def _matches_color_filter(self, card: dict[str, Any], colors: list[str], mode: str) -> bool:
         """Check if card matches color filter."""
+        card_colors = self._get_card_colors_for_filter(card)
+        return matches_color_filter(card_colors, colors, mode)
+
+    def _get_card_colors_for_filter(self, card: dict[str, Any]) -> list[str]:
+        """Return the colors to use for color filtering, treating lands as colorless."""
+        type_line = (card.get("type_line") or card.get("type") or "").lower()
+        if "land" in type_line:
+            return []
         card_colors = card.get("colors", []) or card.get("color_identity", [])
         if isinstance(card_colors, str):
             card_colors = list(card_colors)
-        return matches_color_filter(card_colors, colors, mode)
+        return card_colors
 
     def _matches_type_filter(self, card: dict[str, Any], types: list[str]) -> bool:
         """Check if card matches type filter."""

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -444,3 +444,77 @@ def test_matches_text_filter_no_text():
     card = create_mock_card(oracle_text="")
 
     assert service._matches_text_filter(card, "anything") is False
+
+
+# ============= Land Colorless Tests =============
+
+
+def create_mock_land(name="Forest", color_identity=None, type_line="Basic Land — Forest"):
+    """Helper to create a mock land card."""
+    return {
+        "name": name,
+        "name_lower": name.lower(),
+        "colors": [],
+        "color_identity": color_identity or ["G"],
+        "type_line": type_line,
+        "mana_cost": "",
+        "mana_value": 0,
+        "cmc": 0,
+        "oracle_text": "",
+        "legalities": {},
+    }
+
+
+def test_lands_treated_as_colorless_in_color_filter():
+    """Lands should be treated as colorless regardless of color_identity."""
+    mock_repo = SimpleNamespace()
+    service = SearchService(card_repository=mock_repo)
+
+    forest = create_mock_land(name="Forest", color_identity=["G"])
+
+    # Forest should NOT match a green color filter
+    assert service._matches_color_filter(forest, ["G"], "At least") is False
+    assert service._matches_color_filter(forest, ["G"], "Exactly") is False
+
+    # Forest SHOULD match a colorless filter
+    assert service._matches_color_filter(forest, ["C"], "At least") is True
+    assert service._matches_color_filter(forest, ["C"], "Exactly") is True
+
+    # Forest should pass "Not these" for any color (it's colorless)
+    assert service._matches_color_filter(forest, ["G", "U", "R"], "Not these") is True
+
+
+def test_filter_cards_lands_excluded_from_color_filter():
+    """Lands should not appear in color-filtered results for non-colorless colors."""
+    mock_repo = SimpleNamespace()
+    service = SearchService(card_repository=mock_repo)
+
+    cards = [
+        create_mock_card(name="Llanowar Elves", colors=["G"], type_line="Creature — Elf Druid"),
+        create_mock_land(name="Forest", color_identity=["G"]),
+        create_mock_land(
+            name="Breeding Pool", color_identity=["G", "U"], type_line="Land — Forest Island"
+        ),
+    ]
+
+    # Filtering for green should only return the creature, not lands
+    filtered = service.filter_cards(cards, colors=["G"], color_mode="At least")
+
+    assert len(filtered) == 1
+    assert filtered[0]["name"] == "Llanowar Elves"
+
+
+def test_filter_cards_lands_appear_in_colorless_filter():
+    """Lands should appear when filtering for colorless."""
+    mock_repo = SimpleNamespace()
+    service = SearchService(card_repository=mock_repo)
+
+    cards = [
+        create_mock_card(name="Llanowar Elves", colors=["G"], type_line="Creature — Elf Druid"),
+        create_mock_land(name="Forest", color_identity=["G"]),
+    ]
+
+    filtered = service.filter_cards(cards, colors=["C"], color_mode="At least")
+
+    assert len(filtered) == 1
+    assert filtered[0]["name"] == "Forest"


### PR DESCRIPTION
## Summary
- Fixes #245
- Lands (e.g. Forest, Breeding Pool) have a non-empty `color_identity` in the card data, but should not appear in color-filtered searches since they have no mana cost and aren't colored permanents in the deckbuilding sense
- Added `_get_card_colors_for_filter()` helper in `SearchService` that returns `[]` for any card whose `type_line` contains "land", treating them as colorless (`C`) in all filter modes
- Both `_matches_color_filter` and the inline color filter in `search_with_builder_filters` now use this helper

## Test plan
- [ ] New tests in `test_search_service.py` verify lands are excluded from non-colorless color filters
- [ ] Lands match the colorless (`C`) filter
- [ ] All 354 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)