### PR TITLE
Apply gray-blue theme to toolbar buttons

### DIFF
--- a/widgets/buttons/toolbar_buttons.py
+++ b/widgets/buttons/toolbar_buttons.py
@@ -8,6 +8,8 @@ from collections.abc import Callable
 
 import wx
 
+from utils.stylize import stylize_button
+
 
 class ToolbarButtons(wx.Panel):
     """Panel containing the deck selector toolbar buttons."""
@@ -64,6 +66,7 @@ class ToolbarButtons(wx.Panel):
         self._button_row.AddStretchSpacer(1)
         self._add_divider(gap=10)
         self.settings_button = wx.Button(self, label=labels.get("settings", "\u2699"))
+        stylize_button(self.settings_button)
         self.settings_button.SetToolTip(labels.get("settings_tooltip", "Settings"))
         if on_open_settings_menu:
             self.settings_button.Bind(
@@ -86,6 +89,7 @@ class ToolbarButtons(wx.Panel):
     ) -> wx.Button:
         """Create a toolbar button and bind its handler if provided."""
         button = wx.Button(self, label=label)
+        stylize_button(button)
         if tooltip:
             button.SetToolTip(tooltip)
         if handler:


### PR DESCRIPTION
## Summary
- All toolbar buttons (Opponent Tracker, Timer Alert, Match History, Metagame Analysis, Settings) were using default gray wx.Button styling
- Applied `stylize_button()` from `utils/stylize.py` to every toolbar button, giving them the `DARK_ACCENT` blue background with bold dark foreground text — consistent with the rest of the UI

## Test plan
- [ ] Launch the app and verify the toolbar buttons render with blue styling instead of gray
- [ ] Confirm all five buttons still function correctly (click triggers expected action)

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)