### PR TITLE
Fix Mainboard tab blank after loading a deck while on another tab

### DIFF
--- a/widgets/app_frame.py
+++ b/widgets/app_frame.py
@@ -455,6 +455,7 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
 
         self.deck_tabs = self._create_notebook(detail_box)
         detail_sizer.Add(self.deck_tabs, 1, wx.EXPAND | wx.ALL, PADDING_MD)
+        self.deck_tabs.Bind(fnb.EVT_FLATNOTEBOOK_PAGE_CHANGED, self._on_deck_tab_changed)
 
         # Mainboard and Sideboard as top-level tabs
         self._build_deck_tables_tab()
@@ -538,6 +539,16 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
         )
         self.deck_tabs.AddPage(table, tab_name)
         return table
+
+    def _on_deck_tab_changed(self, event: wx.Event) -> None:
+        """Refresh layout of CardTablePanel tabs that were updated while hidden."""
+        event.Skip()
+        idx = self.deck_tabs.GetSelection()
+        if idx == wx.NOT_FOUND:
+            return
+        page = self.deck_tabs.GetPage(idx)
+        if isinstance(page, CardTablePanel):
+            page.refresh_layout()
 
     # ------------------------------------------------------------------ Left panel helpers -------------------------------------------------
     def _show_left_panel(self, mode: str, force: bool = False) -> None:

--- a/widgets/panels/card_table_panel.py
+++ b/widgets/panels/card_table_panel.py
@@ -96,6 +96,12 @@ class CardTablePanel(wx.Panel):
         self.cards = cards
         self._update_panels(cards, preserve_scroll)
 
+    def refresh_layout(self) -> None:
+        """Re-run scroller layout — call when this tab becomes visible after a hidden set_cards."""
+        self.scroller.Layout()
+        self.scroller.FitInside()
+        self.scroller.SetupScrolling(scroll_x=False, scroll_y=True, rate_x=5, rate_y=5)
+
     @timed
     def _update_panels(self, cards: list[dict[str, Any]], preserve_scroll: bool = False) -> None:
         """Update the fixed pool of panels in-place; no widgets are created or destroyed."""


### PR DESCRIPTION
## Summary
- Fixes #325: Mainboard tab showing blank after selecting a deck while the Sideboard Guide or Deck Notes tab is active
- Root cause: `CardTablePanel.set_cards` calls `FitInside`/`SetupScrolling` on a hidden scrolled panel (wrong/zero size), so the scroller virtual size is incorrect when the tab becomes visible
- Fix: bind `EVT_FLATNOTEBOOK_PAGE_CHANGED` on `deck_tabs`; when switching to a `CardTablePanel` tab, call `refresh_layout()` to re-run scroller layout against the now-visible, correctly-sized widget

## Test plan
- [ ] Select an archetype, navigate to Sideboard Guide or Deck Notes tab, then select a deck from the results list
- [ ] Switch to Mainboard tab — cards should now render correctly instead of appearing blank
- [ ] Confirm Sideboard tab also renders correctly after loading a deck while on another tab
- [ ] Existing test suite passes (346+ tests, excluding pre-existing wx display failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)