### PR TITLE
fix: tighten left search panel layout for better vertical density

### DIFF
--- a/services/search_service.py
+++ b/services/search_service.py
@@ -233,12 +233,12 @@ class SearchService:
                     continue
 
             # Mana value filter
-            if mv_value is not None and mv_cmp != "Any":
+            if mv_value is not None and mv_cmp not in ("Any", "-"):
                 if not matches_mana_value(card.get("mana_value"), mv_value, mv_cmp):
                     continue
 
             # Color identity filter (lands are treated as colorless)
-            if selected_colors and color_mode != "Any":
+            if selected_colors and color_mode not in ("Any", "-"):
                 if not matches_color_filter(
                     self._get_card_colors_for_filter(card), selected_colors, color_mode
                 ):

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -154,74 +154,74 @@ def test_matches_mana_value_fractional():
 
 
 def test_matches_color_filter_any_mode():
-    """Test color filter with 'Any' mode (no filtering)."""
-    assert matches_color_filter(["G"], ["R", "U"], "Any") is True
-    assert matches_color_filter([], ["W"], "Any") is True
+    """Test color filter with '-' mode (no filtering)."""
+    assert matches_color_filter(["G"], ["R", "U"], "-") is True
+    assert matches_color_filter([], ["W"], "-") is True
 
 
 def test_matches_color_filter_empty_selected():
     """Test color filter with no selected colors."""
-    assert matches_color_filter(["G", "U"], [], "At least") is True
-    assert matches_color_filter(["G", "U"], [], "Exactly") is True
+    assert matches_color_filter(["G", "U"], [], "≥") is True
+    assert matches_color_filter(["G", "U"], [], "=") is True
 
 
 def test_matches_color_filter_at_least_single():
-    """Test 'At least' mode with single color."""
-    assert matches_color_filter(["G"], ["G"], "At least") is True
-    assert matches_color_filter(["G", "U"], ["G"], "At least") is True
-    assert matches_color_filter(["U"], ["G"], "At least") is False
+    """Test '≥' (at least) mode with single color."""
+    assert matches_color_filter(["G"], ["G"], "≥") is True
+    assert matches_color_filter(["G", "U"], ["G"], "≥") is True
+    assert matches_color_filter(["U"], ["G"], "≥") is False
 
 
 def test_matches_color_filter_at_least_multiple():
-    """Test 'At least' mode with multiple colors."""
-    assert matches_color_filter(["G", "U"], ["G", "U"], "At least") is True
-    assert matches_color_filter(["W", "U", "B", "R", "G"], ["G", "U"], "At least") is True
-    assert matches_color_filter(["G"], ["G", "U"], "At least") is False
+    """Test '≥' (at least) mode with multiple colors."""
+    assert matches_color_filter(["G", "U"], ["G", "U"], "≥") is True
+    assert matches_color_filter(["W", "U", "B", "R", "G"], ["G", "U"], "≥") is True
+    assert matches_color_filter(["G"], ["G", "U"], "≥") is False
 
 
 def test_matches_color_filter_exactly_single():
-    """Test 'Exactly' mode with single color."""
-    assert matches_color_filter(["G"], ["G"], "Exactly") is True
-    assert matches_color_filter(["G", "U"], ["G"], "Exactly") is False
-    assert matches_color_filter(["U"], ["G"], "Exactly") is False
+    """Test '=' (exactly) mode with single color."""
+    assert matches_color_filter(["G"], ["G"], "=") is True
+    assert matches_color_filter(["G", "U"], ["G"], "=") is False
+    assert matches_color_filter(["U"], ["G"], "=") is False
 
 
 def test_matches_color_filter_exactly_multiple():
-    """Test 'Exactly' mode with multiple colors."""
-    assert matches_color_filter(["G", "U"], ["G", "U"], "Exactly") is True
-    assert matches_color_filter(["U", "G"], ["G", "U"], "Exactly") is True
-    assert matches_color_filter(["G", "U", "R"], ["G", "U"], "Exactly") is False
-    assert matches_color_filter(["G"], ["G", "U"], "Exactly") is False
+    """Test '=' (exactly) mode with multiple colors."""
+    assert matches_color_filter(["G", "U"], ["G", "U"], "=") is True
+    assert matches_color_filter(["U", "G"], ["G", "U"], "=") is True
+    assert matches_color_filter(["G", "U", "R"], ["G", "U"], "=") is False
+    assert matches_color_filter(["G"], ["G", "U"], "=") is False
 
 
 def test_matches_color_filter_not_these():
