### PR TITLE
Fix metagame changes when previous period has no data

### DIFF
--- a/utils/i18n/_en_us.py
+++ b/utils/i18n/_en_us.py
@@ -226,6 +226,7 @@ MESSAGES: dict[str, str] = {
     "metagame.period.days_ago": "{count} day(s) ago",
     "metagame.period.range_days_ago": "{start}-{end} days ago",
     "metagame.changes.no_data": "No comparison data available",
+    "metagame.changes.previous_missing": "No data from the previous period to compare",
     "metagame.changes.vs_period": "Changes vs {period}",
     "metagame.changes.now": "now",
     "metagame.changes.previous": "previous",

--- a/utils/i18n/_pt_br.py
+++ b/utils/i18n/_pt_br.py
@@ -212,6 +212,7 @@ MESSAGES: dict[str, str] = {
     "metagame.period.days_ago": "há {count} dia(s)",
     "metagame.period.range_days_ago": "há {start}-{end} dias",
     "metagame.changes.no_data": "Sem dados de comparação disponíveis",
+    "metagame.changes.previous_missing": "Sem dados do período anterior para comparar",
     "metagame.changes.vs_period": "Mudanças em relação a {period}",
     "metagame.changes.now": "atualmente",
     "metagame.changes.none": "Nenhuma mudança significativa",

--- a/widgets/metagame_analysis.py
+++ b/widgets/metagame_analysis.py
@@ -442,6 +442,20 @@ class MetagameAnalysisFrame(wx.Frame):
             )
             return
 
+        previous_total = sum(self.previous_data.values())
+        if previous_total == 0:
+            self._set_changes_html(
+                self._build_changes_html(
+                    self._t("metagame.label.changes"),
+                    [
+                        "<div class='empty'>"
+                        f"{escape(self._t('metagame.changes.previous_missing'))}"
+                        "</div>"
+                    ],
+                )
+            )
+            return
+
         current_pct = self._calculate_percentages(self.current_data)
         previous_pct = self._calculate_percentages(self.previous_data)
 


### PR DESCRIPTION
## Summary\n- detect when the previous comparison window has zero total decks\n- show a disclaimer instead of rendering change cards in that case\n- add i18n strings for the new disclaimer in English and Portuguese\n\n## Testing\n- python3 -m pytest tests/test_i18n.py\n- python3 -m ruff check widgets/metagame_analysis.py utils/i18n/_en_us.py utils/i18n/_pt_br.py\n\nCloses #346