### PR TITLE
fix: add type counts and hand/land % to Stats tab

### DIFF
--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -1,7 +1,8 @@
 """
 Deck Stats Panel - Displays deck statistics, mana curve, and color distribution.
 
-Shows summary statistics, mana curve breakdown, and color concentration analysis.
+Shows summary statistics, mana curve breakdown, color concentration, type counts,
+and opening-hand land probability analysis.
 """
 
 from collections import Counter
@@ -12,7 +13,19 @@ import wx.dataview as dv
 
 from services.deck_service import DeckService, get_deck_service
 from utils.card_data import CardDataManager
-from utils.constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT
+from utils.constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+from utils.math_utils import hypergeometric_at_least
+
+_CARD_TYPES = [
+    "Land",
+    "Creature",
+    "Instant",
+    "Sorcery",
+    "Enchantment",
+    "Artifact",
+    "Planeswalker",
+    "Battle",
+]
 
 
 class DeckStatsPanel(wx.Panel):
@@ -51,7 +64,7 @@ class DeckStatsPanel(wx.Panel):
         self.summary_label.SetForegroundColour(LIGHT_TEXT)
         sizer.Add(self.summary_label, 0, wx.ALL, 6)
 
-        # Split view for curve and color charts
+        # Split view for curve, color, and type charts
         split = wx.BoxSizer(wx.HORIZONTAL)
         sizer.Add(split, 1, wx.EXPAND | wx.ALL, 6)
 
@@ -69,7 +82,20 @@ class DeckStatsPanel(wx.Panel):
         self.color_list.AppendTextColumn("Share", width=100)
         self.color_list.SetBackgroundColour(DARK_ALT)
         self.color_list.SetForegroundColour(LIGHT_TEXT)
