### PR TITLE
UX: Improve mana filter button size, hover highlight, and tooltips (#321)

### DIFF
--- a/widgets/buttons/mana_button.py
+++ b/widgets/buttons/mana_button.py
@@ -80,8 +80,17 @@ def create_mana_button(
         btn = wx.Button(parent, label=token, size=(44, 28))
         btn.SetFont(get_mana_font(font_size))
 
+    _TOKEN_LABELS = {
+        "W": "White",
+        "U": "Blue",
+        "B": "Black",
+        "R": "Red",
+        "G": "Green",
+        "C": "Colorless",
+        "X": "X (variable)",
+    }
     btn.SetBackgroundColour(DARK_ALT)
     btn.SetForegroundColour(LIGHT_TEXT)
-    btn.SetToolTip(token)
+    btn.SetToolTip(_TOKEN_LABELS.get(token, token))
     btn.Bind(wx.EVT_BUTTON, lambda _evt, sym=token: handler(sym))
     return btn

--- a/widgets/panels/deck_builder_panel.py
+++ b/widgets/panels/deck_builder_panel.py
@@ -387,6 +387,15 @@ class DeckBuilderPanel(wx.Panel):
         self.color_mode_choice = color_mode
         color_mode.Bind(wx.EVT_CHOICE, self._on_filters_changed)
         color_controls.Add(color_mode, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, PADDING_SM)
+        _color_names = {
+            "W": "White",
+            "U": "Blue",
+            "B": "Black",
+            "R": "Red",
+            "G": "Green",
+            "C": "Colorless",
+        }
+        _FILTER_ICON_SIZE = 32
         for code in ["W", "U", "B", "R", "G", "C"]:
             bmp: wx.Bitmap | None = None
             try:
@@ -394,26 +403,36 @@ class DeckBuilderPanel(wx.Panel):
             except Exception:
                 bmp = None
             if bmp and bmp.IsOk():
-                grey_bmp = wx.Bitmap(bmp.ConvertToImage().ConvertToGreyscale())
-                btn_size = (bmp.GetWidth() + 8, bmp.GetHeight() + 8)
+                scaled = wx.Bitmap(
+                    bmp.ConvertToImage().Scale(
+                        _FILTER_ICON_SIZE, _FILTER_ICON_SIZE, wx.IMAGE_QUALITY_HIGH
+                    )
+                )
+                grey_bmp = wx.Bitmap(scaled.ConvertToImage().ConvertToGreyscale())
+                btn_size = (_FILTER_ICON_SIZE + 10, _FILTER_ICON_SIZE + 10)
                 btn: wx.ToggleButton = wx.BitmapToggleButton(
                     self, wx.ID_ANY, grey_bmp, size=btn_size
                 )
-                btn.SetBitmapPressed(bmp)
+                btn.SetBitmapPressed(scaled)
             else:
-                btn = wx.ToggleButton(self, label=code, size=(28, 28))
+                btn = wx.ToggleButton(self, label=code, size=(34, 34))
                 btn.SetForegroundColour(LIGHT_TEXT)
             btn.SetBackgroundColour(DARK_ALT)
-            color_names = {
-                "W": "White",
-                "U": "Blue",
-                "B": "Black",
-                "R": "Red",
-                "G": "Green",
-                "C": "Colorless",
-            }
-            btn.SetToolTip(f"Toggle {color_names.get(code, code)} color filter")
+            btn.SetToolTip(f"Toggle {_color_names.get(code, code)} color filter")
             btn.Bind(wx.EVT_TOGGLEBUTTON, self._on_filters_changed)
+            _btn_ref = btn
+            btn.Bind(
+                wx.EVT_ENTER_WINDOW,
+                lambda evt, b=_btn_ref: (
+                    b.SetBackgroundColour((60, 68, 80)),
+                    b.Refresh(),
+                    evt.Skip(),
+                ),
+            )
+            btn.Bind(
+                wx.EVT_LEAVE_WINDOW,
+                lambda evt, b=_btn_ref: (b.SetBackgroundColour(DARK_ALT), b.Refresh(), evt.Skip()),
+            )
             color_controls.Add(btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, PADDING_XS)
             self.color_checks[code] = btn
         color_col.Add(color_controls, 0)

--- a/widgets/panels/deck_builder_panel.py
+++ b/widgets/panels/deck_builder_panel.py
@@ -399,7 +399,7 @@ class DeckBuilderPanel(wx.Panel):
         for code in ["W", "U", "B", "R", "G", "C"]:
             bmp: wx.Bitmap | None = None
             try:
-                bmp = self.mana_icons.bitmap_for_symbol(code)
+                bmp = self.mana_icons.bitmap_for_symbol_hires(code)
             except Exception:
                 bmp = None
             if bmp and bmp.IsOk():


### PR DESCRIPTION
## Summary
- Scale color identity filter toggle buttons from 26px to 32px icons (buttons are 42×42 instead of ~34×34)
- Add hover highlight (background lightens to `(60, 68, 80)`) so buttons are clearly interactive
- Move `color_names` dict outside the loop (was re-created on every iteration)
- Improve mana keyboard button tooltips from bare token letters (`W`, `U`…) to descriptive names (`White`, `Blue`, `X (variable)`…)

## Test plan
- [ ] Open the Deck Builder panel and verify the mana color filter buttons (W/U/B/R/G/C) are visibly larger
- [ ] Hover over a filter button and confirm the background lightens slightly
- [ ] Leave the button and confirm background returns to normal
- [ ] Hover over a mana keyboard button and confirm the tooltip shows the full color name
- [ ] Toggle a color filter and confirm the icon switches between greyscale/color as before
- [ ] Run `python3 -m pytest tests/ -q --ignore=tests/ui` — no new failures

Fixes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)