### PR TITLE
Guard image CallAfter callbacks against destroyed wx widgets on shutdown

### DIFF
--- a/widgets/card_image_display.py
+++ b/widgets/card_image_display.py
@@ -200,6 +200,10 @@ class CardImageDisplay(wx.Panel):
 
             return True
 
+        except RuntimeError:
+            # Widget was destroyed (e.g. during app shutdown) while a
+            # CallAfter callback was still pending – silently bail out.
+            return False
         except Exception as exc:
             logger.exception(f"Error loading image {image_path}: {exc}")
             return False

--- a/widgets/panels/card_box_panel.py
+++ b/widgets/panels/card_box_panel.py
@@ -200,6 +200,11 @@ class CardBoxPanel(wx.Panel):
 
     def _on_image_load_done(self, gen: int, pil_img: "PilImage.Image | None") -> None:
         """Main-thread callback: apply the loaded image bitmap."""
+        try:
+            if not self:
+                return
+        except RuntimeError:
+            return
         if gen != self._image_generation:
             return  # stale result superseded by a newer assign_card / load
         if pil_img is None:

--- a/widgets/panels/card_inspector_panel.py
+++ b/widgets/panels/card_inspector_panel.py
@@ -496,6 +496,11 @@ class CardInspectorPanel(wx.Panel):
         need_double_face: bool,
     ) -> None:
         """Apply a has-printings image lookup result on the UI thread."""
+        try:
+            if not self:
+                return
+        except RuntimeError:
+            return
         if gen != self._image_lookup_gen:
             return
         image_available = False


### PR DESCRIPTION
## Summary
- Adds `try/except RuntimeError` guards to three `wx.CallAfter` callbacks that could fire after their host widgets are C++-deleted during app teardown
- `CardImageDisplay._load_image_at_index`: catches `RuntimeError` before the general `Exception` handler so stale post-shutdown calls exit silently
- `CardInspectorPanel._apply_printings_image`: early-return guard using `if not self` wrapped in `try/except RuntimeError`
- `CardBoxPanel._on_image_load_done`: same guard pattern

Fixes #293.

## Test plan
- [ ] Reproduce by opening a deck with card images loaded, navigating the card inspector, then closing the app — no `RuntimeError` in logs
- [ ] `python3 -m pytest tests/ -q --ignore=tests/ui` passes (389 tests, pre-existing wx failures unchanged)
- [ ] `ruff check` and `black --check` pass on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)