### PR TITLE
feat: add empty state to Sideboard Guide tab (issue #282)

### DIFF
--- a/widgets/panels/sideboard_guide_panel.py
+++ b/widgets/panels/sideboard_guide_panel.py
@@ -92,7 +92,7 @@ class SideboardGuidePanel(wx.Panel):
         empty_sizer.AddStretchSpacer(1)
         empty_label = wx.StaticText(
             self.empty_state_panel,
-            label='No matchup notes yet.\nClick "Add" or right-click an archetype to create a sideboard guide entry.',
+            label='No matchup notes yet.\nClick "Add" to create a sideboard guide entry.',
             style=wx.ALIGN_CENTRE_HORIZONTAL,
         )
         empty_label.SetForegroundColour(SUBDUED_TEXT)

--- a/widgets/panels/sideboard_guide_panel.py
+++ b/widgets/panels/sideboard_guide_panel.py
@@ -65,6 +65,7 @@ class SideboardGuidePanel(wx.Panel):
         self.exclusions: list[str] = []
 
         self._build_ui()
+        self._refresh_view()
 
     def _build_ui(self) -> None:
         """Build the panel UI."""
@@ -82,6 +83,23 @@ class SideboardGuidePanel(wx.Panel):
         self.guide_view.SetBackgroundColour(DARK_ALT)
         self.guide_view.SetForegroundColour(LIGHT_TEXT)
         sizer.Add(self.guide_view, 1, wx.EXPAND | wx.ALL, PADDING_MD)
+
+        # Empty state panel (shown when there are no entries)
+        self.empty_state_panel = wx.Panel(self)
+        self.empty_state_panel.SetBackgroundColour(DARK_ALT)
+        empty_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.empty_state_panel.SetSizer(empty_sizer)
+        empty_sizer.AddStretchSpacer(1)
+        empty_label = wx.StaticText(
+            self.empty_state_panel,
+            label='No matchup notes yet.\nClick "Add" or right-click an archetype to create a sideboard guide entry.',
+            style=wx.ALIGN_CENTRE_HORIZONTAL,
+        )
+        empty_label.SetForegroundColour(SUBDUED_TEXT)
+        empty_sizer.Add(empty_label, 0, wx.ALIGN_CENTER | wx.ALL, PADDING_MD)
+        empty_sizer.AddStretchSpacer(1)
+        self.empty_state_panel.Hide()
+        sizer.Add(self.empty_state_panel, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_MD)
 
         # Button row
         buttons = wx.BoxSizer(wx.HORIZONTAL)
@@ -204,6 +222,7 @@ class SideboardGuidePanel(wx.Panel):
         self.guide_view.DeleteAllItems()
 
         # Add entries (skip excluded archetypes)
+        visible_entries = 0
         for entry in self.entries:
             if entry.get("archetype") in self.exclusions:
                 continue
@@ -217,6 +236,13 @@ class SideboardGuidePanel(wx.Panel):
                     entry.get("notes", ""),
                 ]
             )
+            visible_entries += 1
+
+        # Toggle empty state visibility
+        is_empty = visible_entries == 0
+        self.guide_view.Show(not is_empty)
+        self.empty_state_panel.Show(is_empty)
+        self.Layout()
 
         # Update exclusions label
         if self.exclusions:


### PR DESCRIPTION
## Summary
- When the Sideboard Guide has no entries, replace the blank table with an instructional message: *"No matchup notes yet. Click 'Add' or right-click an archetype to create a sideboard guide entry."*
- The empty-state panel is shown/hidden automatically in `_refresh_view` based on whether any visible entries exist (accounting for exclusions)
- The `guide_view` table is hidden while the empty state is shown and vice versa

Closes #282

## Test plan
- [ ] Open a deck with no sideboard guide entries → empty state message visible
- [ ] Add a guide entry → message disappears, table appears with the new row
- [ ] Delete the last entry → message reappears
- [ ] Exclusions that filter out all entries → empty state shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)