### PR TITLE
Pre-load card index at startup to eliminate first-search delay

### DIFF
--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -523,6 +523,14 @@ class AppController:
         # Step 4: Check and download bulk data if needed (non-blocking)
         self.check_and_download_bulk_data()
 
+        # Step 5: Pre-load 59 MB card index in the background so it is ready
+        # before the user first types in the builder search box.
+        self.ensure_card_data_loaded(
+            on_success=lambda _: None,
+            on_error=lambda exc: logger.warning(f"Background card data pre-load failed: {exc}"),
+            on_status=callbacks.on_status if callbacks else lambda *a, **kw: None,
+        )
+
     # ============= Frame Factory =============
 
     def create_frame(self, parent: wx.Window | None = None) -> AppFrame:


### PR DESCRIPTION
## Summary
- Calls `ensure_card_data_loaded()` in `run_initial_loads()` so the 59 MB card index is fetched in a background thread at app startup
- Eliminates the visible lag when the user types in the builder search box for the first time
- Uses existing idempotency guards (`is_card_data_loaded()` / `is_card_data_loading()`) — no double-loading risk

## Details
Added as Step 5 in `run_initial_loads()`, alongside the existing parallel bundle fetch, collection load, and bulk data check. `on_success` is a no-op (the manager is stored in `card_repo` internally); `on_error` logs a warning so a failed pre-load is silent and the existing user-triggered path still works as a fallback.

Closes #351

## Test plan
- [ ] Launch the app and open the builder search box — no first-keystroke delay
- [ ] Confirm existing test suite passes (pre-existing failures in `test_identify_opponent_radar` and `test_mtggoldfish` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)