### PR TITLE
refactor: fix dual file-write and replace string-key callback dict

### DIFF
--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     from widgets.app_frame import AppFrame
 
-from controllers.app_controller_helpers import AppControllerUIHelpers
+from controllers.app_controller_helpers import AppControllerUIHelpers, UICallbacks
 from controllers.bulk_data_helpers import BulkDataHelpers
 from controllers.mtgo_background_helpers import MtgoBackgroundHelpers
 from controllers.session_manager import DeckSelectorSessionManager
@@ -115,7 +115,7 @@ class AppController:
         self.outboard_store = self.store_service.load_store(self.outboard_store_path)
         self.guide_store = self.store_service.load_store(self.guide_store_path)
 
-        self._ui_callbacks: dict[str, Callable[..., Any]] = {}
+        self._ui_callbacks: UICallbacks | None = None
 
         # Background worker for tasks with lifecycle control
         self._worker = BackgroundWorker()
@@ -352,9 +352,9 @@ class AppController:
         self, directory: Path | None = None, force: bool = False
     ) -> None:
         callbacks = self._ui_callbacks
-        on_status = callbacks.get("on_status", lambda msg: None)
-        on_success = callbacks.get("on_collection_refresh_success")
-        on_error = callbacks.get("on_collection_failed")
+        on_status = callbacks.on_status if callbacks else lambda msg: None
+        on_success = callbacks.on_collection_refresh_success if callbacks else None
+        on_error = callbacks.on_collection_failed if callbacks else None
         directory = directory or self.deck_save_dir
 
         on_status("Fetching collection from MTGO...")
@@ -465,22 +465,20 @@ class AppController:
         callbacks = self._ui_callbacks
 
         self.fetch_archetypes(
-            on_success=callbacks.get("on_archetypes_success"),
-            on_error=callbacks.get("on_archetypes_error"),
-            on_status=callbacks.get("on_status"),
+            on_success=callbacks.on_archetypes_success if callbacks else None,
+            on_error=callbacks.on_archetypes_error if callbacks else None,
+            on_status=callbacks.on_status if callbacks else None,
             force=force_archetypes,
         )
 
         # Step 3: Load collection from cache (non-blocking)
         success, info = self.load_collection_from_cache(deck_save_dir)
         if success and info:
-            callback = callbacks.get("on_collection_loaded")
-            if callback:
-                callback(info)
+            if callbacks:
+                callbacks.on_collection_loaded(info)
         else:
-            callback = callbacks.get("on_collection_not_found")
-            if callback:
-                callback()
+            if callbacks:
+                callbacks.on_collection_not_found()
 
         # Step 4: Check and download bulk data if needed (non-blocking)
         self.check_and_download_bulk_data()

--- a/controllers/app_controller_helpers.py
+++ b/controllers/app_controller_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -12,12 +13,26 @@ if TYPE_CHECKING:
     from widgets.app_frame import AppFrame
 
 
+@dataclass
+class UICallbacks:
+    on_status: Callable[[str], None]
+    on_archetypes_success: Callable[..., None]
+    on_archetypes_error: Callable[..., None]
+    on_collection_loaded: Callable[[dict[str, Any]], None]
+    on_collection_not_found: Callable[[], None]
+    on_collection_refresh_success: Callable[..., None]
+    on_collection_failed: Callable[[str], None]
+    on_bulk_download_needed: Callable[[str], None]
+    on_bulk_download_complete: Callable[[str], None]
+    on_bulk_download_failed: Callable[[str], None]
+
+
 class AppControllerUIHelpers:
     def __init__(self, controller: AppController, frame: AppFrame) -> None:
         self._controller = controller
         self._frame = frame
 
-    def build_callbacks(self) -> dict[str, Callable[..., Any]]:
+    def build_callbacks(self) -> UICallbacks:
         import wx
 
         frame = self._frame
@@ -37,28 +52,28 @@ class AppControllerUIHelpers:
             wx.CallAfter(frame._render_pending_deck)
 
         # Define UI callback functions that marshal to UI thread
