### PR TITLE
feat: link sideboard guide to opponent tracker

### DIFF
--- a/utils/constants/__init__.py
+++ b/utils/constants/__init__.py
@@ -64,7 +64,13 @@ from utils.constants.search import (
     DEFAULT_SUGGESTION_LIMIT,
     MIN_PARTIAL_NAME_LENGTH,
 )
-from utils.constants.storage import CARD_INSPECTOR_LOG, GUIDE_STORE, NOTES_STORE, OUTBOARD_STORE
+from utils.constants.storage import (
+    ACTIVE_GUIDE_FILE,
+    CARD_INSPECTOR_LOG,
+    GUIDE_STORE,
+    NOTES_STORE,
+    OUTBOARD_STORE,
+)
 from utils.constants.timing import (
     ATOMIC_DATA_DOWNLOAD_TIMEOUT_SECONDS,
     ATOMIC_DATA_HEAD_TIMEOUT_SECONDS,
@@ -205,6 +211,7 @@ __all__ = [
     "ARCHETYPE_LIST_CACHE_FILE",
     "ARCHETYPE_DECKS_CACHE_FILE",
     "ensure_base_dirs",
+    "ACTIVE_GUIDE_FILE",
     "CARD_INSPECTOR_LOG",
     "GUIDE_STORE",
     "NOTES_STORE",

--- a/utils/constants/storage.py
+++ b/utils/constants/storage.py
@@ -1,8 +1,9 @@
 """Local storage files and logs."""
 
-from utils.constants.paths import CACHE_DIR
+from utils.constants.paths import CACHE_DIR, CONFIG_DIR
 
 NOTES_STORE = CACHE_DIR / "deck_notes.json"
 OUTBOARD_STORE = CACHE_DIR / "deck_outboard.json"
 GUIDE_STORE = CACHE_DIR / "deck_sbguides.json"
 CARD_INSPECTOR_LOG = CACHE_DIR / "card_inspector_debug.log"
+ACTIVE_GUIDE_FILE = CONFIG_DIR / "active_guide.json"

--- a/widgets/app_frame.py
+++ b/widgets/app_frame.py
@@ -423,6 +423,7 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
             on_edit_exclusions=self._on_edit_exclusions,
             on_export_csv=self._on_export_guide,
             on_import_csv=self._on_import_guide,
+            on_pin_guide=self._on_pin_guide,
         )
         self.deck_tabs.AddPage(self.sideboard_guide_panel, "Sideboard Guide")
 

--- a/widgets/handlers/sideboard_guide_handlers.py
+++ b/widgets/handlers/sideboard_guide_handlers.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 import wx
 from loguru import logger
 
+from utils.atomic_io import atomic_write_json
+from utils.constants import ACTIVE_GUIDE_FILE
 from widgets.dialogs.guide_entry_dialog import GuideEntryDialog
 
 if TYPE_CHECKING:
@@ -38,6 +40,21 @@ class SideboardGuideHandlers:
             if name and qty > 0:
                 cleaned.append({"name": name, "qty": qty})
         return cleaned
+
+    def _refresh_pin_indicator(self: AppFrame) -> None:
+        """Update the pin button to reflect whether the current deck is pinned."""
+        if not ACTIVE_GUIDE_FILE.exists():
+            self.sideboard_guide_panel.set_pinned(False)
+            return
+        try:
+            import json
+
+            with ACTIVE_GUIDE_FILE.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            current_hash = self.controller.deck_repo.get_current_decklist_hash()
+            self.sideboard_guide_panel.set_pinned(data.get("deck_hash") == current_hash)
+        except Exception:
+            self.sideboard_guide_panel.set_pinned(False)
 
     def _load_guide_for_current(self: AppFrame) -> None:
         # Use decklist hash so each unique 75 has its own guide
@@ -72,6 +89,7 @@ class SideboardGuideHandlers:
         self.sideboard_guide_panel.set_entries(
             self.sideboard_guide_entries, self.sideboard_exclusions
         )
+        self._refresh_pin_indicator()
 
     def _persist_guide_for_current(self: AppFrame) -> None:
         key = self.controller.deck_repo.get_current_decklist_hash()
@@ -464,6 +482,26 @@ class SideboardGuideHandlers:
             warnings.append(f"Cards not in deck: {', '.join(sorted(missing_cards))}")
 
         return imported_entries, warnings
+
+    def _on_pin_guide(self: AppFrame) -> None:
+        """Pin the current deck's sideboard guide for use in the Opponent Tracker."""
+        deck_hash = self.controller.deck_repo.get_current_decklist_hash()
+        current_deck = self.controller.deck_repo.get_current_deck()
+        deck_name = ""
+        if current_deck:
+            deck_name = current_deck.get("name") or current_deck.get("archetype") or ""
+
+        payload = {"deck_hash": deck_hash, "deck_name": deck_name}
+        try:
+            atomic_write_json(ACTIVE_GUIDE_FILE, payload, indent=2)
+            self.sideboard_guide_panel.set_pinned(True)
+            self._set_status(
+                f"Pinned guide for '{deck_name or deck_hash[:8]}' to Opponent Tracker."
+            )
+            logger.info(f"Pinned guide: hash={deck_hash}, name={deck_name!r}")
+        except OSError as exc:
+            logger.error(f"Failed to save active guide: {exc}")
+            self._set_status("Error: could not pin guide.")
 
     def _parse_card_text(self: AppFrame, text: str) -> dict[str, int]:
         """Parse text like '2x Lightning Bolt, 1x Mountain' into a dict."""

--- a/widgets/identify_opponent.py
+++ b/widgets/identify_opponent.py
@@ -28,6 +28,7 @@ from services.radar_service import RadarData, RadarService, get_radar_service
 from utils.archetype_resolver import find_archetype_by_name
 from utils.atomic_io import atomic_write_json, locked_path
 from utils.constants import (
+    ACTIVE_GUIDE_FILE,
     CONFIG_DIR,
     DARK_BG,
     DARK_PANEL,
@@ -35,6 +36,7 @@ from utils.constants import (
     DECK_MONITOR_CONFIG_FILE,
     FORMAT_OPTIONS,
     GOLDFISH,
+    GUIDE_STORE,
     LIGHT_TEXT,
     MTGGOLDFISH_REQUEST_TIMEOUT_SECONDS,
     OPPONENT_TRACKER_CACHE_TTL_SECONDS,
@@ -48,6 +50,7 @@ from utils.constants import (
 from utils.find_opponent_names import find_opponent_names
 from utils.math_utils import hypergeometric_at_least, hypergeometric_probability
 from widgets.panels.compact_radar_panel import CompactRadarPanel
+from widgets.panels.compact_sideboard_panel import CompactSideboardPanel
 
 LEGACY_DECK_MONITOR_CONFIG = Path("deck_monitor_config.json")
 LEGACY_DECK_MONITOR_CACHE = Path("deck_monitor_cache.json")
@@ -147,6 +150,10 @@ class MTGOpponentDeckSpy(wx.Frame):
         self._last_radar_archetype: str = ""
         self._radar_visible: bool = False
 
+        # Sideboard guide integration
+        self._guide_visible: bool = False
+        self._last_guide_archetype: str = ""
+
         self._load_cache()
         self._load_config()
 
@@ -207,6 +214,11 @@ class MTGOpponentDeckSpy(wx.Frame):
         self.radar_toggle_btn.Bind(wx.EVT_BUTTON, self._toggle_radar_panel)
         controls.Add(self.radar_toggle_btn, 0, wx.RIGHT, OPPONENT_TRACKER_SECTION_PADDING)
 
+        self.guide_toggle_btn = wx.Button(panel, label="Guide")
+        self._stylize_secondary_button(self.guide_toggle_btn)
+        self.guide_toggle_btn.Bind(wx.EVT_BUTTON, self._toggle_guide_panel)
+        controls.Add(self.guide_toggle_btn, 0, wx.RIGHT, OPPONENT_TRACKER_SECTION_PADDING)
+
         close_button = wx.Button(panel, label="Close")
         self._stylize_secondary_button(close_button)
         close_button.Bind(wx.EVT_BUTTON, lambda _evt: self.Close())
@@ -219,6 +231,15 @@ class MTGOpponentDeckSpy(wx.Frame):
         self.radar_panel = CompactRadarPanel(panel)
         sizer.Add(
             self.radar_panel,
+            1,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            OPPONENT_TRACKER_SECTION_PADDING,
+        )
+
+        # Sideboard Guide Panel (initially hidden)
+        self.sideboard_panel = CompactSideboardPanel(panel)
+        sizer.Add(
+            self.sideboard_panel,
             1,
             wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
             OPPONENT_TRACKER_SECTION_PADDING,
@@ -383,6 +404,95 @@ class MTGOpponentDeckSpy(wx.Frame):
             self.radar_toggle_btn.SetLabel("Radar")
         self.Layout()
         self.Fit()
+
+    def _toggle_guide_panel(self, _event: wx.CommandEvent | None = None) -> None:
+        """Toggle sideboard guide panel visibility."""
+        self._guide_visible = not self._guide_visible
+        if self._guide_visible:
+            self.sideboard_panel.Show()
+            self.guide_toggle_btn.SetLabel("Hide Guide")
+            # Load guide if we have an opponent archetype
+            if self.last_seen_decks:
+                self._update_guide_display()
+            else:
+                self.sideboard_panel.set_no_pinned_deck()
+        else:
+            self.sideboard_panel.Hide()
+            self.guide_toggle_btn.SetLabel("Guide")
+        self.Layout()
+        self.Fit()
+
+    def _update_guide_display(self) -> None:
+        """Look up the current opponent archetype in the pinned guide and update the panel."""
+        if not self.last_seen_decks:
+            self.sideboard_panel.clear()
+            return
+
+        _format_name, archetype_name = next(iter(self.last_seen_decks.items()))
+        if not archetype_name or archetype_name == "Unknown":
+            self.sideboard_panel.clear()
+            return
+
+        # Load pinned guide
+        if not ACTIVE_GUIDE_FILE.exists():
+            self.sideboard_panel.set_no_pinned_deck()
+            return
+
+        try:
+            with ACTIVE_GUIDE_FILE.open("r", encoding="utf-8") as fh:
+                active = json.load(fh)
+        except Exception as exc:
+            logger.warning(f"Failed to read active guide file: {exc}")
+            self.sideboard_panel.set_no_pinned_deck()
+            return
+
+        deck_hash = active.get("deck_hash", "")
+        if not deck_hash:
+            self.sideboard_panel.set_no_pinned_deck()
+            return
+
+        # Load guide store
+        try:
+            if GUIDE_STORE.exists():
+                with GUIDE_STORE.open("r", encoding="utf-8") as fh:
+                    guide_store = json.load(fh)
+            else:
+                guide_store = {}
+        except Exception as exc:
+            logger.warning(f"Failed to read guide store: {exc}")
+            guide_store = {}
+
+        payload = guide_store.get(deck_hash) or {}
+        entries: list[dict] = payload.get("entries", [])
+        exclusions: list[str] = payload.get("exclusions", [])
+
+        if not entries:
+            self.sideboard_panel.set_no_guide(archetype_name)
+            return
+
+        # Find matching entry (case-insensitive substring match)
+        archetype_lower = archetype_name.lower()
+        match = None
+        for entry in entries:
+            entry_arch = entry.get("archetype", "")
+            if entry_arch in exclusions:
+                continue
+            if entry_arch.lower() == archetype_lower:
+                match = entry
+                break
+        if match is None:
+            for entry in entries:
+                entry_arch = entry.get("archetype", "")
+                if entry_arch in exclusions:
+                    continue
+                if archetype_lower in entry_arch.lower() or entry_arch.lower() in archetype_lower:
+                    match = entry
+                    break
+
+        if match is None:
+            self.sideboard_panel.set_no_guide(archetype_name)
+        else:
+            self.sideboard_panel.display_entry(match, archetype_name)
 
     def _apply_preset(self, deck_size: int, cards_drawn: int) -> None:
         """Apply a preset to the calculator inputs and run calculation."""
@@ -560,6 +670,8 @@ class MTGOpponentDeckSpy(wx.Frame):
         self.current_radar = None
         self._last_radar_archetype = ""
         self.radar_panel.clear()
+        self._last_guide_archetype = ""
+        self.sideboard_panel.clear()
 
     # ------------------------------------------------------------------ Event handlers -------------------------------------------------------
     def _manual_refresh(self, force: bool = False) -> None:
@@ -608,6 +720,8 @@ class MTGOpponentDeckSpy(wx.Frame):
             # Trigger radar loading after successful deck lookup
             if self.last_seen_decks:
                 wx.CallAfter(self._trigger_radar_load)
+                if self._guide_visible:
+                    wx.CallAfter(self._update_guide_display)
 
         self.status_label.SetLabel(f"Match detected: vs {self.player_name}")
         self.status_label.Wrap(320)
@@ -673,6 +787,7 @@ class MTGOpponentDeckSpy(wx.Frame):
             "screen_pos": position,
             "calculator_visible": self._calculator_visible,
             "radar_visible": self._radar_visible,
+            "guide_visible": self._guide_visible,
         }
         try:
             atomic_write_json(DECK_MONITOR_CONFIG_FILE, config, indent=4)
@@ -706,6 +821,7 @@ class MTGOpponentDeckSpy(wx.Frame):
         self._saved_position = data.get("screen_pos")
         self._calculator_visible = data.get("calculator_visible", False)
         self._radar_visible = data.get("radar_visible", False)
+        self._guide_visible = data.get("guide_visible", False)
 
     def _save_cache(self) -> None:
         payload = {"entries": self.cache}
@@ -759,6 +875,12 @@ class MTGOpponentDeckSpy(wx.Frame):
         if getattr(self, "_radar_visible", False):
             self.radar_panel.Show()
             self.radar_toggle_btn.SetLabel("Hide Radar")
+            self.Layout()
+            self.Fit()
+        # Restore guide panel visibility
+        if getattr(self, "_guide_visible", False):
+            self.sideboard_panel.Show()
+            self.guide_toggle_btn.SetLabel("Hide Guide")
             self.Layout()
             self.Fit()
 

--- a/widgets/panels/compact_sideboard_panel.py
+++ b/widgets/panels/compact_sideboard_panel.py
@@ -1,0 +1,161 @@
+"""
+Compact Sideboard Panel - Shows matchup-specific sideboarding plan in the opponent tracker.
+
+Displays the cards to side in/out and notes for the detected opponent archetype,
+sourced from the pinned deck's sideboard guide.
+"""
+
+from __future__ import annotations
+
+import wx
+from loguru import logger
+
+from utils.constants import DARK_BG, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+
+
+class CompactSideboardPanel(wx.Panel):
+    """Compact panel for displaying a single sideboard guide entry in the opponent tracker."""
+
+    def __init__(self, parent: wx.Window):
+        super().__init__(parent)
+        self.SetBackgroundColour(DARK_PANEL)
+
+        self._current_entry: dict | None = None
+        self._play_first: bool = True  # True = on play, False = on draw
+
+        self._build_ui()
+        self.Hide()
+
+    def _build_ui(self) -> None:
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(sizer)
+
+        # Header row: archetype label + play/draw toggle
+        header = wx.BoxSizer(wx.HORIZONTAL)
+        sizer.Add(header, 0, wx.EXPAND | wx.ALL, 4)
+
+        self.header_label = wx.StaticText(self, label="Guide: —")
+        self.header_label.SetForegroundColour(LIGHT_TEXT)
+        font = self.header_label.GetFont()
+        self.header_label.SetFont(font.Bold())
+        header.Add(self.header_label, 1, wx.ALIGN_CENTER_VERTICAL)
+
+        self.toggle_btn = wx.Button(self, label="On Draw", size=(70, 22))
+        self.toggle_btn.SetBackgroundColour(DARK_BG)
+        self.toggle_btn.SetForegroundColour(LIGHT_TEXT)
+        self.toggle_btn.Bind(wx.EVT_BUTTON, self._on_toggle_play_draw)
+        self.toggle_btn.Hide()
+        header.Add(self.toggle_btn, 0, wx.LEFT, 4)
+
+        # Status label (no guide found / no pinned deck)
+        self.status_label = wx.StaticText(self, label="")
+        self.status_label.SetForegroundColour(SUBDUED_TEXT)
+        sizer.Add(self.status_label, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 4)
+
+        # Cards list
+        self.card_list = wx.ListBox(self, style=wx.LB_SINGLE)
+        self.card_list.SetBackgroundColour(DARK_BG)
+        self.card_list.SetForegroundColour(LIGHT_TEXT)
+        sizer.Add(self.card_list, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 4)
+
+    # ============= Public API =============
+
+    def display_entry(self, entry: dict, archetype_name: str) -> None:
+        """
+        Display a sideboard guide entry.
+
+        Args:
+            entry: Guide entry dict with play_out, play_in, draw_out, draw_in, notes keys
+            archetype_name: Name of the opponent archetype
+        """
+        self._current_entry = entry
+        self.header_label.SetLabel(f"Guide: {archetype_name}")
+        self.toggle_btn.Show()
+        self._populate_list()
+        self.Show()
+        self.GetParent().Layout()
+        logger.debug(f"Compact sideboard guide displayed for: {archetype_name}")
+
+    def clear(self) -> None:
+        """Clear the panel and hide it."""
+        self._current_entry = None
+        self.header_label.SetLabel("Guide: —")
+        self.status_label.SetLabel("")
+        self.card_list.Clear()
+        self.toggle_btn.Hide()
+        self.Hide()
+        self.GetParent().Layout()
+
+    def set_no_guide(self, archetype_name: str) -> None:
+        """
+        Show a 'no guide found' state for the given archetype.
+
+        Args:
+            archetype_name: Name of the opponent archetype that wasn't found in the guide
+        """
+        self._current_entry = None
+        self.header_label.SetLabel(f"Guide: {archetype_name}")
+        self.status_label.SetLabel("No guide entry for this matchup.")
+        self.card_list.Clear()
+        self.toggle_btn.Hide()
+        self.Show()
+        self.GetParent().Layout()
+
+    def set_no_pinned_deck(self) -> None:
+        """Show state when no deck has been pinned yet."""
+        self._current_entry = None
+        self.header_label.SetLabel("Guide: —")
+        self.status_label.SetLabel("Pin a deck's guide in the Deck Selector to enable this.")
+        self.card_list.Clear()
+        self.toggle_btn.Hide()
+        self.Show()
+        self.GetParent().Layout()
+
+    # ============= Private Methods =============
+
+    def _on_toggle_play_draw(self, _event: wx.CommandEvent) -> None:
+        self._play_first = not self._play_first
+        self.toggle_btn.SetLabel("On Draw" if self._play_first else "On Play")
+        self._populate_list()
+
+    def _populate_list(self) -> None:
+        entry = self._current_entry
+        if not entry:
+            return
+
+        self.card_list.Clear()
+        self.status_label.SetLabel("")
+
+        if self._play_first:
+            out_cards = entry.get("play_out", {})
+            in_cards = entry.get("play_in", {})
+            scenario = "On Play"
+        else:
+            out_cards = entry.get("draw_out", {})
+            in_cards = entry.get("draw_in", {})
+            scenario = "On Draw"
+
+        self.card_list.Append(f"─── {scenario} ───")
+
+        if out_cards:
+            self.card_list.Append("  OUT:")
+            for name, qty in sorted(out_cards.items()):
+                self.card_list.Append(f"    -{qty} {name}")
+
+        if in_cards:
+            self.card_list.Append("  IN:")
+            for name, qty in sorted(in_cards.items()):
+                self.card_list.Append(f"    +{qty} {name}")
+
+        if not out_cards and not in_cards:
+            self.card_list.Append("  (no changes)")
+
+        notes = entry.get("notes", "").strip()
+        if notes:
+            self.card_list.Append("")
+            self.card_list.Append("Notes:")
+            for line in notes.splitlines():
+                self.card_list.Append(f"  {line}")
+
+
+__all__ = ["CompactSideboardPanel"]

--- a/widgets/panels/sideboard_guide_panel.py
+++ b/widgets/panels/sideboard_guide_panel.py
@@ -80,32 +80,32 @@ class SideboardGuidePanel(wx.Panel):
         buttons = wx.BoxSizer(wx.HORIZONTAL)
         sizer.Add(buttons, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 6)
 
-        self.add_btn = wx.Button(self, label="Add Entry")
+        self.add_btn = wx.Button(self, label="Add")
         stylize_button(self.add_btn)
         self.add_btn.Bind(wx.EVT_BUTTON, self._on_add_clicked)
         buttons.Add(self.add_btn, 0, wx.RIGHT, 6)
 
-        self.edit_btn = wx.Button(self, label="Edit Entry")
+        self.edit_btn = wx.Button(self, label="Edit")
         stylize_button(self.edit_btn)
         self.edit_btn.Bind(wx.EVT_BUTTON, self._on_edit_clicked)
         buttons.Add(self.edit_btn, 0, wx.RIGHT, 6)
 
-        self.remove_btn = wx.Button(self, label="Remove Entry")
+        self.remove_btn = wx.Button(self, label="Delete")
         stylize_button(self.remove_btn)
         self.remove_btn.Bind(wx.EVT_BUTTON, self._on_remove_clicked)
         buttons.Add(self.remove_btn, 0, wx.RIGHT, 6)
 
-        self.exclusions_btn = wx.Button(self, label="Exclude Archetypes")
+        self.exclusions_btn = wx.Button(self, label="Exclusions")
         stylize_button(self.exclusions_btn)
         self.exclusions_btn.Bind(wx.EVT_BUTTON, self._on_exclusions_clicked)
         buttons.Add(self.exclusions_btn, 0, wx.RIGHT, 6)
 
-        self.export_btn = wx.Button(self, label="Export CSV")
+        self.export_btn = wx.Button(self, label="Export")
         stylize_button(self.export_btn)
         self.export_btn.Bind(wx.EVT_BUTTON, self._on_export_clicked)
         buttons.Add(self.export_btn, 0, wx.RIGHT, 6)
 
-        self.import_btn = wx.Button(self, label="Import CSV")
+        self.import_btn = wx.Button(self, label="Import")
         stylize_button(self.import_btn)
         self.import_btn.Bind(wx.EVT_BUTTON, self._on_import_clicked)
         buttons.Add(self.import_btn, 0, wx.RIGHT, 6)
@@ -114,6 +114,7 @@ class SideboardGuidePanel(wx.Panel):
 
         self.pin_btn = wx.Button(self, label="Pin for Tracker")
         stylize_button(self.pin_btn)
+        self.pin_btn.SetBackgroundColour(wx.Colour(140, 90, 210))
         self.pin_btn.SetToolTip(
             "Pin this deck's sideboard guide so the Opponent Tracker can look up matchup plans automatically."
         )

--- a/widgets/panels/sideboard_guide_panel.py
+++ b/widgets/panels/sideboard_guide_panel.py
@@ -28,6 +28,7 @@ class SideboardGuidePanel(wx.Panel):
         on_edit_exclusions: Callable[[], None],
         on_export_csv: Callable[[], None],
         on_import_csv: Callable[[], None],
+        on_pin_guide: Callable[[], None] | None = None,
     ):
         """
         Initialize the sideboard guide panel.
@@ -40,6 +41,7 @@ class SideboardGuidePanel(wx.Panel):
             on_edit_exclusions: Callback for editing archetype exclusions
             on_export_csv: Callback for exporting guide to CSV
             on_import_csv: Callback for importing guide from CSV
+            on_pin_guide: Callback for pinning the current deck's guide for the opponent tracker
         """
         super().__init__(parent)
         self.SetBackgroundColour(DARK_PANEL)
@@ -50,6 +52,7 @@ class SideboardGuidePanel(wx.Panel):
         self.on_edit_exclusions = on_edit_exclusions
         self.on_export_csv = on_export_csv
         self.on_import_csv = on_import_csv
+        self.on_pin_guide = on_pin_guide
 
         self.entries: list[dict[str, str]] = []
         self.exclusions: list[str] = []
@@ -105,9 +108,19 @@ class SideboardGuidePanel(wx.Panel):
         self.import_btn = wx.Button(self, label="Import CSV")
         stylize_button(self.import_btn)
         self.import_btn.Bind(wx.EVT_BUTTON, self._on_import_clicked)
-        buttons.Add(self.import_btn, 0)
+        buttons.Add(self.import_btn, 0, wx.RIGHT, 6)
 
         buttons.AddStretchSpacer(1)
+
+        self.pin_btn = wx.Button(self, label="Pin for Tracker")
+        stylize_button(self.pin_btn)
+        self.pin_btn.SetToolTip(
+            "Pin this deck's sideboard guide so the Opponent Tracker can look up matchup plans automatically."
+        )
+        self.pin_btn.Bind(wx.EVT_BUTTON, self._on_pin_clicked)
+        if self.on_pin_guide is None:
+            self.pin_btn.Disable()
+        buttons.Add(self.pin_btn, 0)
 
         # Exclusions label
         self.exclusions_label = wx.StaticText(self, label="Exclusions: —")
@@ -250,3 +263,20 @@ class SideboardGuidePanel(wx.Panel):
     def _on_import_clicked(self, _event: wx.Event) -> None:
         """Handle Import CSV button click."""
         self.on_import_csv()
+
+    def _on_pin_clicked(self, _event: wx.Event) -> None:
+        """Handle Pin for Tracker button click."""
+        if self.on_pin_guide:
+            self.on_pin_guide()
+
+    def set_pinned(self, pinned: bool) -> None:
+        """
+        Update the pin button label to reflect current pinned state.
+
+        Args:
+            pinned: True if this deck's guide is currently pinned
+        """
+        if pinned:
+            self.pin_btn.SetLabel("Pinned \u2713")
+        else:
+            self.pin_btn.SetLabel("Pin for Tracker")


### PR DESCRIPTION
Closes #154

## Summary
- **Pin for Tracker** button on the Sideboard Guide tab saves the current deck's guide as the "active" guide (stored in `config/active_guide.json`)
- **Guide** toggle button in the Opponent Tracker shows a compact sideboard panel with cards to side in/out for the detected opponent archetype
- Archetype matching uses case-insensitive exact match, falling back to substring match
- Play/Draw toggle lets the user switch between on-play and on-draw sideboard plans
- Guide panel visibility is persisted across sessions in `deck_monitor_config.json`

## Test plan
- [ ] Open Deck Selector, load a deck with sideboard guide entries, navigate to Sideboard Guide tab → "Pin for Tracker" button is present; clicking it shows "Pinned ✓" label and updates status bar
- [ ] Re-loading the same deck shows "Pinned ✓"; loading a different deck shows "Pin for Tracker"
- [ ] Open Opponent Tracker → "Guide" button is present in the toolbar row
- [ ] Without a pinned deck, clicking "Guide" shows "Pin a deck's guide in the Deck Selector to enable this."
- [ ] With a pinned deck and a detected opponent whose archetype matches a guide entry, the sideboard plan (Out/In cards + notes) is displayed
- [ ] Play/Draw toggle switches between scenarios
- [ ] No matching guide entry shows "No guide entry for this matchup."

🤖 Generated with [Claude Code](https://claude.com/claude-code)