### PR TITLE
perf: move startup collection cache load off the UI thread

### DIFF
--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -486,14 +486,20 @@ class AppController:
             force=force_archetypes,
         )
 
-        # Step 3: Load collection from cache (non-blocking)
-        success, info = self.load_collection_from_cache(deck_save_dir)
-        if success and info:
-            if callbacks:
-                callbacks.on_collection_loaded(info)
-        else:
-            if callbacks:
-                callbacks.on_collection_not_found()
+        # Step 3: Load collection from cache (background thread)
+        def _load_collection():
+            return self.load_collection_from_cache(deck_save_dir)
+
+        def _on_collection_load_done(result: tuple[bool, dict[str, Any] | None]):
+            success, info = result
+            if success and info:
+                if callbacks:
+                    callbacks.on_collection_loaded(info)
+            else:
+                if callbacks:
+                    callbacks.on_collection_not_found()
+
+        self._worker.submit(_load_collection, on_success=_on_collection_load_done)
 
         # Step 4: Check and download bulk data if needed (non-blocking)
         self.check_and_download_bulk_data()


### PR DESCRIPTION
Closes #269

## Summary
- Wraps `load_collection_from_cache()` in `BackgroundWorker.submit()` inside `run_initial_loads()` so JSON parsing of the collection cache no longer blocks the UI thread at startup
- The `on_success` callback dispatches to `on_collection_loaded` / `on_collection_not_found`, which already marshal to the UI thread via `wx.CallAfter`
- Fixes the misleading `# non-blocking` comment

## Test plan
- [ ] Existing test suite passes (no regressions)
- [ ] App starts and collection label populates correctly after startup
- [ ] No UI freeze on startup with a large collection cache file

🤖 Generated with [Claude Code](https://claude.com/claude-code)