### PR TITLE
Parallelize archetype fetch with bundle download (optimistic load)

### DIFF
--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -479,29 +479,33 @@ class AppController:
     def run_initial_loads(self, deck_save_dir: Path, force_archetypes: bool = False) -> None:
         callbacks = self._ui_callbacks
 
-        # Step 1: Apply remote bundle to warm caches, then fetch archetypes.
-        # On failure the fetch still proceeds so the live scraper path handles it.
-        def _apply_bundle():
+        # Step 1: Start archetype fetch immediately from local cache (optimistic load),
+        # and run the bundle download in parallel.  If apply() returns True the caches
+        # were updated, so trigger a silent background re-fetch to refresh the list.
+        self.fetch_archetypes(
+            on_success=callbacks.on_archetypes_success if callbacks else None,
+            on_error=callbacks.on_archetypes_error if callbacks else None,
+            on_status=callbacks.on_status if callbacks else None,
+            force=force_archetypes,
+        )
+
+        def _apply_bundle() -> bool:
             from services.bundle_snapshot_client import get_bundle_snapshot_client
 
-            get_bundle_snapshot_client().apply()
+            return get_bundle_snapshot_client().apply()
 
-        def _on_bundle_done(_: Any) -> None:
-            self.fetch_archetypes(
-                on_success=callbacks.on_archetypes_success if callbacks else None,
-                on_error=callbacks.on_archetypes_error if callbacks else None,
-                on_status=callbacks.on_status if callbacks else None,
-                force=force_archetypes,
-            )
+        def _on_bundle_done(updated: bool) -> None:
+            if updated:
+                # Caches were refreshed — silently re-fetch so the UI reflects new data.
+                self.fetch_archetypes(
+                    on_success=callbacks.on_archetypes_success if callbacks else None,
+                    on_error=callbacks.on_archetypes_error if callbacks else None,
+                    on_status=callbacks.on_status if callbacks else None,
+                    force=True,
+                )
 
         def _on_bundle_error(exc: Exception) -> None:
-            logger.warning(f"Remote bundle apply failed, proceeding with live fetch: {exc}")
-            self.fetch_archetypes(
-                on_success=callbacks.on_archetypes_success if callbacks else None,
-                on_error=callbacks.on_archetypes_error if callbacks else None,
-                on_status=callbacks.on_status if callbacks else None,
-                force=force_archetypes,
-            )
+            logger.warning(f"Remote bundle apply failed: {exc}")
 
         self._worker.submit(_apply_bundle, on_success=_on_bundle_done, on_error=_on_bundle_error)
 


### PR DESCRIPTION
## Summary
- Fixes #350
- Start archetype fetch from local cache immediately at startup, rather than waiting for bundle download to complete
- Bundle download runs in parallel; if `apply()` returns `True` (caches updated), a silent background re-fetch refreshes the already-visible list
- On bundle error, the initial optimistic fetch already covers the live-scrape fallback path — no duplicate error handler needed

## Behavior
| Cache state | Before | After |
|---|---|---|
| Fresh stamp | Fast path: archetypes appeared after ~0s bundle check | Same: archetypes appear instantly, bundle check is background no-op |
| Stale stamp | Blocked 2–5s on bundle download before archetypes showed | Archetypes from cache appear immediately; bundle downloads in background and re-fetches if updated |
| Empty cache | Blocked on bundle, then live scrape | Live scrape starts immediately in parallel with bundle |

## Test plan
- [ ] Run `python3 -m pytest tests/ -q --ignore=tests/ui` — 424 pass, pre-existing wx failures unchanged
- [ ] Launch app with stale bundle stamp and confirm archetype list appears before bundle finishes
- [ ] Launch app with fresh stamp and confirm no duplicate fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)