-        split.Add(self.color_list, 0)
+        split.Add(self.color_list, 0, wx.RIGHT, 12)
+
+        # Type counts list
+        self.type_list = dv.DataViewListCtrl(self)
+        self.type_list.AppendTextColumn("Type", width=120)
+        self.type_list.AppendTextColumn("Count", width=80)
+        self.type_list.SetBackgroundColour(DARK_ALT)
+        self.type_list.SetForegroundColour(LIGHT_TEXT)
+        split.Add(self.type_list, 0)
+
+        # Hand/land probability label
+        self.hand_land_label = wx.StaticText(self, label="")
+        self.hand_land_label.SetForegroundColour(SUBDUED_TEXT)
+        sizer.Add(self.hand_land_label, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
 
     # ============= Public API =============
 
@@ -87,6 +113,8 @@ class DeckStatsPanel(wx.Panel):
             self.summary_label.SetLabel("No deck loaded.")
             self.curve_list.DeleteAllItems()
             self.color_list.DeleteAllItems()
+            self.type_list.DeleteAllItems()
+            self.hand_land_label.SetLabel("")
             return
 
         # Analyze deck
@@ -103,6 +131,8 @@ class DeckStatsPanel(wx.Panel):
         # Render charts
         self._render_curve()
         self._render_color_concentration()
+        self._render_type_counts()
+        self._render_hand_land_pct(stats["mainboard_count"], stats["estimated_lands"])
 
     def set_card_manager(self, card_manager: CardDataManager) -> None:
         """Set the card data manager for metadata lookups."""
@@ -113,6 +143,8 @@ class DeckStatsPanel(wx.Panel):
         self.summary_label.SetLabel("No deck loaded.")
         self.curve_list.DeleteAllItems()
         self.color_list.DeleteAllItems()
+        self.type_list.DeleteAllItems()
+        self.hand_land_label.SetLabel("")
 
     # ============= Private Methods =============
 
@@ -130,7 +162,7 @@ class DeckStatsPanel(wx.Panel):
             mana_value = meta.get("mana_value") if meta else None
 
             # Bucket the mana value
-            if isinstance(mana_value, (int, float)):
+            if isinstance(mana_value, int | float):
                 value = int(mana_value)
                 bucket = "7+" if value >= 7 else str(value)
             else:
@@ -196,3 +228,49 @@ class DeckStatsPanel(wx.Panel):
             percentage = (count / grand_total) * 100
             share = f"{count} ({percentage:.1f}%)"
             self.color_list.AppendItem([name, share])
+
+    def _render_type_counts(self) -> None:
+        """Render card type counts for the mainboard."""
+        self.type_list.DeleteAllItems()
+
+        counts: Counter[str] = Counter()
+        for entry in self.zone_cards.get("main", []):
+            type_line = ""
+            if self.card_manager:
+                meta = self.card_manager.get_card(entry["name"])
+                type_line = (meta.get("type_line") or "") if meta else ""
+
+            matched = False
+            for card_type in _CARD_TYPES:
+                if card_type.lower() in type_line.lower():
+                    counts[card_type] += entry["qty"]
+                    matched = True
+            if not matched:
+                counts["Other"] += entry["qty"]
+
+        # Show types in display order, omit zero-count types
+        display_order = _CARD_TYPES + ["Other"]
+        for card_type in display_order:
+            if counts[card_type]:
+                self.type_list.AppendItem([card_type, str(counts[card_type])])
+
+    def _render_hand_land_pct(self, deck_size: int, land_count: int) -> None:
+        """Render opening-hand land probability label."""
+        if deck_size <= 0 or land_count <= 0:
+            self.hand_land_label.SetLabel("")
+            return
+
+        parts = []
+        for target in (2, 3, 4):
+            if target > land_count:
+                break
+            try:
+                pct = hypergeometric_at_least(deck_size, land_count, 7, target) * 100
+                parts.append(f"≥{target} lands: {pct:.1f}%")
+            except ValueError:
+                break
+
+        if parts:
+            self.hand_land_label.SetLabel("Opening hand (7 cards) — " + "  |  ".join(parts))
+        else:
+            self.hand_land_label.SetLabel("")

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -9,11 +9,10 @@ from collections import Counter
 from typing import Any
 
 import wx
-import wx.dataview as dv
 
 from services.deck_service import DeckService, get_deck_service
 from utils.card_data import CardDataManager
-from utils.constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+from utils.constants import DARK_ACCENT, DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
 from utils.math_utils import hypergeometric_at_least
 
 _CARD_TYPES = [
@@ -26,6 +25,125 @@ _CARD_TYPES = [
     "Planeswalker",
     "Battle",
 ]
+
+# MTG color identity → (display name, bar colour)
+_COLOR_MAP: dict[str, tuple[str, tuple[int, int, int]]] = {
+    "W": ("White", (220, 210, 170)),
+    "U": ("Blue", (59, 130, 246)),
+    "B": ("Black", (140, 120, 160)),
+    "R": ("Red", (210, 70, 50)),
+    "G": ("Green", (60, 160, 70)),
+    "C": ("Colorless", (160, 150, 130)),
+    "Colorless": ("Colorless", (160, 150, 130)),
+}
+
+_ROW_H = 22
+_LABEL_W = 90
+_VALUE_W = 60
+_BAR_PAD = 6
+_TITLE_H = 22
+
+
+class BarChartPanel(wx.Panel):
+    """Custom panel that draws a horizontal bar chart."""
+
+    def __init__(self, parent: wx.Window, title: str = "") -> None:
+        super().__init__(parent)
+        self.SetBackgroundColour(wx.Colour(*DARK_ALT))
+        self._title = title
+        # list of (label, display_value, raw_value, bar_colour)
+        self._items: list[tuple[str, str, int, tuple[int, int, int]]] = []
+        self.Bind(wx.EVT_PAINT, self._on_paint)
+        self.Bind(wx.EVT_SIZE, self._on_size)
+
+    def set_data(
+        self,
+        items: list[tuple[str, str, int]],
+        bar_colour: tuple[int, int, int] = DARK_ACCENT,
+        per_item_colours: list[tuple[int, int, int]] | None = None,
+    ) -> None:
+        """Set chart data and trigger a repaint.
+
+        Args:
+            items: List of (label, display_value, raw_value) tuples.
+            bar_colour: Default bar colour for all items.
+            per_item_colours: Optional per-item override colours.
+        """
+        self._items = [
+            (
+                label,
+                display_val,
+                raw_val,
+                per_item_colours[i] if per_item_colours else bar_colour,
+            )
+            for i, (label, display_val, raw_val) in enumerate(items)
+        ]
+        min_h = _TITLE_H + len(self._items) * _ROW_H + _BAR_PAD * 2
+        self.SetMinSize((-1, min_h))
+        self.Refresh()
+
+    def clear(self) -> None:
+        self._items = []
+        self.Refresh()
+
+    # ---- drawing ----
+
+    def _on_size(self, _evt: wx.SizeEvent) -> None:
+        self.Refresh()
+
+    def _on_paint(self, _evt: wx.PaintEvent) -> None:
+        dc = wx.BufferedPaintDC(self)
+        self._draw(dc)
+
+    def _draw(self, dc: wx.DC) -> None:
+        w, h = self.GetClientSize()
+        if w <= 0 or h <= 0:
+            return
+
+        dc.SetBackground(wx.Brush(wx.Colour(*DARK_ALT)))
+        dc.Clear()
+
+        # Title
+        y = 4
+        if self._title:
+            dc.SetTextForeground(wx.Colour(*SUBDUED_TEXT))
+            dc.SetFont(wx.Font(8, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
+            dc.DrawText(self._title, _BAR_PAD, y)
+            y += _TITLE_H
+
+        if not self._items:
+            return
+
+        max_val = max(raw for _, _, raw, _ in self._items) or 1
+        bar_area_w = max(w - _LABEL_W - _VALUE_W - _BAR_PAD * 3, 20)
+
+        dc.SetFont(wx.Font(9, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
+
+        for label, display_val, raw_val, colour in self._items:
+            bar_w = int(bar_area_w * raw_val / max_val)
+
+            # Row background (subtle alternation already from panel bg)
+            row_y = y + (_ROW_H - 14) // 2
+
+            # Label
+            dc.SetTextForeground(wx.Colour(*LIGHT_TEXT))
+            lbl_tw, _ = dc.GetTextExtent(label)
+            lbl_x = _LABEL_W - lbl_tw - _BAR_PAD
+            dc.DrawText(label, max(lbl_x, 0), row_y)
+
+            # Bar
+            bar_x = _LABEL_W + _BAR_PAD
+            bar_y = y + (_ROW_H - 12) // 2
+            dc.SetBrush(wx.Brush(wx.Colour(*colour)))
+            dc.SetPen(wx.TRANSPARENT_PEN)
+            if bar_w > 0:
+                dc.DrawRoundedRectangle(bar_x, bar_y, bar_w, 12, 3)
+
+            # Value
+            dc.SetTextForeground(wx.Colour(*SUBDUED_TEXT))
+            dc.DrawText(display_val, bar_x + bar_area_w + _BAR_PAD, row_y)
+
+            y += _ROW_H
 
 
 class DeckStatsPanel(wx.Panel):
@@ -68,29 +186,17 @@ class DeckStatsPanel(wx.Panel):
         split = wx.BoxSizer(wx.HORIZONTAL)
         sizer.Add(split, 1, wx.EXPAND | wx.ALL, 6)
 
-        # Mana curve list
-        self.curve_list = dv.DataViewListCtrl(self)
-        self.curve_list.AppendTextColumn("CMC", width=80)
-        self.curve_list.AppendTextColumn("Count", width=80)
-        self.curve_list.SetBackgroundColour(DARK_ALT)
-        self.curve_list.SetForegroundColour(LIGHT_TEXT)
-        split.Add(self.curve_list, 1, wx.RIGHT | wx.EXPAND, 12)
+        # Mana curve bar chart
+        self.curve_chart = BarChartPanel(self, title="Mana Curve")
+        split.Add(self.curve_chart, 1, wx.RIGHT | wx.EXPAND, 12)
 
-        # Color concentration list
-        self.color_list = dv.DataViewListCtrl(self)
-        self.color_list.AppendTextColumn("Color", width=100)
-        self.color_list.AppendTextColumn("Share", width=90)
-        self.color_list.SetBackgroundColour(DARK_ALT)
-        self.color_list.SetForegroundColour(LIGHT_TEXT)
-        split.Add(self.color_list, 1, wx.RIGHT | wx.EXPAND, 12)
+        # Color concentration bar chart
+        self.color_chart = BarChartPanel(self, title="Color Share")
+        split.Add(self.color_chart, 1, wx.RIGHT | wx.EXPAND, 12)
 
-        # Type counts list
-        self.type_list = dv.DataViewListCtrl(self)
-        self.type_list.AppendTextColumn("Type", width=120)
-        self.type_list.AppendTextColumn("Count", width=80)
-        self.type_list.SetBackgroundColour(DARK_ALT)
-        self.type_list.SetForegroundColour(LIGHT_TEXT)
-        split.Add(self.type_list, 1, wx.EXPAND)
+        # Type counts bar chart
+        self.type_chart = BarChartPanel(self, title="Card Types")
+        split.Add(self.type_chart, 1, wx.EXPAND)
 
         # Hand/land probability label
         self.hand_land_label = wx.StaticText(self, label="")
@@ -111,9 +217,9 @@ class DeckStatsPanel(wx.Panel):
 
         if not deck_text.strip():
             self.summary_label.SetLabel("No deck loaded.")
-            self.curve_list.DeleteAllItems()
-            self.color_list.DeleteAllItems()
-            self.type_list.DeleteAllItems()
+            self.curve_chart.clear()
+            self.color_chart.clear()
+            self.type_chart.clear()
             self.hand_land_label.SetLabel("")
             return
 
@@ -148,9 +254,9 @@ class DeckStatsPanel(wx.Panel):
     def clear(self) -> None:
         """Clear all statistics."""
         self.summary_label.SetLabel("No deck loaded.")
-        self.curve_list.DeleteAllItems()
-        self.color_list.DeleteAllItems()
-        self.type_list.DeleteAllItems()
+        self.curve_chart.clear()
+        self.color_chart.clear()
+        self.type_chart.clear()
         self.hand_land_label.SetLabel("")
 
     # ============= Private Methods =============
@@ -175,19 +281,16 @@ class DeckStatsPanel(wx.Panel):
         return lands, mdfcs
 
     def _render_curve(self) -> None:
-        """Render the mana curve chart."""
-        self.curve_list.DeleteAllItems()
-
+        """Render the mana curve bar chart."""
         if not self.card_manager:
+            self.curve_chart.clear()
             return
 
-        # Count cards by mana value
         counts: Counter[str] = Counter()
         for entry in self.zone_cards.get("main", []):
             meta = self.card_manager.get_card(entry["name"])
             mana_value = meta.get("mana_value") if meta else None
 
-            # Bucket the mana value
             if isinstance(mana_value, int | float):
                 value = int(mana_value)
                 bucket = "7+" if value >= 7 else str(value)
@@ -196,7 +299,6 @@ class DeckStatsPanel(wx.Panel):
 
             counts[bucket] += entry["qty"]
 
-        # Sort buckets numerically
         def curve_key(bucket: str) -> int:
             if bucket == "X":
                 return 99
@@ -206,18 +308,18 @@ class DeckStatsPanel(wx.Panel):
                 return int(bucket)
             return 98
 
-        # Add to list
-        for bucket in sorted(counts.keys(), key=curve_key):
-            self.curve_list.AppendItem([bucket, str(counts[bucket])])
+        items = [
+            (bucket, str(counts[bucket]), counts[bucket])
+            for bucket in sorted(counts.keys(), key=curve_key)
+        ]
+        self.curve_chart.set_data(items, bar_colour=DARK_ACCENT)
 
     def _render_color_concentration(self) -> None:
-        """Render the color concentration chart."""
-        self.color_list.DeleteAllItems()
-
+        """Render the color concentration bar chart."""
         if not self.card_manager:
+            self.color_chart.clear()
             return
 
-        # Count cards by color identity
         totals: Counter[str] = Counter()
         for entry in self.zone_cards.get("main", []):
             meta = self.card_manager.get_card(entry["name"])
@@ -226,39 +328,29 @@ class DeckStatsPanel(wx.Panel):
             if not identity:
                 totals["Colorless"] += entry["qty"]
             else:
-                # Count each color separately
                 for color in identity:
                     totals[color] += entry["qty"]
 
-        # Calculate total for percentages
         grand_total = sum(totals.values())
         if grand_total == 0:
+            self.color_chart.clear()
             return
 
-        # Sort by count descending
         sorted_colors = sorted(totals.items(), key=lambda x: x[1], reverse=True)
 
-        # Color name mapping
-        color_names = {
-            "W": "White",
-            "U": "Blue",
-            "B": "Black",
-            "R": "Red",
-            "G": "Green",
-            "C": "Colorless",
-        }
-
-        # Add to list with percentages
+        items = []
+        colours = []
         for color, count in sorted_colors:
-            name = color_names.get(color, color)
+            name, bar_colour = _COLOR_MAP.get(color, (color, DARK_ACCENT))
             percentage = (count / grand_total) * 100
-            share = f"{count} ({percentage:.1f}%)"
-            self.color_list.AppendItem([name, share])
+            display = f"{count} ({percentage:.1f}%)"
+            items.append((name, display, count))
+            colours.append(bar_colour)
+
+        self.color_chart.set_data(items, per_item_colours=colours)
 
     def _render_type_counts(self) -> None:
-        """Render card type counts for the mainboard."""
-        self.type_list.DeleteAllItems()
-
+        """Render card type count bar chart for the mainboard."""
         counts: Counter[str] = Counter()
         for entry in self.zone_cards.get("main", []):
             type_line = ""
@@ -274,11 +366,13 @@ class DeckStatsPanel(wx.Panel):
             if not matched:
                 counts["Other"] += entry["qty"]
 
-        # Show types in display order, omit zero-count types
         display_order = _CARD_TYPES + ["Other"]
-        for card_type in display_order:
-            if counts[card_type]:
-                self.type_list.AppendItem([card_type, str(counts[card_type])])
+        items = [
+            (card_type, str(counts[card_type]), counts[card_type])
+            for card_type in display_order
+            if counts[card_type]
+        ]
+        self.type_chart.set_data(items, bar_colour=DARK_ACCENT)
 
     def _render_hand_land_pct(self, deck_size: int, land_count: int) -> None:
         """Render opening-hand land probability label."""

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -91,11 +91,9 @@ def _load_mana_svgs() -> dict[str, str]:
         if path.exists():
             svg = path.read_text(encoding="utf-8")
             svg = svg.replace('width="32" height="32"', 'width="18" height="18"')
-            svg = svg.replace("fill=\"#444\"", "fill=\"#ECECEC\"")
+            svg = svg.replace('fill="#444"', 'fill="#ECECEC"')
             # Strip the XML comment line to reduce HTML payload
-            svg = "\n".join(
-                line for line in svg.splitlines() if not line.startswith("<!--")
-            )
+            svg = "\n".join(line for line in svg.splitlines() if not line.startswith("<!--"))
             result[key] = svg.strip()
     return result
 
@@ -340,7 +338,6 @@ html, body {
 """
 
 
-
 _JS_TOOLTIP = """
 <div id="tooltip"></div>
 <script>
@@ -385,7 +382,7 @@ def _build_vbars(
             f'<div class="vbar-val" style="font-size:{val_font_size}px">{escape(val_text)}</div>'
             f'<div class="vbar" style="height:{pct:.1f}%;background:{colour};"></div>'
             f'<div class="vbar-lbl">{lbl_html}</div>'
-            f'</div>'
+            f"</div>"
         )
     html += "</div>"
     return html
@@ -412,9 +409,9 @@ def _build_hbars(
             f'<div class="hbar-label"{dim}>{escape(label)}</div>'
             f'<div class="hbar-track">'
             f'<div class="hbar" style="width:{pct:.1f}%;background:{colour};"></div>'
-            f'</div>'
+            f"</div>"
             f'<div class="hbar-count"{dim}>{count if count else ""}</div>'
-            f'</div>'
+            f"</div>"
         )
     html += "</div>"
     return html
@@ -466,7 +463,10 @@ def _build_html(
 
 _EMPTY_HTML = _build_html(
     "No deck loaded.",
-    [], [], [], [],
+    [],
+    [],
+    [],
+    [],
 )
 
 

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -1,19 +1,22 @@
 """
-Deck Stats Panel - Displays deck statistics, mana curve, and color distribution.
+Deck Stats Panel - Displays deck statistics using an HTML/CSS visualization.
 
-Shows summary statistics, mana curve breakdown, color concentration, type counts,
-and opening-hand land probability analysis.
+Shows summary statistics, mana curve breakdown, color distribution, type counts,
+and opening-hand land probability analysis.  All charts are rendered in a
+wx.html2.WebView so they support hover tooltips and pixel-perfect layout.
 """
 
 import math
 from collections import Counter
+from html import escape
 from typing import Any
 
 import wx
+import wx.html2
 
 from services.deck_service import DeckService, get_deck_service
 from utils.card_data import CardDataManager
-from utils.constants import DARK_ACCENT, DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+from utils.constants import DARK_PANEL
 
 _CARD_TYPES = [
     "Land",
@@ -26,63 +29,53 @@ _CARD_TYPES = [
     "Battle",
 ]
 
-# MTG color identity → (short label, bar colour)
-_COLOR_MAP: dict[str, tuple[str, tuple[int, int, int]]] = {
-    "W": ("W", (220, 210, 170)),
-    "U": ("U", (59, 130, 246)),
-    "B": ("B", (140, 120, 160)),
-    "R": ("R", (210, 70, 50)),
-    "G": ("G", (60, 160, 70)),
-    "C": ("C", (160, 150, 130)),
-    "Colorless": ("C", (160, 150, 130)),
+# MTG color identity → (full display label, hex bar colour)
+_COLOR_MAP: dict[str, tuple[str, str]] = {
+    "W": ("White", "#DCD2AA"),
+    "U": ("Blue", "#3B82F6"),
+    "B": ("Black", "#8C78A0"),
+    "R": ("Red", "#D24632"),
+    "G": ("Green", "#3CA046"),
+    "C": ("Colorless", "#A0968A"),
+    "Colorless": ("Colorless", "#A0968A"),
 }
 
-# Slightly varied adjacent colors — intentional, not rainbow
-_TYPE_COLOURS: dict[str, tuple[int, int, int]] = {
-    "Land": (145, 125, 95),
-    "Creature": (90, 135, 185),
-    "Instant": (80, 165, 145),
-    "Sorcery": (120, 100, 175),
-    "Enchantment": (165, 110, 150),
-    "Artifact": (155, 155, 165),
-    "Planeswalker": (95, 160, 185),
-    "Battle": (175, 115, 90),
-    "Other": (130, 130, 130),
+_TYPE_COLOURS: dict[str, str] = {
+    "Land": "#917D5F",
+    "Creature": "#5A87B9",
+    "Instant": "#50A591",
+    "Sorcery": "#7864AF",
+    "Enchantment": "#A56E96",
+    "Artifact": "#9B9BA5",
+    "Planeswalker": "#5FA0B9",
+    "Battle": "#AF735A",
+    "Other": "#828282",
 }
 
-# Opening-hand land count: 0-1=red, 2-3=green, 4-7=red
-_HAND_COLOURS: list[tuple[int, int, int]] = [
-    (210, 60, 60),  # 0 lands – red
-    (210, 60, 60),  # 1 land  – red
-    (60, 190, 80),  # 2 lands – green
-    (60, 190, 80),  # 3 lands – green
-    (210, 60, 60),  # 4 lands – red
-    (210, 60, 60),  # 5 lands – red
-    (210, 60, 60),  # 6 lands – red
-    (210, 60, 60),  # 7 lands – red
+# Opening-hand land count bar colours (0-7 lands)
+_HAND_COLOURS = [
+    "#D23C3C",  # 0 – bad
+    "#D23C3C",  # 1 – bad
+    "#3CBE50",  # 2 – good
+    "#3CBE50",  # 3 – good
+    "#D23C3C",  # 4 – bad
+    "#D23C3C",  # 5 – bad
+    "#D23C3C",  # 6 – bad
+    "#D23C3C",  # 7 – bad
 ]
 
-# Mana curve gradient endpoints
-_CURVE_WARM = (255, 220, 40)  # yellow at CMC 0
-_CURVE_COLD = (30, 50, 180)  # dark blue at CMC 15
-
-_BAR_PAD = 8
-_TITLE_H = 20
-_VALUE_H = 16
-_LABEL_H = 16
+_CURVE_WARM = (255, 220, 40)
+_CURVE_COLD = (30, 50, 180)
 
 
-def _lerp_colour(
-    c1: tuple[int, int, int], c2: tuple[int, int, int], t: float
-) -> tuple[int, int, int]:
-    return (
-        int(c1[0] + (c2[0] - c1[0]) * t),
-        int(c1[1] + (c2[1] - c1[1]) * t),
-        int(c1[2] + (c2[2] - c1[2]) * t),
-    )
+def _lerp_hex(c1: tuple[int, int, int], c2: tuple[int, int, int], t: float) -> str:
+    r = int(c1[0] + (c2[0] - c1[0]) * t)
+    g = int(c1[1] + (c2[1] - c1[1]) * t)
+    b = int(c1[2] + (c2[2] - c1[2]) * t)
+    return f"#{r:02x}{g:02x}{b:02x}"
 
 
-def _curve_colour(bucket: str) -> tuple[int, int, int]:
+def _curve_colour(bucket: str) -> str:
     if bucket == "X":
         cmc = 12
     elif bucket.endswith("+") and bucket[:-1].isdigit():
@@ -91,8 +84,7 @@ def _curve_colour(bucket: str) -> tuple[int, int, int]:
         cmc = int(bucket)
     else:
         cmc = 0
-    t = min(cmc / 15.0, 1.0)
-    return _lerp_colour(_CURVE_WARM, _CURVE_COLD, t)
+    return _lerp_hex(_CURVE_WARM, _CURVE_COLD, min(cmc / 15.0, 1.0))
 
 
 def _hypergeometric_exactly(n_total: int, n_success: int, n_draw: int, k: int) -> float:
@@ -103,168 +95,347 @@ def _hypergeometric_exactly(n_total: int, n_success: int, n_draw: int, k: int) -
     return math.comb(n_success, k) * math.comb(n_fail, n_draw - k) / math.comb(n_total, n_draw)
 
 
-class BarChartPanel(wx.Panel):
-    """Custom panel that draws a vertical or horizontal bar chart."""
+# ---------------------------------------------------------------------------
+# HTML builder
+# ---------------------------------------------------------------------------
 
-    def __init__(self, parent: wx.Window, title: str = "", orientation: str = "vertical") -> None:
-        super().__init__(parent)
-        self.SetBackgroundColour(wx.Colour(*DARK_ALT))
-        self._title = title
-        self._orientation = orientation
-        # list of (label, display_value, raw_value, bar_colour)
-        self._items: list[tuple[str, str, float, tuple[int, int, int]]] = []
-        self.Bind(wx.EVT_PAINT, self._on_paint)
-        self.Bind(wx.EVT_SIZE, self._on_size)
+_CSS = """
+* { box-sizing: border-box; margin: 0; padding: 0; }
 
-    def set_data(
-        self,
-        items: list[tuple[str, str, float]],
-        bar_colour: tuple[int, int, int] = DARK_ACCENT,
-        per_item_colours: list[tuple[int, int, int]] | None = None,
-    ) -> None:
-        """Set chart data and trigger a repaint.
+html, body {
+  height: 100%;
+  background: #22272E;
+  color: #ECECEC;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 12px;
+  overflow: hidden;
+}
 
-        Args:
-            items: List of (label, display_value, raw_value) tuples.
-            bar_colour: Default bar colour for all items.
-            per_item_colours: Optional per-item override colours.
-        """
-        self._items = [
-            (
-                label,
-                display_val,
-                raw_val,
-                per_item_colours[i] if per_item_colours else bar_colour,
-            )
-            for i, (label, display_val, raw_val) in enumerate(items)
-        ]
-        self.Refresh()
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 8px;
+  gap: 6px;
+}
 
-    def clear(self) -> None:
-        self._items = []
-        self.Refresh()
+/* ── Summary bar ── */
+.summary {
+  color: #B9BFCA;
+  font-size: 11px;
+  flex-shrink: 0;
+  padding: 2px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-    # ---- drawing ----
+/* ── Top row: three charts side-by-side ── */
+.top-row {
+  display: flex;
+  gap: 8px;
+  flex: 3;
+  min-height: 0;
+}
 
-    def _on_size(self, _evt: wx.SizeEvent) -> None:
-        self.Refresh()
+/* ── Bottom chart ── */
+.bottom-row {
+  flex: 2;
+  min-height: 0;
+}
 
-    def _on_paint(self, _evt: wx.PaintEvent) -> None:
-        dc = wx.BufferedPaintDC(self)
-        self._draw(dc)
+/* ── Shared chart container ── */
+.chart {
+  display: flex;
+  flex-direction: column;
+  background: #28303A;
+  border-radius: 6px;
+  padding: 8px 8px 4px 8px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
 
-    def _draw(self, dc: wx.DC) -> None:
-        w, h = self.GetClientSize()
-        if w <= 0 or h <= 0:
-            return
+.chart-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #8B929E;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+  flex-shrink: 0;
+}
 
-        dc.SetBackground(wx.Brush(wx.Colour(*DARK_ALT)))
-        dc.Clear()
+.chart-empty {
+  color: #555;
+  font-style: italic;
+  padding: 8px;
+}
 
-        font = wx.Font(12, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
-        dc.SetFont(font)
+/* ── Vertical bar chart ── */
+.vbar-area {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 4px;
+  flex: 1;
+  min-height: 0;
+  padding-bottom: 18px;  /* room for x-axis labels */
+  position: relative;
+}
 
-        title_h = 0
-        if self._title:
-            dc.SetTextForeground(wx.Colour(*SUBDUED_TEXT))
-            dc.DrawText(self._title, _BAR_PAD, 4)
-            title_h = _TITLE_H
+.vbar-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  position: relative;
+  cursor: default;
+}
 
-        if not self._items:
-            return
+/* value label above bar */
+.vbar-val {
+  font-size: 10px;
+  color: #ECECEC;
+  margin-bottom: 2px;
+  white-space: nowrap;
+  line-height: 1;
+  text-align: center;
+}
 
-        dc.SetPen(wx.TRANSPARENT_PEN)
-        if self._orientation == "horizontal":
-            self._draw_horizontal(dc, w, h, title_h)
-        else:
-            self._draw_vertical(dc, w, h, title_h)
+.vbar {
+  width: 100%;
+  border-radius: 3px 3px 0 0;
+  transition: filter 0.1s;
+  min-height: 2px;
+}
 
-    def _draw_vertical(self, dc: wx.DC, w: int, h: int, title_h: int) -> None:
-        n = len(self._items)
+.vbar-col:hover .vbar {
+  filter: brightness(1.3);
+}
 
-        bar_top = title_h + _VALUE_H + 4
-        bar_bottom = h - _LABEL_H - _BAR_PAD
-        bar_area_h = bar_bottom - bar_top
-        if bar_area_h <= 0:
-            return
+/* x-axis label below bars */
+.vbar-lbl {
+  position: absolute;
+  bottom: -18px;
+  font-size: 10px;
+  color: #8B929E;
+  white-space: nowrap;
+  text-align: center;
+  left: 50%;
+  transform: translateX(-50%);
+}
 
-        # Bar width tracks label character size; column pitch also accounts for
-        # value text width so neither overlaps at any font size / DPI.
-        char_w = dc.GetCharWidth()
-        max_label_chars = max(len(lbl) for lbl, _, _, _ in self._items)
-        bar_w = char_w * max(max_label_chars, 1) + 4
+/* ── Floating tooltip (JS-positioned, never clipped) ── */
+#tooltip {
+  display: none;
+  position: fixed;
+  background: rgba(10, 12, 16, 0.93);
+  color: #ECECEC;
+  padding: 4px 9px;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-size: 11px;
+  pointer-events: none;
+  z-index: 999;
+  border: 1px solid #3B4351;
+}
 
-        max_val_tw = max(dc.GetTextExtent(dv)[0] for _, dv, _, _ in self._items)
-        min_gap = char_w  # minimum gap between adjacent value texts
-        col_pitch = max(bar_w + char_w, max_val_tw + min_gap)
-        bar_spacing = col_pitch - bar_w
+/* ── Horizontal bar chart (Card Types) ── */
+.hbar-area {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  flex: 1;
+  min-height: 0;
+  gap: 4px;
+  padding-top: 2px;
+}
 
-        total_used = bar_w * n + bar_spacing * (n - 1)
-        avail_w = w - _BAR_PAD * 2
-        x_start = _BAR_PAD + max((avail_w - total_used) // 2, 0)
+.hbar-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: default;
+  position: relative;
+  height: 20px;
+  flex-shrink: 0;
+}
 
-        max_val = max(raw for _, _, raw, _ in self._items) or 1.0
+.hbar-label {
+  width: 82px;
+  text-align: left;
+  color: #ECECEC;
+  font-size: 11px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
 
-        for i, (label, display_val, raw_val, colour) in enumerate(self._items):
-            x = x_start + i * (bar_w + bar_spacing)
+.hbar-track {
+  flex: 1;
+  position: relative;
+  height: 12px;
+  border-radius: 3px;
+  background: #1C2028;
+}
 
-            bar_h = max(int(bar_area_h * raw_val / max_val), 2 if raw_val > 0 else 0)
-            bar_y = bar_bottom - bar_h
+.hbar {
+  height: 100%;
+  border-radius: 3px;
+  transition: filter 0.1s;
+}
 
-            dc.SetBrush(wx.Brush(wx.Colour(*colour)))
-            if bar_h > 0:
-                dc.DrawRoundedRectangle(x, bar_y, bar_w, bar_h, min(3, bar_w // 4))
+.hbar-row:hover .hbar {
+  filter: brightness(1.3);
+}
 
-            # Value above bar
-            dc.SetTextForeground(wx.Colour(*LIGHT_TEXT))
-            tw, th = dc.GetTextExtent(display_val)
-            val_x = x + (bar_w - tw) // 2
-            val_y = bar_y - th - 2
-            if val_y >= title_h:
-                dc.DrawText(display_val, max(val_x, 0), val_y)
+.hbar-count {
+  width: 28px;
+  font-size: 11px;
+  color: #8B929E;
+  flex-shrink: 0;
+}
+"""
 
-            # Label below bar area
-            dc.SetTextForeground(wx.Colour(*SUBDUED_TEXT))
-            lw, _ = dc.GetTextExtent(label)
-            lbl_x = x + (bar_w - lw) // 2
-            dc.DrawText(label, max(lbl_x, 0), bar_bottom + _BAR_PAD // 2)
 
-    def _draw_horizontal(self, dc: wx.DC, w: int, h: int, title_h: int) -> None:
-        _LABEL_W = 90
-        _VALUE_W = 60
-        _ROW_H = 22
 
-        max_val = max(raw for _, _, raw, _ in self._items) or 1.0
-        bar_area_w = max(w - _LABEL_W - _VALUE_W - _BAR_PAD * 3, 20)
+_JS_TOOLTIP = """
+<div id="tooltip"></div>
+<script>
+var tip = document.getElementById('tooltip');
+function showTip(el, evt) {
+  tip.textContent = el.dataset.tip;
+  tip.style.display = 'block';
+  moveTip(evt);
+}
+function moveTip(evt) {
+  var x = evt.clientX + 12, y = evt.clientY - 28;
+  var tw = tip.offsetWidth, th = tip.offsetHeight;
+  if (x + tw > window.innerWidth - 4) x = evt.clientX - tw - 8;
+  if (y < 4) y = evt.clientY + 14;
+  tip.style.left = x + 'px';
+  tip.style.top  = y + 'px';
+}
+function hideTip() { tip.style.display = 'none'; }
+</script>
+"""
 
-        y = title_h + _BAR_PAD
 
-        for label, display_val, raw_val, colour in self._items:
-            bar_w = int(bar_area_w * raw_val / max_val)
-            row_y = y + (_ROW_H - 14) // 2
+def _build_vbars(
+    items: list[tuple[str, str, float, str, str]],  # (label, val_text, raw, colour, tooltip)
+    val_font_size: int = 10,
+) -> str:
+    """Render the inner bar columns of a vertical bar chart."""
+    if not items:
+        return '<div class="chart-empty">No data</div>'
 
-            # Label (right-aligned)
-            dc.SetTextForeground(wx.Colour(*LIGHT_TEXT))
-            lbl_tw, _ = dc.GetTextExtent(label)
-            lbl_x = _LABEL_W - lbl_tw - _BAR_PAD
-            dc.DrawText(label, max(lbl_x, 0), row_y)
+    max_raw = max(r for _, _, r, _, _ in items) or 1.0
 
-            # Bar
-            bar_x = _LABEL_W + _BAR_PAD
-            bar_y = y + (_ROW_H - 12) // 2
-            dc.SetBrush(wx.Brush(wx.Colour(*colour)))
-            if bar_w > 0:
-                dc.DrawRoundedRectangle(bar_x, bar_y, bar_w, 12, 3)
+    html = '<div class="vbar-area">'
+    for label, val_text, raw, colour, tooltip in items:
+        pct = raw / max_raw * 100
+        tip_attr = escape(tooltip, quote=True)
+        html += (
+            f'<div class="vbar-col" data-tip="{tip_attr}"'
+            f' onmouseenter="showTip(this,event)" onmousemove="moveTip(event)" onmouseleave="hideTip()">'
+            f'<div class="vbar-val" style="font-size:{val_font_size}px">{escape(val_text)}</div>'
+            f'<div class="vbar" style="height:{pct:.1f}%;background:{colour};"></div>'
+            f'<div class="vbar-lbl">{escape(label)}</div>'
+            f'</div>'
+        )
+    html += "</div>"
+    return html
 
-            # Value
-            dc.SetTextForeground(wx.Colour(*SUBDUED_TEXT))
-            dc.DrawText(display_val, bar_x + bar_area_w + _BAR_PAD, row_y)
 
-            y += _ROW_H
+def _build_hbars(
+    items: list[tuple[str, int, int, str, str]],  # (label, count, max_count, colour, tooltip)
+) -> str:
+    """Render a horizontal bar chart (Card Types)."""
+    if not items:
+        return '<div class="chart-empty">No data</div>'
+
+    max_count = max(c for _, c, _, _, _ in items) or 1
+
+    html = '<div class="hbar-area">'
+    for label, count, _max, colour, tooltip in items:
+        pct = count / max_count * 100
+        tip_attr = escape(tooltip, quote=True)
+        # Zero-count rows: dim the label and show an empty track
+        dim = ' style="opacity:0.35"' if count == 0 else ""
+        html += (
+            f'<div class="hbar-row" data-tip="{tip_attr}"'
+            f' onmouseenter="showTip(this,event)" onmousemove="moveTip(event)" onmouseleave="hideTip()">'
+            f'<div class="hbar-label"{dim}>{escape(label)}</div>'
+            f'<div class="hbar-track">'
+            f'<div class="hbar" style="width:{pct:.1f}%;background:{colour};"></div>'
+            f'</div>'
+            f'<div class="hbar-count"{dim}>{count if count else ""}</div>'
+            f'</div>'
+        )
+    html += "</div>"
+    return html
+
+
+def _build_html(
+    summary: str,
+    curve_items: list[tuple[str, str, float, str, str]],
+    color_items: list[tuple[str, str, float, str, str]],
+    type_items: list[tuple[str, int, int, str, str]],
+    hand_items: list[tuple[str, str, float, str, str]],
+) -> str:
+    curve_html = _build_vbars(curve_items)
+    color_html = _build_vbars(color_items)
+    type_html = _build_hbars(type_items)
+    hand_html = _build_vbars(hand_items, val_font_size=15)
+
+    return f"""<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><style>{_CSS}</style></head>
+<body>
+{_JS_TOOLTIP}
+<div class="root">
+  <div class="summary">{escape(summary)}</div>
+  <div class="top-row">
+    <div class="chart">
+      <div class="chart-title">Mana Curve</div>
+      {curve_html}
+    </div>
+    <div class="chart">
+      <div class="chart-title">Color Share</div>
+      {color_html}
+    </div>
+    <div class="chart">
+      <div class="chart-title">Card Types</div>
+      {type_html}
+    </div>
+  </div>
+  <div class="bottom-row">
+    <div class="chart" style="height:100%">
+      <div class="chart-title">Lands in Opening Hand</div>
+      {hand_html}
+    </div>
+  </div>
+</div>
+</body>
+</html>"""
+
+
+_EMPTY_HTML = _build_html(
+    "No deck loaded.",
+    [], [], [], [],
+)
+
+
+# ---------------------------------------------------------------------------
+# Panel
+# ---------------------------------------------------------------------------
 
 
 class DeckStatsPanel(wx.Panel):
-    """Panel that displays deck statistics and analysis."""
+    """Panel that displays deck statistics using an embedded HTML view."""
 
     def __init__(
         self,
@@ -272,14 +443,6 @@ class DeckStatsPanel(wx.Panel):
         card_manager: CardDataManager | None = None,
         deck_service: DeckService | None = None,
     ):
-        """
-        Initialize the deck stats panel.
-
-        Args:
-            parent: Parent window
-            card_manager: Card data manager for metadata lookups
-            deck_service: Deck service for analysis
-        """
         super().__init__(parent)
         self.SetBackgroundColour(DARK_PANEL)
 
@@ -287,100 +450,61 @@ class DeckStatsPanel(wx.Panel):
         self.deck_service = deck_service or get_deck_service()
         self.zone_cards: dict[str, list[dict[str, Any]]] = {}
 
-        self._build_ui()
-
-    def _build_ui(self) -> None:
-        """Build the panel UI."""
+        self._webview = wx.html2.WebView.New(self)
         sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self._webview, 1, wx.EXPAND)
         self.SetSizer(sizer)
 
-        # Summary statistics
+        self._webview.SetPage(_EMPTY_HTML, "")
+
+        # Hidden label kept for test/automation compatibility (summary text readable via GetLabel)
         self.summary_label = wx.StaticText(self, label="No deck loaded.")
-        self.summary_label.SetForegroundColour(LIGHT_TEXT)
-        sizer.Add(self.summary_label, 0, wx.ALL, 6)
+        self.summary_label.Hide()
 
-        # Top row: mana curve, color share, card types
-        split = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.Add(split, 3, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 6)
-
-        self.curve_chart = BarChartPanel(self, title="Mana Curve")
-        split.Add(self.curve_chart, 1, wx.EXPAND | wx.RIGHT, 4)
-
-        self.color_chart = BarChartPanel(self, title="Color Share")
-        split.Add(self.color_chart, 1, wx.EXPAND | wx.RIGHT, 4)
-
-        self.type_chart = BarChartPanel(self, title="Card Types", orientation="horizontal")
-        split.Add(self.type_chart, 1, wx.EXPAND)
-
-        # Bottom row: opening-hand land count odds
-        self.hand_odds_chart = BarChartPanel(self, title="Opening Hand — Land Count")
-        sizer.Add(self.hand_odds_chart, 2, wx.EXPAND | wx.ALL, 6)
-
-    # ============= Public API =============
+    # ── Public API ──────────────────────────────────────────────────────────
 
     def update_stats(self, deck_text: str, zone_cards: dict[str, list[dict[str, Any]]]) -> None:
-        """
-        Update the statistics display.
-
-        Args:
-            deck_text: Full deck text for analysis
-            zone_cards: Dictionary mapping zone names to card lists
-        """
         self.zone_cards = zone_cards
 
         if not deck_text.strip():
             self.summary_label.SetLabel("No deck loaded.")
-            self.curve_chart.clear()
-            self.color_chart.clear()
-            self.type_chart.clear()
-            self.hand_odds_chart.clear()
+            self._webview.SetPage(_EMPTY_HTML, "")
             return
 
-        # Analyze deck
         stats = self.deck_service.analyze_deck(deck_text)
-
-        # Count actual lands from zone_cards using type metadata (includes MDFCs)
         land_count, mdfc_count = self._count_lands()
         total_land_count = land_count + mdfc_count
 
-        # Update summary
         land_label = f"{land_count} land{'s' if land_count != 1 else ''}"
         if mdfc_count:
             land_label += f" + {mdfc_count} MDFC{'s' if mdfc_count != 1 else ''}"
         summary = (
-            f"Mainboard: {stats['mainboard_count']} cards ({stats['unique_mainboard']} unique)  |  "
-            f"Sideboard: {stats['sideboard_count']} cards ({stats['unique_sideboard']} unique)  |  "
-            f"Lands: {land_label}"
+            f"Mainboard: {stats['mainboard_count']} cards ({stats['unique_mainboard']} unique)"
+            f"  |  Sideboard: {stats['sideboard_count']} cards ({stats['unique_sideboard']} unique)"
+            f"  |  Lands: {land_label}"
         )
+
         self.summary_label.SetLabel(summary)
 
-        # Render charts
-        self._render_curve()
-        self._render_color_concentration()
-        self._render_type_counts()
-        self._render_hand_odds(stats["mainboard_count"], total_land_count)
+        html = _build_html(
+            summary,
+            self._curve_items(),
+            self._color_items(),
+            self._type_items(),
+            self._hand_items(stats["mainboard_count"], total_land_count),
+        )
+        self._webview.SetPage(html, "")
 
     def set_card_manager(self, card_manager: CardDataManager) -> None:
-        """Set the card data manager for metadata lookups."""
         self.card_manager = card_manager
 
     def clear(self) -> None:
-        """Clear all statistics."""
         self.summary_label.SetLabel("No deck loaded.")
-        self.curve_chart.clear()
-        self.color_chart.clear()
-        self.type_chart.clear()
-        self.hand_odds_chart.clear()
+        self._webview.SetPage(_EMPTY_HTML, "")
 
-    # ============= Private Methods =============
+    # ── Private helpers ─────────────────────────────────────────────────────
 
     def _count_lands(self) -> tuple[int, int]:
-        """Count lands and MDFC-lands in the mainboard using card type metadata.
-
-        Returns:
-            (lands, mdfcs) where lands are cards with Land in front type_line and
-            mdfcs are cards with Land only in the back face type_line.
-        """
         lands = mdfcs = 0
         for entry in self.zone_cards.get("main", []):
             qty = entry["qty"]
@@ -393,52 +517,60 @@ class DeckStatsPanel(wx.Panel):
                 mdfcs += qty
         return lands, mdfcs
 
-    def _render_curve(self) -> None:
-        """Render the mana curve bar chart."""
+    def _curve_items(self) -> list[tuple[str, str, float, str, str]]:
+        """Build mana curve data items."""
         if not self.card_manager:
-            self.curve_chart.clear()
-            return
+            return []
 
         counts: Counter[str] = Counter()
         for entry in self.zone_cards.get("main", []):
             meta = self.card_manager.get_card(entry["name"])
             mana_value = meta.get("mana_value") if meta else None
-
             if isinstance(mana_value, int | float):
                 value = int(mana_value)
                 bucket = "7+" if value >= 7 else str(value)
             else:
                 bucket = "X"
-
             counts[bucket] += entry["qty"]
 
-        def curve_key(bucket: str) -> int:
-            if bucket == "X":
+        if not counts:
+            return []
+
+        def curve_key(b: str) -> int:
+            if b == "X":
                 return 99
-            if bucket.endswith("+") and bucket[:-1].isdigit():
-                return int(bucket[:-1]) + 10
-            if bucket.isdigit():
-                return int(bucket)
+            if b.endswith("+") and b[:-1].isdigit():
+                return int(b[:-1]) + 10
+            if b.isdigit():
+                return int(b)
             return 98
 
-        items = [
-            (bucket, str(counts[bucket]), counts[bucket])
-            for bucket in sorted(counts.keys(), key=curve_key)
-        ]
-        per_item_colours = [_curve_colour(bucket) for bucket, _, _ in items]
-        self.curve_chart.set_data(items, per_item_colours=per_item_colours)
+        # Fill in zero buckets so the curve is continuous from 0 to the max CMC present
+        numeric_buckets = [int(b) for b in counts if b.isdigit()]
+        if numeric_buckets:
+            max_cmc = max(numeric_buckets)
+            for cmc in range(0, max_cmc + 1):
+                counts.setdefault(str(cmc), 0)
 
-    def _render_color_concentration(self) -> None:
-        """Render the color concentration bar chart."""
+        items = []
+        for bucket in sorted(counts.keys(), key=curve_key):
+            count = counts[bucket]
+            colour = _curve_colour(bucket)
+            label_text = "X" if bucket == "X" else bucket
+            mv_label = "X" if bucket == "X" else f"{label_text}"
+            tooltip = f"Mana Value {mv_label}: {count} card{'s' if count != 1 else ''}"
+            items.append((label_text, str(count), float(count), colour, tooltip))
+        return items
+
+    def _color_items(self) -> list[tuple[str, str, float, str, str]]:
+        """Build color share data items."""
         if not self.card_manager:
-            self.color_chart.clear()
-            return
+            return []
 
         totals: Counter[str] = Counter()
         for entry in self.zone_cards.get("main", []):
             meta = self.card_manager.get_card(entry["name"])
             identity = meta.get("color_identity") if meta else []
-
             if not identity:
                 totals["Colorless"] += entry["qty"]
             else:
@@ -447,23 +579,18 @@ class DeckStatsPanel(wx.Panel):
 
         grand_total = sum(totals.values())
         if grand_total == 0:
-            self.color_chart.clear()
-            return
-
-        sorted_colors = sorted(totals.items(), key=lambda x: x[1], reverse=True)
+            return []
 
         items = []
-        colours = []
-        for color, count in sorted_colors:
-            short_name, bar_colour = _COLOR_MAP.get(color, (color, DARK_ACCENT))
-            percentage = (count / grand_total) * 100
-            items.append((short_name, f"{percentage:.0f}%", count))
-            colours.append(bar_colour)
+        for color, count in sorted(totals.items(), key=lambda x: x[1], reverse=True):
+            full_name, hex_colour = _COLOR_MAP.get(color, (color, "#828282"))
+            pct = count / grand_total * 100
+            tooltip = f"{full_name}: {pct:.1f}%"
+            items.append((full_name, f"{pct:.0f}%", pct, hex_colour, tooltip))
+        return items
 
-        self.color_chart.set_data(items, per_item_colours=colours)
-
-    def _render_type_counts(self) -> None:
-        """Render card type count bar chart for the mainboard."""
+    def _type_items(self) -> list[tuple[str, int, int, str, str]]:
+        """Build card type data items (all types always shown, zero-count ones dimmed)."""
         counts: Counter[str] = Counter()
         for entry in self.zone_cards.get("main", []):
             type_line = ""
@@ -480,25 +607,41 @@ class DeckStatsPanel(wx.Panel):
                 counts["Other"] += entry["qty"]
 
         display_order = _CARD_TYPES + ["Other"]
-        items = [
-            (card_type, str(counts[card_type]), counts[card_type])
-            for card_type in display_order
-            if counts[card_type]
-        ]
-        per_item_colours = [_TYPE_COLOURS.get(ct, DARK_ACCENT) for ct, _, _ in items]
-        self.type_chart.set_data(items, per_item_colours=per_item_colours)
+        # Only include "Other" if something actually fell into it
+        if not counts.get("Other"):
+            display_order = _CARD_TYPES
 
-    def _render_hand_odds(self, deck_size: int, land_count: int) -> None:
-        """Render opening-hand land count probability as a bar chart."""
+        max_count = max((counts[t] for t in display_order), default=1) or 1
+        items = []
+        for card_type in display_order:
+            count = counts[card_type]
+            colour = _TYPE_COLOURS.get(card_type, "#828282")
+            tooltip = f"{card_type}: {count} card{'s' if count != 1 else ''}"
+            items.append((card_type, count, max_count, colour, tooltip))
+        return items
+
+    def _hand_items(
+        self, deck_size: int, land_count: int
+    ) -> list[tuple[str, str, float, str, str]]:
+        """Build opening-hand land probability data items."""
         if deck_size <= 0:
-            self.hand_odds_chart.clear()
-            return
+            return []
 
         hand_size = 7
-        items: list[tuple[str, str, float]] = []
-        for k in range(hand_size + 1):
-            prob = _hypergeometric_exactly(deck_size, land_count, hand_size, k)
-            pct = prob * 100
-            items.append((str(k), f"{pct:.1f}%", pct))
+        probs = [
+            _hypergeometric_exactly(deck_size, land_count, hand_size, k) * 100
+            for k in range(hand_size + 1)
+        ]
 
-        self.hand_odds_chart.set_data(items, per_item_colours=_HAND_COLOURS)
+        # Collapse 6 and 7 into "6+" to avoid unreadably tiny bars
+        collapsed_prob = probs[6] + probs[7]
+        display = list(zip(range(6), probs[:6])) + [(6, collapsed_prob)]
+
+        items = []
+        for k, pct in display:
+            label = f"{k}+" if k == 6 else str(k)
+            n_word = "land" if k == 1 else "lands"
+            tooltip = f"{label} {n_word} in opener: {pct:.1f}%"
+            colour = _HAND_COLOURS[min(k, len(_HAND_COLOURS) - 1)]
+            items.append((label, f"{pct:.1f}%", pct, colour, tooltip))
+        return items

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -27,6 +27,7 @@ _CARD_TYPES = [
     "Artifact",
     "Planeswalker",
     "Battle",
+    "Kindred",
 ]
 
 # MTG color identity → (full display label, hex bar colour)
@@ -49,6 +50,7 @@ _TYPE_COLOURS: dict[str, str] = {
     "Artifact": "#9B9BA5",
     "Planeswalker": "#5FA0B9",
     "Battle": "#AF735A",
+    "Kindred": "#7A9E6A",
     "Other": "#828282",
 }
 

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -74,15 +74,15 @@ class DeckStatsPanel(wx.Panel):
         self.curve_list.AppendTextColumn("Count", width=80)
         self.curve_list.SetBackgroundColour(DARK_ALT)
         self.curve_list.SetForegroundColour(LIGHT_TEXT)
-        split.Add(self.curve_list, 0, wx.RIGHT, 12)
+        split.Add(self.curve_list, 1, wx.RIGHT | wx.EXPAND, 12)
 
         # Color concentration list
         self.color_list = dv.DataViewListCtrl(self)
-        self.color_list.AppendTextColumn("Color", width=120)
-        self.color_list.AppendTextColumn("Share", width=100)
+        self.color_list.AppendTextColumn("Color", width=100)
+        self.color_list.AppendTextColumn("Share", width=90)
         self.color_list.SetBackgroundColour(DARK_ALT)
         self.color_list.SetForegroundColour(LIGHT_TEXT)
-        split.Add(self.color_list, 0, wx.RIGHT, 12)
+        split.Add(self.color_list, 1, wx.RIGHT | wx.EXPAND, 12)
 
         # Type counts list
         self.type_list = dv.DataViewListCtrl(self)
@@ -90,7 +90,7 @@ class DeckStatsPanel(wx.Panel):
         self.type_list.AppendTextColumn("Count", width=80)
         self.type_list.SetBackgroundColour(DARK_ALT)
         self.type_list.SetForegroundColour(LIGHT_TEXT)
-        split.Add(self.type_list, 0)
+        split.Add(self.type_list, 1, wx.EXPAND)
 
         # Hand/land probability label
         self.hand_land_label = wx.StaticText(self, label="")
@@ -120,11 +120,18 @@ class DeckStatsPanel(wx.Panel):
         # Analyze deck
         stats = self.deck_service.analyze_deck(deck_text)
 
+        # Count actual lands from zone_cards using type metadata (includes MDFCs)
+        land_count, mdfc_count = self._count_lands()
+        total_land_count = land_count + mdfc_count
+
         # Update summary
+        land_label = f"{land_count} land{'s' if land_count != 1 else ''}"
+        if mdfc_count:
+            land_label += f" + {mdfc_count} MDFC{'s' if mdfc_count != 1 else ''}"
         summary = (
             f"Mainboard: {stats['mainboard_count']} cards ({stats['unique_mainboard']} unique)  |  "
             f"Sideboard: {stats['sideboard_count']} cards ({stats['unique_sideboard']} unique)  |  "
-            f"Estimated lands: {stats['estimated_lands']}"
+            f"Lands: {land_label}"
         )
         self.summary_label.SetLabel(summary)
 
@@ -132,7 +139,7 @@ class DeckStatsPanel(wx.Panel):
         self._render_curve()
         self._render_color_concentration()
         self._render_type_counts()
-        self._render_hand_land_pct(stats["mainboard_count"], stats["estimated_lands"])
+        self._render_hand_land_pct(stats["mainboard_count"], total_land_count)
 
     def set_card_manager(self, card_manager: CardDataManager) -> None:
         """Set the card data manager for metadata lookups."""
@@ -147,6 +154,25 @@ class DeckStatsPanel(wx.Panel):
         self.hand_land_label.SetLabel("")
 
     # ============= Private Methods =============
+
+    def _count_lands(self) -> tuple[int, int]:
+        """Count lands and MDFC-lands in the mainboard using card type metadata.
+
+        Returns:
+            (lands, mdfcs) where lands are cards with Land in front type_line and
+            mdfcs are cards with Land only in the back face type_line.
+        """
+        lands = mdfcs = 0
+        for entry in self.zone_cards.get("main", []):
+            qty = entry["qty"]
+            meta = self.card_manager.get_card(entry["name"]) if self.card_manager else None
+            type_line = (meta.get("type_line") or "").lower() if meta else ""
+            back_type_line = (meta.get("back_type_line") or "").lower() if meta else ""
+            if "land" in type_line:
+                lands += qty
+            elif "land" in back_type_line:
+                mdfcs += qty
+        return lands, mdfcs
 
     def _render_curve(self) -> None:
         """Render the mana curve chart."""

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -9,6 +9,7 @@ wx.html2.WebView so they support hover tooltips and pixel-perfect layout.
 import math
 from collections import Counter
 from html import escape
+from pathlib import Path
 from typing import Any
 
 import wx
@@ -68,6 +69,38 @@ _HAND_COLOURS = [
 
 _CURVE_WARM = (255, 220, 40)
 _CURVE_COLD = (30, 50, 180)
+
+# Color key → mana SVG filename stem
+_COLOR_SVG_FILENAMES: dict[str, str] = {
+    "W": "w",
+    "U": "u",
+    "B": "b",
+    "R": "r",
+    "G": "g",
+    "C": "c",
+    "Colorless": "c",
+}
+
+
+def _load_mana_svgs() -> dict[str, str]:
+    """Load and inline mana symbol SVGs for each color key, sized 18×18."""
+    svg_dir = Path(__file__).parent.parent.parent / "assets" / "mana" / "svg"
+    result: dict[str, str] = {}
+    for key, stem in _COLOR_SVG_FILENAMES.items():
+        path = svg_dir / f"{stem}.svg"
+        if path.exists():
+            svg = path.read_text(encoding="utf-8")
+            svg = svg.replace('width="32" height="32"', 'width="18" height="18"')
+            svg = svg.replace("fill=\"#444\"", "fill=\"#ECECEC\"")
+            # Strip the XML comment line to reduce HTML payload
+            svg = "\n".join(
+                line for line in svg.splitlines() if not line.startswith("<!--")
+            )
+            result[key] = svg.strip()
+    return result
+
+
+_COLOR_SVG_HTML: dict[str, str] = _load_mana_svgs()
 
 
 def _lerp_hex(c1: tuple[int, int, int], c2: tuple[int, int, int], t: float) -> str:
@@ -182,7 +215,7 @@ html, body {
   gap: 4px;
   flex: 1;
   min-height: 0;
-  padding-bottom: 18px;  /* room for x-axis labels */
+  padding-bottom: 22px;  /* room for x-axis labels (icons up to 18px tall) */
   position: relative;
 }
 
@@ -222,13 +255,17 @@ html, body {
 /* x-axis label below bars */
 .vbar-lbl {
   position: absolute;
-  bottom: -18px;
+  bottom: -22px;
   font-size: 10px;
   color: #8B929E;
   white-space: nowrap;
   text-align: center;
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 
 /* ── Floating tooltip (JS-positioned, never clipped) ── */
@@ -329,6 +366,7 @@ function hideTip() { tip.style.display = 'none'; }
 def _build_vbars(
     items: list[tuple[str, str, float, str, str]],  # (label, val_text, raw, colour, tooltip)
     val_font_size: int = 10,
+    icon_map: dict[str, str] | None = None,
 ) -> str:
     """Render the inner bar columns of a vertical bar chart."""
     if not items:
@@ -340,12 +378,13 @@ def _build_vbars(
     for label, val_text, raw, colour, tooltip in items:
         pct = raw / max_raw * 100
         tip_attr = escape(tooltip, quote=True)
+        lbl_html = icon_map[label] if (icon_map and label in icon_map) else escape(label)
         html += (
             f'<div class="vbar-col" data-tip="{tip_attr}"'
             f' onmouseenter="showTip(this,event)" onmousemove="moveTip(event)" onmouseleave="hideTip()">'
             f'<div class="vbar-val" style="font-size:{val_font_size}px">{escape(val_text)}</div>'
             f'<div class="vbar" style="height:{pct:.1f}%;background:{colour};"></div>'
-            f'<div class="vbar-lbl">{escape(label)}</div>'
+            f'<div class="vbar-lbl">{lbl_html}</div>'
             f'</div>'
         )
     html += "</div>"
@@ -389,7 +428,7 @@ def _build_html(
     hand_items: list[tuple[str, str, float, str, str]],
 ) -> str:
     curve_html = _build_vbars(curve_items)
-    color_html = _build_vbars(color_items)
+    color_html = _build_vbars(color_items, icon_map=_COLOR_SVG_HTML if _COLOR_SVG_HTML else None)
     type_html = _build_hbars(type_items)
     hand_html = _build_vbars(hand_items, val_font_size=15)
 
@@ -588,7 +627,7 @@ class DeckStatsPanel(wx.Panel):
             full_name, hex_colour = _COLOR_MAP.get(color, (color, "#828282"))
             pct = count / grand_total * 100
             tooltip = f"{full_name}: {pct:.1f}%"
-            items.append((full_name, f"{pct:.0f}%", pct, hex_colour, tooltip))
+            items.append((color, f"{pct:.0f}%", pct, hex_colour, tooltip))
         return items
 
     def _type_items(self) -> list[tuple[str, int, int, str, str]]:

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -50,23 +50,23 @@ _TYPE_COLOURS: dict[str, tuple[int, int, int]] = {
     "Other": (130, 130, 130),
 }
 
-# Opening-hand land count: 0=very red, 3=green, 7=very red
+# Opening-hand land count: 0-1=red, 2-3=green, 4-7=red
 _HAND_COLOURS: list[tuple[int, int, int]] = [
-    (220, 40, 40),  # 0 lands – very red
-    (205, 75, 55),  # 1 land  – red
-    (190, 135, 65),  # 2 lands – red fading to green
-    (60, 190, 85),  # 3 lands – green
-    (130, 185, 70),  # 4 lands – green fading to red
-    (200, 130, 55),  # 5 lands – orange-red
-    (210, 70, 55),  # 6 lands – red
-    (225, 35, 35),  # 7 lands – very red
+    (210, 60, 60),  # 0 lands – red
+    (210, 60, 60),  # 1 land  – red
+    (60, 190, 80),  # 2 lands – green
+    (60, 190, 80),  # 3 lands – green
+    (210, 60, 60),  # 4 lands – red
+    (210, 60, 60),  # 5 lands – red
+    (210, 60, 60),  # 6 lands – red
+    (210, 60, 60),  # 7 lands – red
 ]
 
 # Mana curve gradient endpoints
 _CURVE_WARM = (255, 220, 40)  # yellow at CMC 0
 _CURVE_COLD = (30, 50, 180)  # dark blue at CMC 15
 
-_BAR_PAD = 6
+_BAR_PAD = 8
 _TITLE_H = 20
 _VALUE_H = 16
 _LABEL_H = 16
@@ -104,12 +104,13 @@ def _hypergeometric_exactly(n_total: int, n_success: int, n_draw: int, k: int) -
 
 
 class BarChartPanel(wx.Panel):
-    """Custom panel that draws a vertical bar chart."""
+    """Custom panel that draws a vertical or horizontal bar chart."""
 
-    def __init__(self, parent: wx.Window, title: str = "") -> None:
+    def __init__(self, parent: wx.Window, title: str = "", orientation: str = "vertical") -> None:
         super().__init__(parent)
         self.SetBackgroundColour(wx.Colour(*DARK_ALT))
         self._title = title
+        self._orientation = orientation
         # list of (label, display_value, raw_value, bar_colour)
         self._items: list[tuple[str, str, float, tuple[int, int, int]]] = []
         self.Bind(wx.EVT_PAINT, self._on_paint)
@@ -160,17 +161,11 @@ class BarChartPanel(wx.Panel):
         dc.SetBackground(wx.Brush(wx.Colour(*DARK_ALT)))
         dc.Clear()
 
-        # Title
+        font = wx.Font(12, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
+        dc.SetFont(font)
+
         title_h = 0
         if self._title:
-            dc.SetFont(
-                wx.Font(
-                    8,
-                    wx.FONTFAMILY_DEFAULT,
-                    wx.FONTSTYLE_NORMAL,
-                    wx.FONTWEIGHT_NORMAL,
-                )
-            )
             dc.SetTextForeground(wx.Colour(*SUBDUED_TEXT))
             dc.DrawText(self._title, _BAR_PAD, 4)
             title_h = _TITLE_H
@@ -178,25 +173,37 @@ class BarChartPanel(wx.Panel):
         if not self._items:
             return
 
+        dc.SetPen(wx.TRANSPARENT_PEN)
+        if self._orientation == "horizontal":
+            self._draw_horizontal(dc, w, h, title_h)
+        else:
+            self._draw_vertical(dc, w, h, title_h)
+
+    def _draw_vertical(self, dc: wx.DC, w: int, h: int, title_h: int) -> None:
         n = len(self._items)
 
-        # Bar area bounds
         bar_top = title_h + _VALUE_H + 4
         bar_bottom = h - _LABEL_H - _BAR_PAD
         bar_area_h = bar_bottom - bar_top
         if bar_area_h <= 0:
             return
 
-        avail_w = w - _BAR_PAD * 2
-        bar_spacing = max(2, avail_w // max(n * 5, 1))
-        bar_w = max((avail_w - bar_spacing * (n - 1)) // n, 4)
+        # Bar width tracks label character size; column pitch also accounts for
+        # value text width so neither overlaps at any font size / DPI.
+        char_w = dc.GetCharWidth()
+        max_label_chars = max(len(lbl) for lbl, _, _, _ in self._items)
+        bar_w = char_w * max(max_label_chars, 1) + 4
+
+        max_val_tw = max(dc.GetTextExtent(dv)[0] for _, dv, _, _ in self._items)
+        min_gap = char_w  # minimum gap between adjacent value texts
+        col_pitch = max(bar_w + char_w, max_val_tw + min_gap)
+        bar_spacing = col_pitch - bar_w
+
         total_used = bar_w * n + bar_spacing * (n - 1)
+        avail_w = w - _BAR_PAD * 2
         x_start = _BAR_PAD + max((avail_w - total_used) // 2, 0)
 
         max_val = max(raw for _, _, raw, _ in self._items) or 1.0
-
-        dc.SetFont(wx.Font(8, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
-        dc.SetPen(wx.TRANSPARENT_PEN)
 
         for i, (label, display_val, raw_val, colour) in enumerate(self._items):
             x = x_start + i * (bar_w + bar_spacing)
@@ -204,7 +211,6 @@ class BarChartPanel(wx.Panel):
             bar_h = max(int(bar_area_h * raw_val / max_val), 2 if raw_val > 0 else 0)
             bar_y = bar_bottom - bar_h
 
-            # Bar
             dc.SetBrush(wx.Brush(wx.Colour(*colour)))
             if bar_h > 0:
                 dc.DrawRoundedRectangle(x, bar_y, bar_w, bar_h, min(3, bar_w // 4))
@@ -222,6 +228,39 @@ class BarChartPanel(wx.Panel):
             lw, _ = dc.GetTextExtent(label)
             lbl_x = x + (bar_w - lw) // 2
             dc.DrawText(label, max(lbl_x, 0), bar_bottom + _BAR_PAD // 2)
+
+    def _draw_horizontal(self, dc: wx.DC, w: int, h: int, title_h: int) -> None:
+        _LABEL_W = 90
+        _VALUE_W = 60
+        _ROW_H = 22
+
+        max_val = max(raw for _, _, raw, _ in self._items) or 1.0
+        bar_area_w = max(w - _LABEL_W - _VALUE_W - _BAR_PAD * 3, 20)
+
+        y = title_h + _BAR_PAD
+
+        for label, display_val, raw_val, colour in self._items:
+            bar_w = int(bar_area_w * raw_val / max_val)
+            row_y = y + (_ROW_H - 14) // 2
+
+            # Label (right-aligned)
+            dc.SetTextForeground(wx.Colour(*LIGHT_TEXT))
+            lbl_tw, _ = dc.GetTextExtent(label)
+            lbl_x = _LABEL_W - lbl_tw - _BAR_PAD
+            dc.DrawText(label, max(lbl_x, 0), row_y)
+
+            # Bar
+            bar_x = _LABEL_W + _BAR_PAD
+            bar_y = y + (_ROW_H - 12) // 2
+            dc.SetBrush(wx.Brush(wx.Colour(*colour)))
+            if bar_w > 0:
+                dc.DrawRoundedRectangle(bar_x, bar_y, bar_w, 12, 3)
+
+            # Value
+            dc.SetTextForeground(wx.Colour(*SUBDUED_TEXT))
+            dc.DrawText(display_val, bar_x + bar_area_w + _BAR_PAD, row_y)
+
+            y += _ROW_H
 
 
 class DeckStatsPanel(wx.Panel):
@@ -270,7 +309,7 @@ class DeckStatsPanel(wx.Panel):
         self.color_chart = BarChartPanel(self, title="Color Share")
         split.Add(self.color_chart, 1, wx.EXPAND | wx.RIGHT, 4)
 
-        self.type_chart = BarChartPanel(self, title="Card Types")
+        self.type_chart = BarChartPanel(self, title="Card Types", orientation="horizontal")
         split.Add(self.type_chart, 1, wx.EXPAND)
 
         # Bottom row: opening-hand land count odds

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -5,6 +5,7 @@ Shows summary statistics, mana curve breakdown, color concentration, type counts
 and opening-hand land probability analysis.
 """
 
+import math
 from collections import Counter
 from typing import Any
 
@@ -13,7 +14,6 @@ import wx
 from services.deck_service import DeckService, get_deck_service
 from utils.card_data import CardDataManager
 from utils.constants import DARK_ACCENT, DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
-from utils.math_utils import hypergeometric_at_least
 
 _CARD_TYPES = [
     "Land",
@@ -26,39 +26,98 @@ _CARD_TYPES = [
     "Battle",
 ]
 
-# MTG color identity → (display name, bar colour)
+# MTG color identity → (short label, bar colour)
 _COLOR_MAP: dict[str, tuple[str, tuple[int, int, int]]] = {
-    "W": ("White", (220, 210, 170)),
-    "U": ("Blue", (59, 130, 246)),
-    "B": ("Black", (140, 120, 160)),
-    "R": ("Red", (210, 70, 50)),
-    "G": ("Green", (60, 160, 70)),
-    "C": ("Colorless", (160, 150, 130)),
-    "Colorless": ("Colorless", (160, 150, 130)),
+    "W": ("W", (220, 210, 170)),
+    "U": ("U", (59, 130, 246)),
+    "B": ("B", (140, 120, 160)),
+    "R": ("R", (210, 70, 50)),
+    "G": ("G", (60, 160, 70)),
+    "C": ("C", (160, 150, 130)),
+    "Colorless": ("C", (160, 150, 130)),
 }
 
-_ROW_H = 22
-_LABEL_W = 90
-_VALUE_W = 60
+# Slightly varied adjacent colors — intentional, not rainbow
+_TYPE_COLOURS: dict[str, tuple[int, int, int]] = {
+    "Land": (145, 125, 95),
+    "Creature": (90, 135, 185),
+    "Instant": (80, 165, 145),
+    "Sorcery": (120, 100, 175),
+    "Enchantment": (165, 110, 150),
+    "Artifact": (155, 155, 165),
+    "Planeswalker": (95, 160, 185),
+    "Battle": (175, 115, 90),
+    "Other": (130, 130, 130),
+}
+
+# Opening-hand land count: 0=very red, 3=green, 7=very red
+_HAND_COLOURS: list[tuple[int, int, int]] = [
+    (220, 40, 40),  # 0 lands – very red
+    (205, 75, 55),  # 1 land  – red
+    (190, 135, 65),  # 2 lands – red fading to green
+    (60, 190, 85),  # 3 lands – green
+    (130, 185, 70),  # 4 lands – green fading to red
+    (200, 130, 55),  # 5 lands – orange-red
+    (210, 70, 55),  # 6 lands – red
+    (225, 35, 35),  # 7 lands – very red
+]
+
+# Mana curve gradient endpoints
+_CURVE_WARM = (255, 220, 40)  # yellow at CMC 0
+_CURVE_COLD = (30, 50, 180)  # dark blue at CMC 15
+
 _BAR_PAD = 6
-_TITLE_H = 22
+_TITLE_H = 20
+_VALUE_H = 16
+_LABEL_H = 16
+
+
+def _lerp_colour(
+    c1: tuple[int, int, int], c2: tuple[int, int, int], t: float
+) -> tuple[int, int, int]:
+    return (
+        int(c1[0] + (c2[0] - c1[0]) * t),
+        int(c1[1] + (c2[1] - c1[1]) * t),
+        int(c1[2] + (c2[2] - c1[2]) * t),
+    )
+
+
+def _curve_colour(bucket: str) -> tuple[int, int, int]:
+    if bucket == "X":
+        cmc = 12
+    elif bucket.endswith("+") and bucket[:-1].isdigit():
+        cmc = int(bucket[:-1])
+    elif bucket.isdigit():
+        cmc = int(bucket)
+    else:
+        cmc = 0
+    t = min(cmc / 15.0, 1.0)
+    return _lerp_colour(_CURVE_WARM, _CURVE_COLD, t)
+
+
+def _hypergeometric_exactly(n_total: int, n_success: int, n_draw: int, k: int) -> float:
+    """P(X = k) under the hypergeometric distribution."""
+    n_fail = n_total - n_success
+    if k < 0 or k > n_success or n_draw - k < 0 or n_draw - k > n_fail:
+        return 0.0
+    return math.comb(n_success, k) * math.comb(n_fail, n_draw - k) / math.comb(n_total, n_draw)
 
 
 class BarChartPanel(wx.Panel):
-    """Custom panel that draws a horizontal bar chart."""
+    """Custom panel that draws a vertical bar chart."""
 
     def __init__(self, parent: wx.Window, title: str = "") -> None:
         super().__init__(parent)
         self.SetBackgroundColour(wx.Colour(*DARK_ALT))
         self._title = title
         # list of (label, display_value, raw_value, bar_colour)
-        self._items: list[tuple[str, str, int, tuple[int, int, int]]] = []
+        self._items: list[tuple[str, str, float, tuple[int, int, int]]] = []
         self.Bind(wx.EVT_PAINT, self._on_paint)
         self.Bind(wx.EVT_SIZE, self._on_size)
 
     def set_data(
         self,
-        items: list[tuple[str, str, int]],
+        items: list[tuple[str, str, float]],
         bar_colour: tuple[int, int, int] = DARK_ACCENT,
         per_item_colours: list[tuple[int, int, int]] | None = None,
     ) -> None:
@@ -78,8 +137,6 @@ class BarChartPanel(wx.Panel):
             )
             for i, (label, display_val, raw_val) in enumerate(items)
         ]
-        min_h = _TITLE_H + len(self._items) * _ROW_H + _BAR_PAD * 2
-        self.SetMinSize((-1, min_h))
         self.Refresh()
 
     def clear(self) -> None:
@@ -104,46 +161,67 @@ class BarChartPanel(wx.Panel):
         dc.Clear()
 
         # Title
-        y = 4
+        title_h = 0
         if self._title:
+            dc.SetFont(
+                wx.Font(
+                    8,
+                    wx.FONTFAMILY_DEFAULT,
+                    wx.FONTSTYLE_NORMAL,
+                    wx.FONTWEIGHT_NORMAL,
+                )
+            )
             dc.SetTextForeground(wx.Colour(*SUBDUED_TEXT))
-            dc.SetFont(wx.Font(8, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
-            dc.DrawText(self._title, _BAR_PAD, y)
-            y += _TITLE_H
+            dc.DrawText(self._title, _BAR_PAD, 4)
+            title_h = _TITLE_H
 
         if not self._items:
             return
 
-        max_val = max(raw for _, _, raw, _ in self._items) or 1
-        bar_area_w = max(w - _LABEL_W - _VALUE_W - _BAR_PAD * 3, 20)
+        n = len(self._items)
 
-        dc.SetFont(wx.Font(9, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
+        # Bar area bounds
+        bar_top = title_h + _VALUE_H + 4
+        bar_bottom = h - _LABEL_H - _BAR_PAD
+        bar_area_h = bar_bottom - bar_top
+        if bar_area_h <= 0:
+            return
 
-        for label, display_val, raw_val, colour in self._items:
-            bar_w = int(bar_area_w * raw_val / max_val)
+        avail_w = w - _BAR_PAD * 2
+        bar_spacing = max(2, avail_w // max(n * 5, 1))
+        bar_w = max((avail_w - bar_spacing * (n - 1)) // n, 4)
+        total_used = bar_w * n + bar_spacing * (n - 1)
+        x_start = _BAR_PAD + max((avail_w - total_used) // 2, 0)
 
-            # Row background (subtle alternation already from panel bg)
-            row_y = y + (_ROW_H - 14) // 2
+        max_val = max(raw for _, _, raw, _ in self._items) or 1.0
 
-            # Label
-            dc.SetTextForeground(wx.Colour(*LIGHT_TEXT))
-            lbl_tw, _ = dc.GetTextExtent(label)
-            lbl_x = _LABEL_W - lbl_tw - _BAR_PAD
-            dc.DrawText(label, max(lbl_x, 0), row_y)
+        dc.SetFont(wx.Font(8, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL))
+        dc.SetPen(wx.TRANSPARENT_PEN)
+
+        for i, (label, display_val, raw_val, colour) in enumerate(self._items):
+            x = x_start + i * (bar_w + bar_spacing)
+
+            bar_h = max(int(bar_area_h * raw_val / max_val), 2 if raw_val > 0 else 0)
+            bar_y = bar_bottom - bar_h
 
             # Bar
-            bar_x = _LABEL_W + _BAR_PAD
-            bar_y = y + (_ROW_H - 12) // 2
             dc.SetBrush(wx.Brush(wx.Colour(*colour)))
-            dc.SetPen(wx.TRANSPARENT_PEN)
-            if bar_w > 0:
-                dc.DrawRoundedRectangle(bar_x, bar_y, bar_w, 12, 3)
+            if bar_h > 0:
+                dc.DrawRoundedRectangle(x, bar_y, bar_w, bar_h, min(3, bar_w // 4))
 
-            # Value
+            # Value above bar
+            dc.SetTextForeground(wx.Colour(*LIGHT_TEXT))
+            tw, th = dc.GetTextExtent(display_val)
+            val_x = x + (bar_w - tw) // 2
+            val_y = bar_y - th - 2
+            if val_y >= title_h:
+                dc.DrawText(display_val, max(val_x, 0), val_y)
+
+            # Label below bar area
             dc.SetTextForeground(wx.Colour(*SUBDUED_TEXT))
-            dc.DrawText(display_val, bar_x + bar_area_w + _BAR_PAD, row_y)
-
-            y += _ROW_H
+            lw, _ = dc.GetTextExtent(label)
+            lbl_x = x + (bar_w - lw) // 2
+            dc.DrawText(label, max(lbl_x, 0), bar_bottom + _BAR_PAD // 2)
 
 
 class DeckStatsPanel(wx.Panel):
@@ -182,26 +260,22 @@ class DeckStatsPanel(wx.Panel):
         self.summary_label.SetForegroundColour(LIGHT_TEXT)
         sizer.Add(self.summary_label, 0, wx.ALL, 6)
 
-        # Split view for curve, color, and type charts
+        # Top row: mana curve, color share, card types
         split = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.Add(split, 1, wx.EXPAND | wx.ALL, 6)
+        sizer.Add(split, 3, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 6)
 
-        # Mana curve bar chart
         self.curve_chart = BarChartPanel(self, title="Mana Curve")
-        split.Add(self.curve_chart, 1, wx.RIGHT | wx.EXPAND, 12)
+        split.Add(self.curve_chart, 1, wx.EXPAND | wx.RIGHT, 4)
 
-        # Color concentration bar chart
         self.color_chart = BarChartPanel(self, title="Color Share")
-        split.Add(self.color_chart, 1, wx.RIGHT | wx.EXPAND, 12)
+        split.Add(self.color_chart, 1, wx.EXPAND | wx.RIGHT, 4)
 
-        # Type counts bar chart
         self.type_chart = BarChartPanel(self, title="Card Types")
         split.Add(self.type_chart, 1, wx.EXPAND)
 
-        # Hand/land probability label
-        self.hand_land_label = wx.StaticText(self, label="")
-        self.hand_land_label.SetForegroundColour(SUBDUED_TEXT)
-        sizer.Add(self.hand_land_label, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
+        # Bottom row: opening-hand land count odds
+        self.hand_odds_chart = BarChartPanel(self, title="Opening Hand — Land Count")
+        sizer.Add(self.hand_odds_chart, 2, wx.EXPAND | wx.ALL, 6)
 
     # ============= Public API =============
 
@@ -220,7 +294,7 @@ class DeckStatsPanel(wx.Panel):
             self.curve_chart.clear()
             self.color_chart.clear()
             self.type_chart.clear()
-            self.hand_land_label.SetLabel("")
+            self.hand_odds_chart.clear()
             return
 
         # Analyze deck
@@ -245,7 +319,7 @@ class DeckStatsPanel(wx.Panel):
         self._render_curve()
         self._render_color_concentration()
         self._render_type_counts()
-        self._render_hand_land_pct(stats["mainboard_count"], total_land_count)
+        self._render_hand_odds(stats["mainboard_count"], total_land_count)
 
     def set_card_manager(self, card_manager: CardDataManager) -> None:
         """Set the card data manager for metadata lookups."""
@@ -257,7 +331,7 @@ class DeckStatsPanel(wx.Panel):
         self.curve_chart.clear()
         self.color_chart.clear()
         self.type_chart.clear()
-        self.hand_land_label.SetLabel("")
+        self.hand_odds_chart.clear()
 
     # ============= Private Methods =============
 
@@ -312,7 +386,8 @@ class DeckStatsPanel(wx.Panel):
             (bucket, str(counts[bucket]), counts[bucket])
             for bucket in sorted(counts.keys(), key=curve_key)
         ]
-        self.curve_chart.set_data(items, bar_colour=DARK_ACCENT)
+        per_item_colours = [_curve_colour(bucket) for bucket, _, _ in items]
+        self.curve_chart.set_data(items, per_item_colours=per_item_colours)
 
     def _render_color_concentration(self) -> None:
         """Render the color concentration bar chart."""
@@ -341,10 +416,9 @@ class DeckStatsPanel(wx.Panel):
         items = []
         colours = []
         for color, count in sorted_colors:
-            name, bar_colour = _COLOR_MAP.get(color, (color, DARK_ACCENT))
+            short_name, bar_colour = _COLOR_MAP.get(color, (color, DARK_ACCENT))
             percentage = (count / grand_total) * 100
-            display = f"{count} ({percentage:.1f}%)"
-            items.append((name, display, count))
+            items.append((short_name, f"{percentage:.0f}%", count))
             colours.append(bar_colour)
 
         self.color_chart.set_data(items, per_item_colours=colours)
@@ -372,25 +446,20 @@ class DeckStatsPanel(wx.Panel):
             for card_type in display_order
             if counts[card_type]
         ]
-        self.type_chart.set_data(items, bar_colour=DARK_ACCENT)
+        per_item_colours = [_TYPE_COLOURS.get(ct, DARK_ACCENT) for ct, _, _ in items]
+        self.type_chart.set_data(items, per_item_colours=per_item_colours)
 
-    def _render_hand_land_pct(self, deck_size: int, land_count: int) -> None:
-        """Render opening-hand land probability label."""
-        if deck_size <= 0 or land_count <= 0:
-            self.hand_land_label.SetLabel("")
+    def _render_hand_odds(self, deck_size: int, land_count: int) -> None:
+        """Render opening-hand land count probability as a bar chart."""
+        if deck_size <= 0:
+            self.hand_odds_chart.clear()
             return
 
-        parts = []
-        for target in (2, 3, 4):
-            if target > land_count:
-                break
-            try:
-                pct = hypergeometric_at_least(deck_size, land_count, 7, target) * 100
-                parts.append(f"≥{target} lands: {pct:.1f}%")
-            except ValueError:
-                break
+        hand_size = 7
+        items: list[tuple[str, str, float]] = []
+        for k in range(hand_size + 1):
+            prob = _hypergeometric_exactly(deck_size, land_count, hand_size, k)
+            pct = prob * 100
+            items.append((str(k), f"{pct:.1f}%", pct))
 
-        if parts:
-            self.hand_land_label.SetLabel("Opening hand (7 cards) — " + "  |  ".join(parts))
-        else:
-            self.hand_land_label.SetLabel("")
+        self.hand_odds_chart.set_data(items, per_item_colours=_HAND_COLOURS)


### PR DESCRIPTION
## Summary
- Adds a **Type counts** list to the Stats tab (Land, Creature, Instant, Sorcery, Enchantment, Artifact, Planeswalker, Battle, Other)
- Adds an **opening-hand land %** label showing probability of drawing ≥2, ≥3, ≥4 lands in a 7-card hand using the existing hypergeometric calculator
- Uses `card_manager.get_card()` → `type_line` for type detection; cards with multiple types (e.g. Artifact Creature) are counted in each applicable bucket

Closes #244

## Test plan
- [ ] Load a deck and switch to the Stats tab — type counts, color share, mana curve, and hand/land % should all appear
- [ ] Clear the deck — all stats clear cleanly
- [ ] Test with a mono-color, two-color, and artifact-heavy deck

🤖 Generated with [Claude Code](https://claude.com/claude-code)