### PR TITLE
Fix accent-insensitive card image lookup (Lórien Revealed)

### DIFF
--- a/tests/test_card_images_cache.py
+++ b/tests/test_card_images_cache.py
@@ -401,3 +401,52 @@ def test_get_image_path_concurrent_add_and_get_is_race_free(tmp_path):
         t.join()
 
     assert not errors, f"Race errors: {errors}"
+
+
+def test_get_image_path_accent_normalized_fallback(tmp_path):
+    """get_image_path() should find a card stored as 'Lórien Revealed' when queried as 'Lorien Revealed'."""
+    cache = card_images.CardImageCache(
+        cache_dir=tmp_path / "cache", db_path=tmp_path / "cache" / "images.db"
+    )
+    image_file = cache.cache_dir / "normal" / "uuid-lorien.jpg"
+    image_file.parent.mkdir(parents=True, exist_ok=True)
+    image_file.write_bytes(b"fake")
+
+    # Store the image under the accented Scryfall name
+    cache.add_image(
+        uuid="uuid-lorien",
+        name="Lórien Revealed",
+        set_code="LTR",
+        collector_number="057",
+        image_size="normal",
+        file_path=image_file,
+    )
+    cache._path_cache.clear()
+
+    # Querying without the accent should still find the image
+    result = cache.get_image_path("Lorien Revealed", "normal")
+    assert result == image_file
+
+
+def test_get_image_path_no_accent_no_extra_query(tmp_path):
+    """When both the stored and requested name have no accents, the fallback query is skipped."""
+    cache = card_images.CardImageCache(
+        cache_dir=tmp_path / "cache", db_path=tmp_path / "cache" / "images.db"
+    )
+    image_file = cache.cache_dir / "normal" / "uuid-bolt.jpg"
+    image_file.parent.mkdir(parents=True, exist_ok=True)
+    image_file.write_bytes(b"fake")
+
+    cache.add_image(
+        uuid="uuid-bolt",
+        name="Lightning Bolt",
+        set_code="LEA",
+        collector_number="161",
+        image_size="normal",
+        file_path=image_file,
+    )
+    cache._path_cache.clear()
+
+    # A plain ASCII name must still resolve correctly
+    result = cache.get_image_path("Lightning Bolt", "normal")
+    assert result == image_file

--- a/utils/card_images.py
+++ b/utils/card_images.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import threading
+import unicodedata
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -182,6 +183,13 @@ class CardImageRequest:
     def can_fetch(self) -> bool:
         """Return True when there is enough data to fetch from Scryfall."""
         return bool((self.card_name or "").strip())
+
+
+def _strip_accents(text: str) -> str:
+    """Return *text* with combining diacritical marks removed (e.g. ó → o)."""
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", text) if not unicodedata.combining(c)
+    ).lower()
 
 
 class CardImageCache:
@@ -419,6 +427,27 @@ class CardImageCache:
             alias_path = self._lookup_double_faced_alias(conn, card_name, size)
             if alias_path:
                 return alias_path
+
+            # Fallback: accent-insensitive lookup for cards like "Lórien Revealed"
+            # stored under their accented Scryfall name but requested without accents
+            # (or vice-versa).  SQLite's LOWER() does not strip combining characters,
+            # so we register a custom scalar and compare normalised forms.
+            conn.create_function("strip_accents", 1, _strip_accents)
+            cursor = conn.execute(
+                """
+                SELECT file_path
+                FROM card_images
+                WHERE strip_accents(name) = ? AND image_size = ?
+                ORDER BY face_index
+                LIMIT 1
+                """,
+                (_strip_accents(card_name), size),
+            )
+            row = cursor.fetchone()
+            if row:
+                path = self._resolve_path(row[0])
+                if path.exists():
+                    return path
         return None
 
     def _lookup_double_faced_alias(


### PR DESCRIPTION
## Summary

- Adds `_strip_accents()` helper in `utils/card_images.py` using `unicodedata.normalize('NFKD', ...)` to strip combining diacritical marks
- Adds a fallback query in `CardImageCache._get_image_path_from_db`: when the standard `LOWER(name) = LOWER(?)` lookup misses, registers `strip_accents` as a SQLite scalar function and retries with normalised names on both sides
- Fixes the root cause of `Assuming card image download failed for Lorien Revealed (2.95s elapsed)`: the card was stored under its Scryfall name `Lórien Revealed` but looked up as `Lorien Revealed`, causing `_is_cached` to return False and triggering a re-download that timed out

## Test plan

- [ ] `test_get_image_path_accent_normalized_fallback` — card stored as `Lórien Revealed`, queried as `Lorien Revealed`, resolves to the same image
- [ ] `test_get_image_path_no_accent_no_extra_query` — plain ASCII names still resolve correctly
- [ ] Full test suite: `python3 -m pytest tests/ -q --ignore=tests/ui` — no new failures

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)