### PR TITLE
fix: handle unloaded card manager in session restore (#263)

### DIFF
--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -151,7 +151,7 @@ class AppController:
         on_error: Callable[[Exception], None],
         on_status: Callable[[str], None],
     ) -> None:
-        if self.card_repo.get_card_manager() or self.card_repo.is_card_data_loading():
+        if self.card_repo.is_card_data_loaded() or self.card_repo.is_card_data_loading():
             return
 
         self.card_repo.set_card_data_loading(True)

--- a/repositories/card_repository.py
+++ b/repositories/card_repository.py
@@ -126,7 +126,7 @@ class CardRepository:
 
     def is_card_data_loaded(self) -> bool:
         """Check if card data has been loaded."""
-        return self.card_data_manager._cards is not None
+        return self._card_data_manager is not None and self._card_data_manager.is_loaded
 
     def load_card_data(self, force: bool = False) -> bool:
         """
@@ -386,7 +386,7 @@ class CardRepository:
         Returns:
             Initialized CardDataManager
         """
-        if not force and self._card_data_manager is not None:
+        if not force and self._card_data_manager is not None and self._card_data_manager.is_loaded:
             return self._card_data_manager
 
         from utils.card_data import load_card_manager

--- a/tests/test_card_repository.py
+++ b/tests/test_card_repository.py
@@ -14,6 +14,7 @@ def mock_card_manager():
     """Mock CardDataManager for testing."""
     manager = SimpleNamespace()
     manager._cards = {"Lightning Bolt": {"name": "Lightning Bolt", "cmc": 1}}
+    manager.is_loaded = True
     manager.get_card = Mock(return_value={"name": "Lightning Bolt", "mana_cost": "{R}", "cmc": 1})
     manager.search_cards = Mock(
         return_value=[
@@ -116,6 +117,7 @@ def test_is_card_data_loaded_false():
     """Test checking when card data is not loaded."""
     manager = SimpleNamespace()
     manager._cards = None
+    manager.is_loaded = False
     repo = CardRepository(card_data_manager=manager)
 
     assert repo.is_card_data_loaded() is False

--- a/utils/card_data.py
+++ b/utils/card_data.py
@@ -193,6 +193,11 @@ class CardDataManager:
                 formats.append(fmt)
         return sorted(formats)
 
+    @property
+    def is_loaded(self) -> bool:
+        """Return True if card data has been loaded into memory."""
+        return self._cards is not None
+
     def _require_cards(self) -> None:
         if self._cards is None:
             raise RuntimeError("Card data not loaded; call ensure_latest first")

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -594,7 +594,9 @@ class DeckStatsPanel(wx.Panel):
         lands = mdfcs = 0
         for entry in self.zone_cards.get("main", []):
             qty = entry["qty"]
-            meta = self.card_manager.get_card(entry["name"]) if self._card_data_available() else None
+            meta = (
+                self.card_manager.get_card(entry["name"]) if self._card_data_available() else None
+            )
             type_line = (meta.get("type_line") or "").lower() if meta else ""
             back_type_line = (meta.get("back_type_line") or "").lower() if meta else ""
             if "land" in type_line:

--- a/widgets/panels/deck_stats_panel.py
+++ b/widgets/panels/deck_stats_panel.py
@@ -587,11 +587,14 @@ class DeckStatsPanel(wx.Panel):
 
     # ── Private helpers ─────────────────────────────────────────────────────
 
+    def _card_data_available(self) -> bool:
+        return self.card_manager is not None and self.card_manager.is_loaded
+
     def _count_lands(self) -> tuple[int, int]:
         lands = mdfcs = 0
         for entry in self.zone_cards.get("main", []):
             qty = entry["qty"]
-            meta = self.card_manager.get_card(entry["name"]) if self.card_manager else None
+            meta = self.card_manager.get_card(entry["name"]) if self._card_data_available() else None
             type_line = (meta.get("type_line") or "").lower() if meta else ""
             back_type_line = (meta.get("back_type_line") or "").lower() if meta else ""
             if "land" in type_line:
@@ -602,7 +605,7 @@ class DeckStatsPanel(wx.Panel):
 
     def _curve_items(self) -> list[tuple[str, str, float, str, str]]:
         """Build mana curve data items."""
-        if not self.card_manager:
+        if not self._card_data_available():
             return []
 
         counts: Counter[str] = Counter()
@@ -651,7 +654,7 @@ class DeckStatsPanel(wx.Panel):
 
     def _color_items(self) -> list[tuple[str, str, float, str, str]]:
         """Build color share data items."""
-        if not self.card_manager:
+        if not self._card_data_available():
             return []
 
         totals: Counter[str] = Counter()
@@ -681,7 +684,7 @@ class DeckStatsPanel(wx.Panel):
         counts: Counter[str] = Counter()
         for entry in self.zone_cards.get("main", []):
             type_line = ""
-            if self.card_manager:
+            if self._card_data_available():
                 meta = self.card_manager.get_card(entry["name"])
                 type_line = (meta.get("type_line") or "") if meta else ""
 


### PR DESCRIPTION
## Summary
- Fixes `RuntimeError: Card data not loaded; call ensure_latest first` thrown from `_restore_session_state` when the session is restored before card data finishes loading
- Root cause: the `card_data_manager` property in `CardRepository` auto-creates an unloaded `CardDataManager()` when accessed, which then poisons `ensure_card_data_loaded()` (it returned early with the unloaded manager) and `is_card_data_loaded()` (it triggered the auto-creation)
- Defense-in-depth: `DeckStatsPanel` now treats an unloaded manager the same as no manager, so partial/unloaded card data during startup is a gracefully handled state

## Changes
- `CardDataManager.is_loaded` property — public way to check if `ensure_latest` has been called
- `CardRepository.is_card_data_loaded()` — no longer calls the auto-creating property; reads `_card_data_manager` directly
- `CardRepository.ensure_card_data_loaded()` — early return now requires `is_loaded` to be True (not just non-None)
- `AppController.ensure_card_data_loaded()` — uses `is_card_data_loaded()` instead of `get_card_manager()` so an unloaded auto-created manager doesn't block the background load
- `DeckStatsPanel._card_data_available()` — guards all `get_card()` call sites; returns `False` for unloaded managers

## Test plan
- [ ] All existing tests pass (`pytest tests/ -q --ignore=tests/ui --ignore=tests/test_gamelog_parser.py`)
- [ ] Start app with a saved deck in builder mode — deck should render without exception once card data loads
- [ ] Check logs: no `RuntimeError: Card data not loaded` in `_restore_session_state`

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)