### PR TITLE
Make timer alert watcher startup async

### DIFF
--- a/tests/test_timer_alert_async.py
+++ b/tests/test_timer_alert_async.py
@@ -1,0 +1,140 @@
+"""Headless tests for TimerAlertFrame bridge watcher lifecycle."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _build_wx_stub() -> MagicMock:
+    stub = MagicMock()
+    stub.Frame = type("_WxFrame", (object,), {})
+    stub.Panel = type("_WxPanel", (object,), {})
+    stub.Window = type("_WxWindow", (object,), {})
+    stub.CommandEvent = type("_WxCommandEvent", (object,), {})
+    stub.TimerEvent = type("_WxTimerEvent", (object,), {})
+    stub.CloseEvent = type("_WxCloseEvent", (object,), {})
+    return stub
+
+
+def _load_timer_alert_module():
+    source = Path(__file__).resolve().parent.parent / "widgets" / "timer_alert.py"
+    spec = importlib.util.spec_from_file_location("_timer_alert_under_test", source)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_original_wx = sys.modules.get("wx")
+sys.modules["wx"] = _build_wx_stub()
+try:
+    timer_alert = _load_timer_alert_module()
+finally:
+    if _original_wx is None:
+        sys.modules.pop("wx", None)
+    else:
+        sys.modules["wx"] = _original_wx
+
+TimerAlertFrame = timer_alert.TimerAlertFrame
+
+
+def _make_frame() -> TimerAlertFrame:
+    frame = object.__new__(TimerAlertFrame)
+    frame.WATCH_INTERVAL_MS = 750
+    frame.WATCH_RETRY_DELAY_MS = 5000
+    frame._watcher = None
+    frame._watch_start_pending = False
+    frame._closed = False
+    frame._watch_timer = MagicMock()
+    frame._monitor_timer = MagicMock()
+    frame._repeat_timer = MagicMock()
+    frame._set_status = MagicMock()
+    return frame
+
+
+def test_start_watch_loop_runs_bridge_start_in_background(monkeypatch) -> None:
+    frame = _make_frame()
+    watcher = MagicMock()
+    start_watch_calls: list[int] = []
+    call_after_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+    threads: list[object] = []
+
+    def fake_start_watch(*, interval_ms: int):
+        start_watch_calls.append(interval_ms)
+        return watcher
+
+    class FakeThread:
+        def __init__(self, *, target, daemon: bool, args: tuple[object, ...] = ()) -> None:
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+            self.started = False
+            threads.append(self)
+
+        def start(self) -> None:
+            self.started = True
+
+    monkeypatch.setattr(timer_alert.mtgo_bridge, "start_watch", fake_start_watch)
+    monkeypatch.setattr(
+        timer_alert.wx,
+        "CallAfter",
+        lambda func, *args, **kwargs: call_after_calls.append((func, args, kwargs)),
+    )
+    monkeypatch.setattr(timer_alert.threading, "Thread", FakeThread)
+
+    TimerAlertFrame._start_watch_loop(frame)
+
+    assert frame._watch_start_pending is True
+    assert start_watch_calls == []
+    assert len(threads) == 1
+    assert threads[0].started is True
+    assert threads[0].daemon is True
+
+    threads[0].target(*threads[0].args)
+
+    assert start_watch_calls == [frame.WATCH_INTERVAL_MS]
+    assert call_after_calls == [(frame._complete_watch_start, (watcher,), {})]
+
+
+def test_on_close_stops_existing_watcher_in_background(monkeypatch) -> None:
+    frame = _make_frame()
+    watcher = MagicMock()
+    frame._watcher = watcher
+    frame._watch_timer.IsRunning.return_value = True
+    frame._monitor_timer.IsRunning.return_value = True
+    frame._repeat_timer.IsRunning.return_value = True
+    threads: list[object] = []
+
+    class FakeThread:
+        def __init__(self, *, target, daemon: bool, args: tuple[object, ...] = ()) -> None:
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+            self.started = False
+            threads.append(self)
+
+        def start(self) -> None:
+            self.started = True
+
+    monkeypatch.setattr(timer_alert.threading, "Thread", FakeThread)
+    event = MagicMock()
+
+    TimerAlertFrame.on_close(frame, event)
+
+    assert frame._closed is True
+    assert frame._watcher is None
+    frame._watch_timer.Stop.assert_called_once_with()
+    frame._monitor_timer.Stop.assert_called_once_with()
+    frame._repeat_timer.Stop.assert_called_once_with()
+    watcher.stop.assert_not_called()
+    assert len(threads) == 1
+    assert threads[0].started is True
+    assert threads[0].daemon is True
+
+    threads[0].target(*threads[0].args)
+
+    watcher.stop.assert_called_once_with()
+    event.Skip.assert_called_once_with()

--- a/widgets/timer_alert.py
+++ b/widgets/timer_alert.py
@@ -123,6 +123,7 @@ class TimerAlertFrame(wx.Frame):
     """Polls MTGO challenge timers via the bridge and plays audible alerts."""
 
     WATCH_INTERVAL_MS = TIMER_ALERT_WATCH_INTERVAL_MS
+    WATCH_RETRY_DELAY_MS = 5000
     POLL_INTERVAL_MS = TIMER_ALERT_POLL_INTERVAL_MS
 
     def __init__(self, parent: wx.Window | None = None, locale: str | None = None) -> None:
@@ -136,6 +137,8 @@ class TimerAlertFrame(wx.Frame):
         self._locale = locale
 
         self._watcher: BridgeWatcher | None = None
+        self._watch_start_pending = False
+        self._closed = False
         self._watch_timer = wx.Timer(self)
         self._monitor_timer = wx.Timer(self)
         self._repeat_timer = wx.Timer(self)
@@ -498,26 +501,68 @@ class TimerAlertFrame(wx.Frame):
 
     # ------------------------------------------------------------------ Watch loop -----------------------------------------------------------
     def _start_watch_loop(self) -> None:
-        if self._watcher:
+        if self._closed or self._watcher or self._watch_start_pending:
+            return
+        self._watch_start_pending = True
+        threading.Thread(target=self._watch_start_worker, daemon=True).start()
+
+    def _watch_start_worker(self) -> None:
+        try:
+            watcher = mtgo_bridge.start_watch(interval_ms=self.WATCH_INTERVAL_MS)
+        except FileNotFoundError as exc:
+            logger.error("Bridge executable not found: {}", exc)
+            if not self._closed:
+                wx.CallAfter(self._handle_watch_start_failure, "timer.status.bridge_missing", exc)
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Unable to start bridge watcher")
+            if not self._closed:
+                wx.CallAfter(self._handle_watch_start_failure, "timer.status.bridge_error", exc)
             return
 
-        def starter():
-            try:
-                watcher = mtgo_bridge.start_watch(interval_ms=self.WATCH_INTERVAL_MS)
-            except FileNotFoundError as exc:
-                wx.CallAfter(self._set_status, "timer.status.bridge_missing")
-                logger.error("Bridge executable not found: %s", exc)
-                wx.CallLater(5000, self._start_watch_loop)
-                return
-            except Exception as exc:  # noqa: BLE001
-                logger.exception("Unable to start bridge watcher")
-                wx.CallAfter(self._set_status, "timer.status.bridge_error", error=exc)
-                wx.CallLater(5000, self._start_watch_loop)
-                return
-            self._watcher = watcher
-            wx.CallAfter(self._watch_timer.Start, self.WATCH_INTERVAL_MS)
+        if self._closed:
+            self._stop_watcher_worker(watcher)
+            return
+        wx.CallAfter(self._complete_watch_start, watcher)
 
-        threading.Thread(target=starter, daemon=True).start()
+    def _handle_watch_start_failure(self, status_key: str, error: Exception) -> None:
+        self._watch_start_pending = False
+        if self._closed:
+            return
+        if status_key == "timer.status.bridge_missing":
+            self._set_status(status_key)
+        else:
+            self._set_status(status_key, error=error)
+        wx.CallLater(self.WATCH_RETRY_DELAY_MS, self._start_watch_loop)
+
+    def _complete_watch_start(self, watcher: BridgeWatcher) -> None:
+        self._watch_start_pending = False
+        if self._closed:
+            self._stop_watcher_async(watcher)
+            return
+        if self._watcher is not None and self._watcher is not watcher:
+            self._stop_watcher_async(watcher)
+            return
+        self._watcher = watcher
+        self._watch_timer.Start(self.WATCH_INTERVAL_MS)
+
+    def _stop_watcher_async(self, watcher: BridgeWatcher | None = None) -> None:
+        watcher_to_stop = watcher or self._watcher
+        if watcher is None:
+            self._watcher = None
+        if watcher_to_stop is None:
+            return
+        threading.Thread(
+            target=self._stop_watcher_worker,
+            args=(watcher_to_stop,),
+            daemon=True,
+        ).start()
+
+    def _stop_watcher_worker(self, watcher: BridgeWatcher) -> None:
+        try:
+            watcher.stop()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(f"Failed to stop bridge watcher: {exc}")
 
     def _on_watch_timer(self, _event: wx.TimerEvent) -> None:
         if not self._watcher:
@@ -572,18 +617,15 @@ class TimerAlertFrame(wx.Frame):
 
     # ------------------------------------------------------------------ Lifecycle -------------------------------------------------------------
     def on_close(self, event: wx.CloseEvent) -> None:
+        self._closed = True
+        self._watch_start_pending = False
         if self._watch_timer.IsRunning():
             self._watch_timer.Stop()
         if self._monitor_timer.IsRunning():
             self._monitor_timer.Stop()
         if self._repeat_timer.IsRunning():
             self._repeat_timer.Stop()
-        if self._watcher:
-            try:
-                self._watcher.stop()
-            except Exception as exc:  # noqa: BLE001
-                logger.debug(f"Failed to stop bridge watcher: {exc}")
-            self._watcher = None
+        self._stop_watcher_async()
         event.Skip()
 
 


### PR DESCRIPTION
## Summary
- move timer alert watcher start and stop work off the wx UI thread
- marshal watcher state changes, retries, and timer activation back onto the UI thread
- add headless regression tests for async start and close behavior

## Testing
- python3 -m pytest tests/test_mtgo_bridge_client.py tests/test_timer_alert_async.py
- python3 -m ruff check .
- git ls-files '*.py' | xargs python3 -m black --check

Closes #339