### PR TITLE
Preserve bundle MTGO decks during live MTGGoldfish scrape (#173)

### DIFF
--- a/repositories/metagame_repository.py
+++ b/repositories/metagame_repository.py
@@ -213,11 +213,15 @@ class MetagameRepository:
         try:
             # get_archetype_decks expects just the href string, not the dict
             decks = get_archetype_decks(archetype_href)
-            # Cache the results
-            self._save_cached_decks(archetype_href, decks)
-            mtggoldfish_decks = self._filter_decks_by_source(decks, source_filter)
+            # Preserve any MTGO-sourced entries hydrated from the remote bundle so
+            # a live MTGGoldfish refresh does not evict them from the cache.
+            existing = self._load_cached_decks(archetype_href, max_age=None) or []
+            bundle_mtgo = [d for d in existing if d.get("source") == "mtgo"]
+            merged = decks + bundle_mtgo
+            self._save_cached_decks(archetype_href, merged)
+            filtered = self._filter_decks_by_source(merged, source_filter)
             mtgo_decks = self._get_mtgo_decks_from_db(archetype_name, source_filter)
-            return self._merge_and_sort_decks(mtggoldfish_decks, mtgo_decks)
+            return self._merge_and_sort_decks(filtered, mtgo_decks)
         except Exception as exc:
             logger.error(f"Failed to fetch decks for {archetype_name}: {exc}")
             # Try to return stale cache if available

--- a/tests/test_metagame_repository.py
+++ b/tests/test_metagame_repository.py
@@ -380,6 +380,150 @@ def test_get_decks_respects_source_filters_and_sorting(
     assert all(deck["source"] == "mtgo" for deck in mtgo_only)
 
 
+# ============= Bundle MTGO Preservation Tests =============
+
+
+def test_live_scrape_preserves_bundle_mtgo_decks(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """A live MTGGoldfish scrape must not evict MTGO decks hydrated from the bundle."""
+    repo = MetagameRepository(
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    bundle_mtgo = {"name": "Bundle MTGO", "date": "2026-03-25", "source": "mtgo", "number": "m1"}
+    fresh_gf = {"name": "GF Fresh", "date": "2026-03-26", "source": "mtggoldfish", "number": "g1"}
+    archetype = {"href": "test-arch", "name": "Test"}
+
+    # Seed the cache with a bundle-provided MTGO entry
+    _write_cache(
+        archetype_deck_cache_file,
+        {"test-arch": {"timestamp": time.time(), "items": [bundle_mtgo]}},
+    )
+
+    monkeypatch.setattr(
+        "repositories.metagame_repository.get_archetype_decks",
+        lambda _href: [fresh_gf],
+    )
+    monkeypatch.setattr(repo, "_get_mtgo_decks_from_db", lambda *_: [])
+
+    result = repo.get_decks_for_archetype(archetype, force_refresh=True)
+
+    names = [d["name"] for d in result]
+    assert "Bundle MTGO" in names
+    assert "GF Fresh" in names
+
+
+def test_live_scrape_preserves_only_mtgo_source(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """Only entries with source='mtgo' are preserved; old MTGGoldfish entries are replaced."""
+    repo = MetagameRepository(
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    old_gf = {"name": "Old GF", "date": "2026-01-01", "source": "mtggoldfish", "number": "g0"}
+    bundle_mtgo = {"name": "Bundle MTGO", "date": "2026-03-25", "source": "mtgo", "number": "m1"}
+    fresh_gf = {"name": "GF Fresh", "date": "2026-03-26", "source": "mtggoldfish", "number": "g1"}
+    archetype = {"href": "test-arch", "name": "Test"}
+
+    _write_cache(
+        archetype_deck_cache_file,
+        {"test-arch": {"timestamp": time.time(), "items": [old_gf, bundle_mtgo]}},
+    )
+
+    monkeypatch.setattr(
+        "repositories.metagame_repository.get_archetype_decks",
+        lambda _href: [fresh_gf],
+    )
+    monkeypatch.setattr(repo, "_get_mtgo_decks_from_db", lambda *_: [])
+
+    result = repo.get_decks_for_archetype(archetype, force_refresh=True)
+
+    names = [d["name"] for d in result]
+    assert "Old GF" not in names  # replaced by fresh scrape
+    assert "GF Fresh" in names
+    assert "Bundle MTGO" in names  # preserved
+
+
+def test_live_scrape_no_prior_bundle_entries(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """Live scrape with no prior bundle MTGO entries behaves the same as before."""
+    repo = MetagameRepository(
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    fresh_gf = {"name": "GF Fresh", "date": "2026-03-26", "source": "mtggoldfish", "number": "g1"}
+    archetype = {"href": "test-arch", "name": "Test"}
+
+    monkeypatch.setattr(
+        "repositories.metagame_repository.get_archetype_decks",
+        lambda _href: [fresh_gf],
+    )
+    monkeypatch.setattr(repo, "_get_mtgo_decks_from_db", lambda *_: [])
+
+    result = repo.get_decks_for_archetype(archetype, force_refresh=True)
+
+    assert len(result) == 1
+    assert result[0]["name"] == "GF Fresh"
+
+
+def test_cached_path_returns_bundle_mtgo_decks(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """Bundle MTGO decks in the archetype cache are returned on the cache hit path."""
+    repo = MetagameRepository(
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    bundle_mtgo = {"name": "Bundle MTGO", "date": "2026-03-25", "source": "mtgo", "number": "m1"}
+    gf_deck = {"name": "GF Deck", "date": "2026-03-24", "source": "mtggoldfish", "number": "g1"}
+    archetype = {"href": "test-arch", "name": "Test"}
+
+    _write_cache(
+        archetype_deck_cache_file,
+        {"test-arch": {"timestamp": time.time(), "items": [gf_deck, bundle_mtgo]}},
+    )
+    monkeypatch.setattr(repo, "_get_mtgo_decks_from_db", lambda *_: [])
+
+    result = repo.get_decks_for_archetype(archetype)
+
+    names = [d["name"] for d in result]
+    assert "Bundle MTGO" in names
+    assert "GF Deck" in names
+
+
+def test_saved_cache_after_live_scrape_contains_bundle_mtgo(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """After a live scrape, persisted cache contains both fresh GF and bundle MTGO entries."""
+    repo = MetagameRepository(
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    bundle_mtgo = {"name": "Bundle MTGO", "date": "2026-03-25", "source": "mtgo", "number": "m1"}
+    fresh_gf = {"name": "GF Fresh", "date": "2026-03-26", "source": "mtggoldfish", "number": "g1"}
+    archetype = {"href": "test-arch", "name": "Test"}
+
+    _write_cache(
+        archetype_deck_cache_file,
+        {"test-arch": {"timestamp": time.time(), "items": [bundle_mtgo]}},
+    )
+    monkeypatch.setattr(
+        "repositories.metagame_repository.get_archetype_decks",
+        lambda _href: [fresh_gf],
+    )
+    monkeypatch.setattr(repo, "_get_mtgo_decks_from_db", lambda *_: [])
+
+    repo.get_decks_for_archetype(archetype, force_refresh=True)
+
+    saved = json.loads(archetype_deck_cache_file.read_text())
+    saved_names = [d["name"] for d in saved["test-arch"]["items"]]
+    assert "Bundle MTGO" in saved_names
+    assert "GF Fresh" in saved_names
+
+
 # ============= Clear Cache Tests =============
 
 


### PR DESCRIPTION
## Summary

- When the remote bundle (from `MTGO_Scrapes_Repository`) hydrates MTGO-sourced deck entries into the archetype decks cache, a subsequent live MTGGoldfish refresh was silently overwriting them
- `get_decks_for_archetype` now reads existing `source="mtgo"` entries from the cache before writing fresh MTGGoldfish results, merging them so bundle-provided MTGO decks survive the refresh
- The `_save_cached_decks` write path is unchanged — the merge logic lives in the caller, keeping the helper simple

## How it works

MTGO decks from the remote bundle land in `ARCHETYPE_DECKS_CACHE_FILE` with `source="mtgo"`. On a live scrape (`force_refresh=True`), `get_archetype_decks` returns only MTGGoldfish entries. The fix reads any existing `source="mtgo"` items from the stale cache before overwriting, merges them with the fresh MTGGoldfish entries, and writes the combined list back. The cached path was already correct.

## Test plan

- [x] `test_live_scrape_preserves_bundle_mtgo_decks` — MTGO entries in cache survive a force-refresh
- [x] `test_live_scrape_preserves_only_mtgo_source` — old MTGGoldfish entries are replaced, MTGO preserved
- [x] `test_live_scrape_no_prior_bundle_entries` — no regressions when no MTGO entries exist
- [x] `test_cached_path_returns_bundle_mtgo_decks` — cache-hit path returns mixed sources correctly
- [x] `test_saved_cache_after_live_scrape_contains_bundle_mtgo` — persisted cache has both sources after refresh
- [x] All 424 existing tests continue to pass

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)