### PR TITLE
Add flex slots definition to sideboard guide

### DIFF
--- a/utils/constants/colors.py
+++ b/utils/constants/colors.py
@@ -17,3 +17,5 @@ CALC_BUTTON_GREEN = "#2a6b2a"
 # Sideboard Guide Panel — button and label colors
 PIN_BUTTON_COLOR = (140, 90, 210)  # purple accent for the "Pin for Tracker" button
 WARNING_LABEL_COLOR = (255, 165, 0)  # orange for inline warning messages
+FLEX_SLOT_BUTTON_COLOR = (60, 130, 80)  # green accent for "Flex Slots" button
+FLEX_SLOT_HIGHLIGHT_COLOR = (55, 70, 45)  # subtle green tint for flex slot card rows

--- a/widgets/app_frame.py
+++ b/widgets/app_frame.py
@@ -77,6 +77,7 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
 
         self.sideboard_guide_entries: list[dict[str, str]] = []
         self.sideboard_exclusions: list[str] = []
+        self.sideboard_flex_slots: list[str] = []
         self.active_inspector_zone: str | None = None
         self.left_stack: wx.Simplebook | None = None
         self.research_panel: DeckResearchPanel | None = None
@@ -457,6 +458,7 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
             on_export_csv=self._on_export_guide,
             on_import_csv=self._on_import_guide,
             on_pin_guide=self._on_pin_guide,
+            on_edit_flex_slots=self._on_edit_flex_slots,
         )
         self.deck_tabs.AddPage(self.sideboard_guide_panel, "Sideboard Guide")
 

--- a/widgets/dialogs/guide_entry_dialog.py
+++ b/widgets/dialogs/guide_entry_dialog.py
@@ -20,6 +20,7 @@ class GuideEntryDialog(wx.Dialog):
         mainboard_cards: list[dict[str, Any]],
         sideboard_cards: list[dict[str, Any]],
         data: dict[str, Any] | None = None,
+        flex_slots: list[str] | None = None,
     ) -> None:
         """
         Initialize the guide entry dialog.
@@ -30,6 +31,7 @@ class GuideEntryDialog(wx.Dialog):
             mainboard_cards: List of mainboard cards available to take out
             sideboard_cards: List of sideboard cards available to bring in
             data: Existing entry data to edit (optional)
+            flex_slots: Card names marked as flex slots (highlighted in Out selectors)
         """
         super().__init__(parent, title="Sideboard Guide Entry", size=(1100, 750))
 
@@ -71,7 +73,7 @@ class GuideEntryDialog(wx.Dialog):
 
         # Play: Out (from mainboard)
         self.play_out_selector = SideboardCardSelector(
-            panel, "Out (from Mainboard)", mainboard_cards
+            panel, "Out (from Mainboard)", mainboard_cards, flex_slots=flex_slots
         )
         play_sizer.Add(self.play_out_selector, 1, wx.EXPAND | wx.RIGHT, 4)
 
@@ -90,7 +92,7 @@ class GuideEntryDialog(wx.Dialog):
 
         # Draw: Out (from mainboard)
         self.draw_out_selector = SideboardCardSelector(
-            panel, "Out (from Mainboard)", mainboard_cards
+            panel, "Out (from Mainboard)", mainboard_cards, flex_slots=flex_slots
         )
         draw_sizer.Add(self.draw_out_selector, 1, wx.EXPAND | wx.RIGHT, 4)
 

--- a/widgets/handlers/sideboard_guide_handlers.py
+++ b/widgets/handlers/sideboard_guide_handlers.py
@@ -93,6 +93,7 @@ class SideboardGuideHandlers:
 
         self.sideboard_guide_entries = migrated_entries
         self.sideboard_exclusions = payload.get("exclusions", [])
+        self.sideboard_flex_slots = payload.get("flex_slots", [])
         self.sideboard_guide_panel.set_entries(
             self.sideboard_guide_entries, self.sideboard_exclusions
         )
@@ -103,6 +104,7 @@ class SideboardGuideHandlers:
         self.controller.guide_store[key] = {
             "entries": self.sideboard_guide_entries,
             "exclusions": self.sideboard_exclusions,
+            "flex_slots": self.sideboard_flex_slots,
         }
         self.controller.store_service.save_store(
             self.controller.guide_store_path, self.controller.guide_store
@@ -118,7 +120,13 @@ class SideboardGuideHandlers:
         mainboard = self.zone_cards.get("main", [])
         sideboard = self.zone_cards.get("side", [])
 
-        dlg = GuideEntryDialog(self, names, mainboard_cards=mainboard, sideboard_cards=sideboard)
+        dlg = GuideEntryDialog(
+            self,
+            names,
+            mainboard_cards=mainboard,
+            sideboard_cards=sideboard,
+            flex_slots=self.sideboard_flex_slots,
+        )
 
         while True:
             result = dlg.ShowModal()
@@ -169,6 +177,7 @@ class SideboardGuideHandlers:
             mainboard_cards=self.zone_cards.get("main", []),
             sideboard_cards=self.zone_cards.get("side", []),
             data=data,
+            flex_slots=self.sideboard_flex_slots,
         )
         if dlg.ShowModal() == wx.ID_OK:
             updated = dlg.get_data()