-    """Test 'Not these' mode."""
-    assert matches_color_filter(["R"], ["G", "U"], "Not these") is True
-    assert matches_color_filter(["G"], ["G", "U"], "Not these") is False
-    assert matches_color_filter(["G", "U"], ["G"], "Not these") is False
-    assert matches_color_filter(["W", "B"], ["R", "G"], "Not these") is True
+    """Test '≠' (not these) mode."""
+    assert matches_color_filter(["R"], ["G", "U"], "≠") is True
+    assert matches_color_filter(["G"], ["G", "U"], "≠") is False
+    assert matches_color_filter(["G", "U"], ["G"], "≠") is False
+    assert matches_color_filter(["W", "B"], ["R", "G"], "≠") is True
 
 
 def test_matches_color_filter_colorless():
     """Test color filter with colorless cards."""
     # Empty color list should be treated as colorless "C"
-    assert matches_color_filter([], ["C"], "At least") is True
-    assert matches_color_filter([], ["C"], "Exactly") is True
-    assert matches_color_filter([], ["G"], "Not these") is True
+    assert matches_color_filter([], ["C"], "≥") is True
+    assert matches_color_filter([], ["C"], "=") is True
+    assert matches_color_filter([], ["G"], "≠") is True
 
 
 def test_matches_color_filter_case_insensitive():
     """Test that color filter is case insensitive."""
-    assert matches_color_filter(["g"], ["G"], "At least") is True
-    assert matches_color_filter(["G"], ["g"], "At least") is True
-    assert matches_color_filter(["g", "u"], ["G", "U"], "Exactly") is True
+    assert matches_color_filter(["g"], ["G"], "≥") is True
+    assert matches_color_filter(["G"], ["g"], "≥") is True
+    assert matches_color_filter(["g", "u"], ["G", "U"], "=") is True
 
 
 def test_matches_color_filter_colorless_not_these():
-    """Test 'Not these' mode with colorless."""
+    """Test '≠' mode with colorless."""
     # Colorless card should not match any color
-    assert matches_color_filter([], ["G"], "Not these") is True
-    assert matches_color_filter([], ["W", "U", "B", "R", "G"], "Not these") is True
+    assert matches_color_filter([], ["G"], "≠") is True
+    assert matches_color_filter([], ["W", "U", "B", "R", "G"], "≠") is True
 
 
 def test_matches_color_filter_unknown_mode():

--- a/utils/constants/ui_layout.py
+++ b/utils/constants/ui_layout.py
@@ -50,7 +50,7 @@ GUIDE_COL_NOTES_WIDTH = 180  # width of Notes column (px)
 # Deck Builder Panel — search results list layout
 BUILDER_NAME_COL_MIN_WIDTH = 40  # minimum width of the Name column (px)
 BUILDER_NAME_COL_DEFAULT_WIDTH = 180  # initial width of the Name column (px)
-BUILDER_FORMATS_GRID_COLS = 2  # number of columns in the formats FlexGridSizer
+BUILDER_FORMATS_GRID_COLS = 3  # number of columns in the formats FlexGridSizer
 BUILDER_FORMATS_GRID_HGAP = 8  # horizontal gap between format checkbox cells (px)
 BUILDER_MANA_ALL_BTN_SIZE = (52, 28)  # size of the "All" mana keyboard button (px)
 

--- a/utils/search_filters.py
+++ b/utils/search_filters.py
@@ -38,16 +38,16 @@ def matches_mana_value(card_value: Any, target: float, comparator: str) -> bool:
 
 
 def matches_color_filter(card_colors: list[str], selected: list[str], mode: str) -> bool:
-    if not selected or mode == "Any":
+    if not selected or mode in ("Any", "-"):
         return True
     selected_set = {c.upper() for c in selected}
     card_set = {c.upper() for c in card_colors if c}
     if not card_set:
         card_set = {"C"}
-    if mode == "At least":
+    if mode in ("At least", "≥"):
         return selected_set.issubset(card_set)
-    if mode == "Exactly":
+    if mode in ("Exactly", "="):
         return card_set == selected_set
-    if mode == "Not these":
+    if mode in ("Not these", "≠"):
         return selected_set.isdisjoint(card_set)
     return True