-        return {
-            "on_archetypes_success": lambda archetypes: wx.CallAfter(
+        return UICallbacks(
+            on_archetypes_success=lambda archetypes: wx.CallAfter(
                 frame._on_archetypes_loaded, archetypes
             ),
-            "on_archetypes_error": lambda error: wx.CallAfter(frame._on_archetypes_error, error),
-            "on_collection_loaded": _on_collection_loaded,
-            "on_collection_not_found": lambda: wx.CallAfter(
+            on_archetypes_error=lambda error: wx.CallAfter(frame._on_archetypes_error, error),
+            on_collection_loaded=_on_collection_loaded,
+            on_collection_not_found=lambda: wx.CallAfter(
                 frame.collection_status_label.SetLabel,
                 "No collection found. Click 'Refresh Collection' to fetch from MTGO.",
             ),
-            "on_collection_refresh_success": lambda filepath, cards: wx.CallAfter(
+            on_collection_refresh_success=lambda filepath, cards: wx.CallAfter(
                 frame._on_collection_fetched, filepath, cards
             ),
-            "on_collection_failed": lambda msg: wx.CallAfter(
+            on_collection_failed=lambda msg: wx.CallAfter(
                 frame._on_collection_fetch_failed, msg
             ),
-            "on_status": lambda message: wx.CallAfter(frame._set_status, message),
-            "on_bulk_download_needed": lambda reason: logger.info(
+            on_status=lambda message: wx.CallAfter(frame._set_status, message),
+            on_bulk_download_needed=lambda reason: logger.info(
                 f"Bulk data needs update: {reason}"
             ),
-            "on_bulk_download_complete": lambda msg: wx.CallAfter(
+            on_bulk_download_complete=lambda msg: wx.CallAfter(
                 frame._on_bulk_data_downloaded, msg
             ),
-            "on_bulk_download_failed": lambda msg: wx.CallAfter(frame._on_bulk_data_failed, msg),
-        }
+            on_bulk_download_failed=lambda msg: wx.CallAfter(frame._on_bulk_data_failed, msg),
+        )

--- a/controllers/app_controller_helpers.py
+++ b/controllers/app_controller_helpers.py
@@ -65,15 +65,9 @@ class AppControllerUIHelpers:
             on_collection_refresh_success=lambda filepath, cards: wx.CallAfter(
                 frame._on_collection_fetched, filepath, cards
             ),
-            on_collection_failed=lambda msg: wx.CallAfter(
-                frame._on_collection_fetch_failed, msg
-            ),
+            on_collection_failed=lambda msg: wx.CallAfter(frame._on_collection_fetch_failed, msg),
             on_status=lambda message: wx.CallAfter(frame._set_status, message),
-            on_bulk_download_needed=lambda reason: logger.info(
-                f"Bulk data needs update: {reason}"
-            ),
-            on_bulk_download_complete=lambda msg: wx.CallAfter(
-                frame._on_bulk_data_downloaded, msg
-            ),
+            on_bulk_download_needed=lambda reason: logger.info(f"Bulk data needs update: {reason}"),
+            on_bulk_download_complete=lambda msg: wx.CallAfter(frame._on_bulk_data_downloaded, msg),
             on_bulk_download_failed=lambda msg: wx.CallAfter(frame._on_bulk_data_failed, msg),
         )

--- a/controllers/bulk_data_helpers.py
+++ b/controllers/bulk_data_helpers.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 if TYPE_CHECKING:
+    from controllers.app_controller_helpers import UICallbacks
     from utils.background_worker import BackgroundWorker
     from widgets.app_frame import AppFrame
 
@@ -25,15 +26,15 @@ class BulkDataHelpers:
         self._frame_provider = frame_provider
         self._bulk_check_worker_active = False
 
-    def check_and_download_bulk_data(self, callbacks: dict[str, Callable[..., Any]]) -> None:
+    def check_and_download_bulk_data(self, callbacks: UICallbacks | None) -> None:
         if self._bulk_check_worker_active:
             logger.debug("Bulk data check already running")
             return
 
-        on_status = callbacks.get("on_status", lambda msg: None)
-        on_download_needed = callbacks.get("on_bulk_download_needed", lambda reason: None)
-        on_download_complete = callbacks.get("on_bulk_download_complete", lambda msg: None)
-        on_download_failed = callbacks.get("on_bulk_download_failed", lambda msg: None)
+        on_status = callbacks.on_status if callbacks else lambda msg: None
+        on_download_needed = callbacks.on_bulk_download_needed if callbacks else lambda reason: None
+        on_download_complete = callbacks.on_bulk_download_complete if callbacks else lambda msg: None
+        on_download_failed = callbacks.on_bulk_download_failed if callbacks else lambda msg: None
 
         on_status("Checking card image database…")
         self._bulk_check_worker_active = True
@@ -108,15 +109,15 @@ class BulkDataHelpers:
         if not started:
             on_status("Ready")
 
-    def force_bulk_data_update(self, callbacks: dict[str, Callable[..., Any]]) -> None:
+    def force_bulk_data_update(self, callbacks: UICallbacks | None) -> None:
         """Force download of bulk data regardless of current state."""
         if self._bulk_check_worker_active:
             logger.debug("Bulk data update already running")
             return
 
-        on_status = callbacks.get("on_status", lambda msg: None)
-        on_download_complete = callbacks.get("on_bulk_download_complete", lambda msg: None)
-        on_download_failed = callbacks.get("on_bulk_download_failed", lambda msg: None)
+        on_status = callbacks.on_status if callbacks else lambda msg: None
+        on_download_complete = callbacks.on_bulk_download_complete if callbacks else lambda msg: None
+        on_download_failed = callbacks.on_bulk_download_failed if callbacks else lambda msg: None
 
         on_status("Downloading card image database...")
         self._bulk_check_worker_active = True

--- a/controllers/bulk_data_helpers.py
+++ b/controllers/bulk_data_helpers.py
@@ -33,7 +33,9 @@ class BulkDataHelpers:
 
         on_status = callbacks.on_status if callbacks else lambda msg: None
         on_download_needed = callbacks.on_bulk_download_needed if callbacks else lambda reason: None
-        on_download_complete = callbacks.on_bulk_download_complete if callbacks else lambda msg: None
+        on_download_complete = (
+            callbacks.on_bulk_download_complete if callbacks else lambda msg: None
+        )
         on_download_failed = callbacks.on_bulk_download_failed if callbacks else lambda msg: None
 
         on_status("Checking card image database…")
@@ -116,7 +118,9 @@ class BulkDataHelpers:
             return
 
         on_status = callbacks.on_status if callbacks else lambda msg: None
-        on_download_complete = callbacks.on_bulk_download_complete if callbacks else lambda msg: None
+        on_download_complete = (
+            callbacks.on_bulk_download_complete if callbacks else lambda msg: None
+        )
         on_download_failed = callbacks.on_bulk_download_failed if callbacks else lambda msg: None
 
         on_status("Downloading card image database...")

--- a/services/deck_workflow_service.py
+++ b/services/deck_workflow_service.py
@@ -6,7 +6,7 @@ from typing import Any
 from loguru import logger
 
 from navigators.mtggoldfish import download_deck, get_archetypes
-from utils.deck import read_curr_deck_file, sanitize_filename
+from utils.deck import read_curr_deck_file
 
 
 class DeckWorkflowService:
@@ -88,10 +88,7 @@ class DeckWorkflowService:
         deck: dict[str, Any] | None,
         deck_save_dir,
     ) -> tuple:
-        safe_name = sanitize_filename(deck_name or "saved_deck") or "saved_deck"
-        file_path = deck_save_dir / f"{safe_name}.txt"
-        with file_path.open("w", encoding="utf-8") as fh:
-            fh.write(deck_content)
+        file_path = self.deck_repo.save_deck_to_file(deck_name, deck_content, deck_save_dir)
 
         deck_id = None
         try:

--- a/tests/test_deck_workflow_service.py
+++ b/tests/test_deck_workflow_service.py
@@ -28,6 +28,15 @@ class FakeDeckRepo:
     def set_current_deck(self, deck: dict | None) -> None:
         self.current_deck = deck or {}
 
+    def save_deck_to_file(self, deck_name: str, deck_content: str, directory) -> object:
+        from pathlib import Path
+        from utils.deck import sanitize_filename
+
+        safe_name = sanitize_filename(deck_name, fallback="saved_deck")
+        path = Path(directory) / f"{safe_name}.txt"
+        path.write_text(deck_content, encoding="utf-8")
+        return path
+
     def save_to_db(self, **payload):
         self.saved_payload = payload
         return 123

--- a/tests/test_deck_workflow_service.py
+++ b/tests/test_deck_workflow_service.py
@@ -30,6 +30,7 @@ class FakeDeckRepo:
 
     def save_deck_to_file(self, deck_name: str, deck_content: str, directory) -> object:
         from pathlib import Path
+
         from utils.deck import sanitize_filename
 
         safe_name = sanitize_filename(deck_name, fallback="saved_deck")


### PR DESCRIPTION
## Summary

- **Finding 1 (High):** `DeckWorkflowService.save_deck` was writing deck files directly, duplicating `DeckRepository.save_deck_to_file`. Removed the inline write; now routes through `deck_repo.save_deck_to_file()` so file persistence has a single owner.
- **Finding 2 (Moderate):** `AppController._ui_callbacks` was a `dict[str, Callable]` where a mistyped key silently returns `None` with no error. Replaced with a typed `UICallbacks` dataclass — missing fields fail at construction, not silently at runtime.
- Updated `BulkDataHelpers` methods to accept `UICallbacks | None` instead of `dict`.
- Added `save_deck_to_file` to `FakeDeckRepo` in tests to match the new interface.

## Test plan

- [ ] All 354 existing tests pass (`pytest tests/ --ignore=tests/ui`)
- [ ] Deck save still writes file to `deck_save_dir` and stores to DB
- [ ] UI callbacks still wire up correctly on frame creation