@@ -208,6 +217,31 @@ class SideboardGuideHandlers:
             self.sideboard_exclusions = [archetype_names[idx] for idx in selections]
             self._persist_guide_for_current()
             self._refresh_guide_view()
+        dlg.Destroy()
+
+    def _on_edit_flex_slots(self: AppFrame) -> None:
+        """Allow the user to mark which mainboard cards are flex slots."""
+        mainboard_cards = self.zone_cards.get("main", [])
+        if not mainboard_cards:
+            wx.MessageBox("No mainboard cards loaded.", "Flex Slots", wx.OK | wx.ICON_INFORMATION)
+            return
+
+        card_names = [card["name"] for card in mainboard_cards]
+        dlg = wx.MultiChoiceDialog(
+            self,
+            "Select mainboard cards that can be taken out during sideboarding (flex slots).\n"
+            "These will be highlighted in the Out selectors when adding guide entries.",
+            "Flex Slots",
+            card_names,
+        )
+        selected_indices = [
+            card_names.index(name) for name in self.sideboard_flex_slots if name in card_names
+        ]
+        dlg.SetSelections(selected_indices)
+        if dlg.ShowModal() == wx.ID_OK:
+            selections = dlg.GetSelections()
+            self.sideboard_flex_slots = [card_names[idx] for idx in selections]
+            self._persist_guide_for_current()
         dlg.Destroy()
 
     def _on_export_guide(self: AppFrame) -> None:

--- a/widgets/panels/sideboard_card_selector.py
+++ b/widgets/panels/sideboard_card_selector.py
@@ -8,6 +8,7 @@ import wx
 import wx.lib.scrolledpanel as scrolled
 
 from utils.constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+from utils.constants.colors import FLEX_SLOT_HIGHLIGHT_COLOR
 
 
 class SideboardCardSelector(wx.Panel):
@@ -18,6 +19,7 @@ class SideboardCardSelector(wx.Panel):
         parent: wx.Window,
         title: str,
         available_cards: list[dict[str, Any]],
+        flex_slots: list[str] | None = None,
     ):
         """
         Initialize the card selector.
@@ -26,9 +28,11 @@ class SideboardCardSelector(wx.Panel):
             parent: Parent window
             title: Title for this selector (e.g., "Play: Out")
             available_cards: List of cards available to select from (from mainboard or sideboard)
+            flex_slots: Optional list of card names that are marked as flex slots (highlighted)
         """
         super().__init__(parent)
         self.SetBackgroundColour(DARK_PANEL)
+        self.flex_slots: set[str] = set(flex_slots) if flex_slots else set()
 
         self.available_cards = available_cards
         self.selected_cards: dict[str, int] = {}  # name -> quantity
@@ -66,10 +70,12 @@ class SideboardCardSelector(wx.Panel):
         for card in self.available_cards:
             card_name = card["name"]
             max_qty = card["qty"]
+            is_flex = card_name in self.flex_slots
 
             # Card row panel
             row_panel = wx.Panel(self.scroll_panel)
-            row_panel.SetBackgroundColour(DARK_ALT)
+            row_bg = wx.Colour(*FLEX_SLOT_HIGHLIGHT_COLOR) if is_flex else DARK_ALT
+            row_panel.SetBackgroundColour(row_bg)
             row_sizer = wx.BoxSizer(wx.HORIZONTAL)
             row_panel.SetSizer(row_sizer)
 
@@ -80,7 +86,7 @@ class SideboardCardSelector(wx.Panel):
 
             # Buttons panel
             btn_panel = wx.Panel(row_panel)
-            btn_panel.SetBackgroundColour(DARK_ALT)
+            btn_panel.SetBackgroundColour(row_bg)
             btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
             btn_panel.SetSizer(btn_sizer)
 
@@ -114,7 +120,8 @@ class SideboardCardSelector(wx.Panel):
             row_sizer.Add(btn_panel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 8)
 
             # Card name
-            name_label = wx.StaticText(row_panel, label=f"{card_name} (max {max_qty})")
+            flex_tag = " [flex]" if is_flex else ""
+            name_label = wx.StaticText(row_panel, label=f"{card_name} (max {max_qty}){flex_tag}")
             name_label.SetForegroundColour(LIGHT_TEXT)
             row_sizer.Add(name_label, 1, wx.ALIGN_CENTER_VERTICAL)
 