--- a/widgets/panels/deck_builder_panel.py
+++ b/widgets/panels/deck_builder_panel.py
@@ -7,8 +7,6 @@ import wx
 
 from services.radar_service import RadarData
 from utils.constants import (
-    BUILDER_FORMATS_GRID_COLS,
-    BUILDER_FORMATS_GRID_HGAP,
     BUILDER_MANA_ALL_BTN_SIZE,
     BUILDER_MANA_CANVAS_WIDTH,
     BUILDER_MANA_ICON_GAP,
@@ -234,8 +232,8 @@ class DeckBuilderPanel(wx.Panel):
         self.mana_exact_cb: wx.CheckBox | None = None
         self.mv_comparator: wx.Choice | None = None
         self.mv_value: wx.TextCtrl | None = None
-        self.format_checks: list[wx.CheckBox] = []
-        self.color_checks: dict[str, wx.CheckBox] = {}
+        self.format_choice: wx.Choice | None = None
+        self.color_checks: dict[str, wx.ToggleButton] = {}
         self.color_mode_choice: wx.Choice | None = None
         self.text_mode_choice: wx.Choice | None = None
         self.results_ctrl: _SearchResultsView | None = None
@@ -286,25 +284,21 @@ class DeckBuilderPanel(wx.Panel):
             stylize_textctrl(ctrl)
             ctrl.SetHint(hint)
             ctrl.Bind(wx.EVT_TEXT, self._on_filters_changed)
-            sizer.Add(ctrl, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
             self.inputs[key] = ctrl
 
-            # Oracle Text field gets a match-mode selector
+            # Oracle Text field gets match-mode selector on same row as input
             if key == "text":
-                text_match_row = wx.BoxSizer(wx.HORIZONTAL)
-                text_match_label = wx.StaticText(self, label="Match")
-                stylize_label(text_match_label, True)
-                text_match_row.Add(
-                    text_match_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, PADDING_MD
-                )
-                text_mode_choice = wx.Choice(self, choices=["Exact phrase", "All words"])
+                text_row = wx.BoxSizer(wx.HORIZONTAL)
+                text_row.Add(ctrl, 1, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, PADDING_SM)
+                text_mode_choice = wx.Choice(self, choices=["=", "≈"])
                 text_mode_choice.SetSelection(0)
                 stylize_choice(text_mode_choice)
                 self.text_mode_choice = text_mode_choice
                 text_mode_choice.Bind(wx.EVT_CHOICE, self._on_filters_changed)
-                text_match_row.Add(text_mode_choice, 0)
-                text_match_row.AddStretchSpacer(1)
-                sizer.Add(text_match_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_XS)
+                text_row.Add(text_mode_choice, 0, wx.ALIGN_CENTER_VERTICAL)
+                sizer.Add(text_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
+            else:
+                sizer.Add(ctrl, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
 
             # Mana cost field gets extra controls
             if key == "mana":
@@ -341,68 +335,71 @@ class DeckBuilderPanel(wx.Panel):
                 )
 
         # Mana value filter
-        mv_row = wx.BoxSizer(wx.HORIZONTAL)
         mv_label = wx.StaticText(self, label="Mana Value Filter")
         stylize_label(mv_label, True)
-        mv_row.Add(mv_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, PADDING_MD)
-        mv_choice = wx.Choice(self, choices=["Any", "<", "≤", "=", "≥", ">"])
-        mv_choice.SetSelection(0)
-        stylize_choice(mv_choice)
-        self.mv_comparator = mv_choice
-        mv_choice.Bind(wx.EVT_CHOICE, self._on_filters_changed)
-        mv_row.Add(mv_choice, 0, wx.RIGHT, PADDING_MD)
+        sizer.Add(mv_label, 0, wx.LEFT | wx.RIGHT, PADDING_MD)
+        mv_row = wx.BoxSizer(wx.HORIZONTAL)
         mv_value = wx.TextCtrl(self)
         stylize_textctrl(mv_value)
         mv_value.SetHint("e.g. 3")
         self.mv_value = mv_value
         mv_value.Bind(wx.EVT_TEXT, self._on_filters_changed)
-        mv_row.Add(mv_value, 1)
+        mv_row.Add(mv_value, 1, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, PADDING_SM)
+        mv_choice = wx.Choice(self, choices=["-", "<", "≤", "=", "≥", ">"])
+        mv_choice.SetSelection(0)
+        stylize_choice(mv_choice)
+        self.mv_comparator = mv_choice
+        mv_choice.Bind(wx.EVT_CHOICE, self._on_filters_changed)
+        mv_row.Add(mv_choice, 0, wx.ALIGN_CENTER_VERTICAL)
         sizer.Add(mv_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
 
-        # Format checkboxes
-        formats_label = wx.StaticText(self, label="Formats")
-        stylize_label(formats_label, True)
-        sizer.Add(formats_label, 0, wx.LEFT | wx.RIGHT, PADDING_MD)
-        formats_grid = wx.FlexGridSizer(
-            0, BUILDER_FORMATS_GRID_COLS, PADDING_SM, BUILDER_FORMATS_GRID_HGAP
-        )
-        for fmt in FORMAT_OPTIONS:
-            cb = wx.CheckBox(self, label=fmt)
-            cb.SetForegroundColour(LIGHT_TEXT)
-            cb.SetBackgroundColour(DARK_PANEL)
-            formats_grid.Add(cb, 0, wx.RIGHT, PADDING_MD)
-            cb.Bind(wx.EVT_CHECKBOX, self._on_filters_changed)
-            self.format_checks.append(cb)
-        sizer.Add(formats_grid, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
+        # Color identity filter (left) + Format filter (right) on same line
+        color_format_row = wx.BoxSizer(wx.HORIZONTAL)
 
-        # Color identity filter
+        color_col = wx.BoxSizer(wx.VERTICAL)
         color_label = wx.StaticText(self, label="Color Identity Filter")
         stylize_label(color_label, True)
-        sizer.Add(color_label, 0, wx.LEFT | wx.RIGHT, PADDING_MD)
-
-        color_mode = wx.Choice(self, choices=["Any", "At least", "Exactly", "Not these"])
+        color_col.Add(color_label, 0, wx.BOTTOM, PADDING_XS)
+        color_controls = wx.BoxSizer(wx.HORIZONTAL)
+        color_mode = wx.Choice(self, choices=["-", "≥", "=", "≠"])
         color_mode.SetSelection(0)
         stylize_choice(color_mode)
         self.color_mode_choice = color_mode
         color_mode.Bind(wx.EVT_CHOICE, self._on_filters_changed)
-        sizer.Add(color_mode, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
+        color_controls.Add(color_mode, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, PADDING_SM)
+        for code in ["W", "U", "B", "R", "G", "C"]:
+            bmp: wx.Bitmap | None = None
+            try:
+                bmp = self.mana_icons.bitmap_for_symbol(code)
+            except Exception:
+                bmp = None
+            if bmp and bmp.IsOk():
+                btn: wx.ToggleButton = wx.BitmapToggleButton(
+                    self, wx.ID_ANY, bmp, size=(bmp.GetWidth() + 8, bmp.GetHeight() + 8)
+                )
+            else:
+                btn = wx.ToggleButton(self, label=code, size=(28, 28))
+                btn.SetForegroundColour(LIGHT_TEXT)
+            btn.SetBackgroundColour(DARK_ALT)
+            btn.Bind(wx.EVT_TOGGLEBUTTON, self._on_filters_changed)
+            color_controls.Add(btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, PADDING_XS)
+            self.color_checks[code] = btn
+        color_col.Add(color_controls, 0)
+        color_format_row.Add(color_col, 1, wx.RIGHT, PADDING_MD)
 
-        colors_row = wx.BoxSizer(wx.HORIZONTAL)
-        for code, label in [
-            ("W", "White"),
-            ("U", "Blue"),
-            ("B", "Black"),
-            ("R", "Red"),
-            ("G", "Green"),
-            ("C", "Colorless"),
-        ]:
-            cb = wx.CheckBox(self, label=label)
-            cb.SetForegroundColour(LIGHT_TEXT)
-            cb.SetBackgroundColour(DARK_PANEL)
-            colors_row.Add(cb, 0, wx.RIGHT, PADDING_SM)
-            cb.Bind(wx.EVT_CHECKBOX, self._on_filters_changed)
-            self.color_checks[code] = cb
-        sizer.Add(colors_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
+        format_col = wx.BoxSizer(wx.VERTICAL)
+        format_label = wx.StaticText(self, label="Format")
+        stylize_label(format_label, True)
+        format_col.Add(format_label, 0, wx.BOTTOM, PADDING_XS)
+        format_choice = wx.Choice(self, choices=["Any"] + list(FORMAT_OPTIONS))
+        format_choice.SetSelection(0)
+        stylize_choice(format_choice)
+        self.format_choice = format_choice
+        format_choice.Bind(wx.EVT_CHOICE, self._on_filters_changed)
+        format_col.Add(format_choice, 0, wx.EXPAND)
+        color_format_row.Add(format_col, 0)
+
+        sizer.Add(color_format_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
 
         # Clear button
         controls = wx.BoxSizer(wx.HORIZONTAL)
@@ -572,12 +569,16 @@ class DeckBuilderPanel(wx.Panel):
         )
         mv_value_text = self.mv_value.GetValue().strip() if self.mv_value else ""
         filters["mv_value"] = mv_value_text
-        filters["formats"] = [cb.GetLabel().lower() for cb in self.format_checks if cb.IsChecked()]
+        filters["formats"] = (
+            [self.format_choice.GetStringSelection().lower()]
+            if self.format_choice and self.format_choice.GetSelection() > 0
+            else []
+        )
         filters["color_mode"] = (
             self.color_mode_choice.GetStringSelection() if self.color_mode_choice else "Any"
         )
         filters["selected_colors"] = [
-            code for code, cb in self.color_checks.items() if cb.IsChecked()
+            code for code, btn in self.color_checks.items() if btn.GetValue()
         ]
 
         # Add radar filter if enabled
@@ -612,8 +613,8 @@ class DeckBuilderPanel(wx.Panel):
             self.mv_comparator.SetSelection(0)
         if self.mv_value:
             self.mv_value.ChangeValue("")
-        for cb in self.format_checks:
-            cb.SetValue(False)
+        if self.format_choice:
+            self.format_choice.SetSelection(0)
         if self.color_mode_choice:
             self.color_mode_choice.SetSelection(0)
         for cb in self.color_checks.values():

--- a/widgets/panels/deck_builder_panel.py
+++ b/widgets/panels/deck_builder_panel.py
@@ -376,7 +376,9 @@ class DeckBuilderPanel(wx.Panel):
             if bmp and bmp.IsOk():
                 grey_bmp = wx.Bitmap(bmp.ConvertToImage().ConvertToGreyscale())
                 btn_size = (bmp.GetWidth() + 8, bmp.GetHeight() + 8)
-                btn: wx.ToggleButton = wx.BitmapToggleButton(self, wx.ID_ANY, grey_bmp, size=btn_size)
+                btn: wx.ToggleButton = wx.BitmapToggleButton(
+                    self, wx.ID_ANY, grey_bmp, size=btn_size
+                )
                 btn.SetBitmapPressed(bmp)
             else:
                 btn = wx.ToggleButton(self, label=code, size=(28, 28))

--- a/widgets/panels/deck_builder_panel.py
+++ b/widgets/panels/deck_builder_panel.py
@@ -374,9 +374,10 @@ class DeckBuilderPanel(wx.Panel):
             except Exception:
                 bmp = None
             if bmp and bmp.IsOk():
-                btn: wx.ToggleButton = wx.BitmapToggleButton(
-                    self, wx.ID_ANY, bmp, size=(bmp.GetWidth() + 8, bmp.GetHeight() + 8)
-                )
+                grey_bmp = wx.Bitmap(bmp.ConvertToImage().ConvertToGreyscale())
+                btn_size = (bmp.GetWidth() + 8, bmp.GetHeight() + 8)
+                btn: wx.ToggleButton = wx.BitmapToggleButton(self, wx.ID_ANY, grey_bmp, size=btn_size)
+                btn.SetBitmapPressed(bmp)
             else:
                 btn = wx.ToggleButton(self, label=code, size=(28, 28))
                 btn.SetForegroundColour(LIGHT_TEXT)

--- a/widgets/panels/deck_builder_panel.py
+++ b/widgets/panels/deck_builder_panel.py
@@ -286,7 +286,7 @@ class DeckBuilderPanel(wx.Panel):
             stylize_textctrl(ctrl)
             ctrl.SetHint(hint)
             ctrl.Bind(wx.EVT_TEXT, self._on_filters_changed)
-            sizer.Add(ctrl, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_MD)
+            sizer.Add(ctrl, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
             self.inputs[key] = ctrl
 
             # Oracle Text field gets a match-mode selector
@@ -304,7 +304,7 @@ class DeckBuilderPanel(wx.Panel):
                 text_mode_choice.Bind(wx.EVT_CHOICE, self._on_filters_changed)
                 text_match_row.Add(text_mode_choice, 0)
                 text_match_row.AddStretchSpacer(1)
-                sizer.Add(text_match_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_MD)
+                sizer.Add(text_match_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_XS)
 
             # Mana cost field gets extra controls
             if key == "mana":
@@ -320,7 +320,7 @@ class DeckBuilderPanel(wx.Panel):
                 self.mana_exact_cb = exact_cb
                 exact_cb.Bind(wx.EVT_CHECKBOX, self._on_filters_changed)
                 match_row.AddStretchSpacer(1)
-                sizer.Add(match_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_MD)
+                sizer.Add(match_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_XS)
 
                 # Mana symbol keyboard
                 keyboard_row = wx.BoxSizer(wx.HORIZONTAL)
@@ -337,7 +337,7 @@ class DeckBuilderPanel(wx.Panel):
                     keyboard_row,
                     0,
                     wx.ALIGN_CENTER_HORIZONTAL | wx.LEFT | wx.RIGHT | wx.BOTTOM,
-                    PADDING_SM,
+                    PADDING_XS,
                 )
 
         # Mana value filter
@@ -357,7 +357,7 @@ class DeckBuilderPanel(wx.Panel):
         self.mv_value = mv_value
         mv_value.Bind(wx.EVT_TEXT, self._on_filters_changed)
         mv_row.Add(mv_value, 1)
-        sizer.Add(mv_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_MD)
+        sizer.Add(mv_row, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
 
         # Format checkboxes
         formats_label = wx.StaticText(self, label="Formats")
@@ -373,7 +373,7 @@ class DeckBuilderPanel(wx.Panel):
             formats_grid.Add(cb, 0, wx.RIGHT, PADDING_MD)
             cb.Bind(wx.EVT_CHECKBOX, self._on_filters_changed)
             self.format_checks.append(cb)
-        sizer.Add(formats_grid, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_MD)
+        sizer.Add(formats_grid, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
 
         # Color identity filter
         color_label = wx.StaticText(self, label="Color Identity Filter")
@@ -385,7 +385,7 @@ class DeckBuilderPanel(wx.Panel):
         stylize_choice(color_mode)
         self.color_mode_choice = color_mode
         color_mode.Bind(wx.EVT_CHOICE, self._on_filters_changed)
-        sizer.Add(color_mode, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_MD)
+        sizer.Add(color_mode, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
 
         colors_row = wx.BoxSizer(wx.HORIZONTAL)
         for code, label in [
@@ -399,10 +399,10 @@ class DeckBuilderPanel(wx.Panel):
             cb = wx.CheckBox(self, label=label)
             cb.SetForegroundColour(LIGHT_TEXT)
             cb.SetBackgroundColour(DARK_PANEL)
-            colors_row.Add(cb, 0, wx.RIGHT, PADDING_MD)
+            colors_row.Add(cb, 0, wx.RIGHT, PADDING_SM)
             cb.Bind(wx.EVT_CHECKBOX, self._on_filters_changed)
             self.color_checks[code] = cb
-        sizer.Add(colors_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_MD)
+        sizer.Add(colors_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, PADDING_SM)
 
         # Clear button
         controls = wx.BoxSizer(wx.HORIZONTAL)


### PR DESCRIPTION
## Summary

- Tightens vertical density of the left search panel (issue #280)
- Color Identity mode words (Any/At least/Exactly/Not these) replaced with symbols (-/≥/=/≠); color checkboxes replaced with `BitmapToggleButton` mana symbol icons, all on one inline row with the mode dropdown
- Format filter moved off its own full-width row — now a single dropdown placed to the right of the Color Identity row
- Mana Value Filter now follows the label-above / [input][dropdown]-below pattern used by other text-search fields
- Oracle Text match mode (= / ≈) is now inline with the input box instead of on a separate row
- `matches_color_filter()` and `search_service.py` updated to accept new symbol mode strings; tests updated accordingly

Closes #280

## Test plan
- [ ] Run `python -m pytest tests/ -q --ignore=tests/ui` — all tests pass
- [ ] Open Deck Builder panel and verify Color Identity shows mana icon toggles inline with the -/≥/=/≠ dropdown
- [ ] Verify Format dropdown sits to the right of the Color Identity section
- [ ] Verify Mana Value shows label above, [input][dropdown] below
- [ ] Verify Oracle Text input has = / ≈ dropdown on the same line
- [ ] Confirm filtering logic works for each color identity mode and format selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)