### PR TITLE
fix: treat Dryad Arbor as green, not colorless, in color filter

### DIFF
--- a/services/search_service.py
+++ b/services/search_service.py
@@ -269,10 +269,18 @@ class SearchService:
         return matches_color_filter(card_colors, colors, mode)
 
     def _get_card_colors_for_filter(self, card: dict[str, Any]) -> list[str]:
-        """Return the colors to use for color filtering, treating lands as colorless."""
+        """Return the colors to use for color filtering.
+
+        Most lands are treated as colorless. However, lands that have actual
+        card colors in their mtgjson entry (e.g. Dryad Arbor, which is a green
+        Forest Land creature with colors=["G"]) retain those colors.
+        """
         type_line = (card.get("type_line") or card.get("type") or "").lower()
         if "land" in type_line:
-            return []
+            card_colors = card.get("colors", [])
+            if isinstance(card_colors, str):
+                card_colors = list(card_colors)
+            return card_colors
         card_colors = card.get("colors", []) or card.get("color_identity", [])
         if isinstance(card_colors, str):
             card_colors = list(card_colors)

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -533,12 +533,14 @@ def test_matches_text_filter_no_text():
 # ============= Land Colorless Tests =============
 
 
-def create_mock_land(name="Forest", color_identity=None, type_line="Basic Land — Forest"):
+def create_mock_land(
+    name="Forest", colors=None, color_identity=None, type_line="Basic Land — Forest"
+):
     """Helper to create a mock land card."""
     return {
         "name": name,
         "name_lower": name.lower(),
-        "colors": [],
+        "colors": colors or [],
         "color_identity": color_identity or ["G"],
         "type_line": type_line,
         "mana_cost": "",
@@ -550,11 +552,11 @@ def create_mock_land(name="Forest", color_identity=None, type_line="Basic Land �
 
 
 def test_lands_treated_as_colorless_in_color_filter():
-    """Lands should be treated as colorless regardless of color_identity."""
+    """Lands with no card colors (colors=[]) are treated as colorless."""
     mock_repo = SimpleNamespace()
     service = SearchService(card_repository=mock_repo)
 
-    forest = create_mock_land(name="Forest", color_identity=["G"])
+    forest = create_mock_land(name="Forest", colors=[], color_identity=["G"])
 
     # Forest should NOT match a green color filter
     assert service._matches_color_filter(forest, ["G"], "At least") is False
@@ -566,6 +568,30 @@ def test_lands_treated_as_colorless_in_color_filter():
 
     # Forest should pass "Not these" for any color (it's colorless)
     assert service._matches_color_filter(forest, ["G", "U", "R"], "Not these") is True
+
+
+def test_dryad_arbor_treated_as_green_in_color_filter():
+    """Dryad Arbor is a green land (colors=["G"]) and should be treated as green, not colorless."""
+    mock_repo = SimpleNamespace()
+    service = SearchService(card_repository=mock_repo)
+
+    dryad_arbor = create_mock_land(
+        name="Dryad Arbor",
+        colors=["G"],
+        color_identity=["G"],
+        type_line="Land Creature — Forest Dryad",
+    )
+
+    # Dryad Arbor SHOULD match a green color filter
+    assert service._matches_color_filter(dryad_arbor, ["G"], "At least") is True
+    assert service._matches_color_filter(dryad_arbor, ["G"], "Exactly") is True
+
+    # Dryad Arbor should NOT match a colorless filter
+    assert service._matches_color_filter(dryad_arbor, ["C"], "At least") is False
+    assert service._matches_color_filter(dryad_arbor, ["C"], "Exactly") is False
+
+    # Dryad Arbor should NOT pass "Not these" when green is excluded
+    assert service._matches_color_filter(dryad_arbor, ["G"], "Not these") is False
 
 
 def test_filter_cards_lands_excluded_from_color_filter():


### PR DESCRIPTION
Fixes #251

## Summary
- `_get_card_colors_for_filter` in `SearchService` previously returned `[]` (colorless) for all lands regardless of their card colors
- Dryad Arbor has `colors: ["G"]` in its mtgjson entry (it's genuinely a green card), so it should not be treated as colorless
- Regular lands like Forest have `colors: []` and continue to be treated as colorless

## Changes
- `services/search_service.py`: For lands, return the card's `colors` field directly instead of always returning `[]`. Empty `colors` (most lands) → colorless; non-empty `colors` (Dryad Arbor) → those colors
- `tests/test_search_service.py`: Added `colors` parameter to `create_mock_land`, updated existing test docstring, and added `test_dryad_arbor_treated_as_green_in_color_filter`

## Test plan
- [ ] All 362 existing tests pass
- [ ] New `test_dryad_arbor_treated_as_green_in_color_filter` confirms Dryad Arbor matches green filter and not colorless filter
- [ ] Existing Forest tests still pass (colorless behavior preserved for normal lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)