--- a/widgets/panels/sideboard_guide_panel.py
+++ b/widgets/panels/sideboard_guide_panel.py
@@ -13,7 +13,7 @@ import wx
 import wx.dataview as dv
 
 from utils.constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
-from utils.constants.colors import PIN_BUTTON_COLOR, WARNING_LABEL_COLOR
+from utils.constants.colors import FLEX_SLOT_BUTTON_COLOR, PIN_BUTTON_COLOR, WARNING_LABEL_COLOR
 from utils.constants.ui_layout import (
     GUIDE_COL_ARCHETYPE_WIDTH,
     GUIDE_COL_CARDS_WIDTH,
@@ -36,6 +36,7 @@ class SideboardGuidePanel(wx.Panel):
         on_export_csv: Callable[[], None],
         on_import_csv: Callable[[], None],
         on_pin_guide: Callable[[], None] | None = None,
+        on_edit_flex_slots: Callable[[], None] | None = None,
     ):
         """
         Initialize the sideboard guide panel.
@@ -49,6 +50,7 @@ class SideboardGuidePanel(wx.Panel):
             on_export_csv: Callback for exporting guide to CSV
             on_import_csv: Callback for importing guide from CSV
             on_pin_guide: Callback for pinning the current deck's guide for the opponent tracker
+            on_edit_flex_slots: Callback for editing the deck's flex slot cards
         """
         super().__init__(parent)
         self.SetBackgroundColour(DARK_PANEL)
@@ -60,6 +62,7 @@ class SideboardGuidePanel(wx.Panel):
         self.on_export_csv = on_export_csv
         self.on_import_csv = on_import_csv
         self.on_pin_guide = on_pin_guide
+        self.on_edit_flex_slots = on_edit_flex_slots
 
         self.entries: list[dict[str, str]] = []
         self.exclusions: list[str] = []
@@ -134,6 +137,18 @@ class SideboardGuidePanel(wx.Panel):
         stylize_button(self.import_btn)
         self.import_btn.Bind(wx.EVT_BUTTON, self._on_import_clicked)
         buttons.Add(self.import_btn, 0, wx.RIGHT, PADDING_MD)
+
+        self.flex_slots_btn = wx.Button(self, label="Flex Slots")
+        stylize_button(self.flex_slots_btn)
+        self.flex_slots_btn.SetBackgroundColour(wx.Colour(*FLEX_SLOT_BUTTON_COLOR))
+        self.flex_slots_btn.SetToolTip(
+            "Mark mainboard cards as flex slots. Flex slots are highlighted in the Out selectors "
+            "when creating guide entries, making it easier to identify cards to side out."
+        )
+        self.flex_slots_btn.Bind(wx.EVT_BUTTON, self._on_flex_slots_clicked)
+        if self.on_edit_flex_slots is None:
+            self.flex_slots_btn.Disable()
+        buttons.Add(self.flex_slots_btn, 0, wx.RIGHT, PADDING_MD)
 
         buttons.AddStretchSpacer(1)
 
@@ -302,6 +317,11 @@ class SideboardGuidePanel(wx.Panel):
         """Handle Pin for Tracker button click."""
         if self.on_pin_guide:
             self.on_pin_guide()
+
+    def _on_flex_slots_clicked(self, _event: wx.Event) -> None:
+        """Handle Flex Slots button click."""
+        if self.on_edit_flex_slots:
+            self.on_edit_flex_slots()
 
     def set_pinned(self, pinned: bool) -> None:
         """


### PR DESCRIPTION
Closes #292

## Summary
- Adds a **Flex Slots** button to the Sideboard Guide panel (green accent, sits between Import and Pin for Tracker)
- Clicking it opens a multi-choice dialog listing all mainboard cards; the user selects which ones are candidates to be sided out (flex slots)
- Flex slot selections are persisted in `cache/deck_sbguides.json` alongside entries and exclusions, keyed per decklist hash
- When adding or editing a guide entry, cards marked as flex slots are **highlighted** (distinct background + `[flex]` label) in both the Play: Out and Draw: Out card selectors, making it faster to identify cards to remove

## Test plan
- [ ] Load a deck and open the Sideboard Guide tab
- [ ] Click "Flex Slots", select a few mainboard cards, confirm and close
- [ ] Click "Add" to create a new entry — verify the selected flex slot cards are visually highlighted in the Out selectors
- [ ] Click "Edit" on an existing entry — same highlighting should appear
- [ ] Reload the deck — verify flex slot selections are persisted across sessions
- [ ] With no deck loaded, verify "Flex Slots" shows a friendly "No mainboard cards" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)