### PR TITLE
Stale-while-revalidate for archetype cache

### DIFF
--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -191,8 +191,14 @@ class AppController:
 
         on_status("app.status.loading_archetypes_for", format=self.current_format)
 
+        def _on_bg_refresh(fresh_archetypes: list[dict[str, Any]]) -> None:
+            """Called from the repository's background thread with fresh archetype data."""
+            on_success(fresh_archetypes)
+
         def loader(fmt: str):
-            return self.workflow_service.fetch_archetypes(fmt, force=force)
+            return self.metagame_repo.get_archetypes_for_format(
+                fmt, force_refresh=force, on_background_refresh=_on_bg_refresh
+            )
 
         def success_handler(archetypes: list[dict[str, Any]]):
             with self._loading_lock:

--- a/repositories/metagame_repository.py
+++ b/repositories/metagame_repository.py
@@ -8,7 +8,9 @@ This module handles all metagame-related data fetching including:
 """
 
 import json
+import threading
 import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
@@ -86,32 +88,48 @@ class MetagameRepository:
     # ============= Archetype Operations =============
 
     def get_archetypes_for_format(
-        self, mtg_format: str, force_refresh: bool = False
+        self,
+        mtg_format: str,
+        force_refresh: bool = False,
+        on_background_refresh: Callable[[list[dict[str, Any]]], None] | None = None,
     ) -> list[dict[str, Any]]:
         """
         Get list of archetypes for a specific format.
 
         Resolution order (unless force_refresh):
         1. Local cache (if still fresh)
-        2. Remote snapshot (if REMOTE_SNAPSHOTS_ENABLED)
-        3. Live MTGGoldfish scrape
-        4. Stale local cache (last-resort fallback on live-scrape failure)
+        2. Stale local cache — returned immediately while a background re-fetch is
+           triggered via ``on_background_refresh`` (stale-while-revalidate)
+        3. Remote snapshot (if REMOTE_SNAPSHOTS_ENABLED)
+        4. Live MTGGoldfish scrape
+        5. Stale local cache (last-resort fallback on live-scrape failure)
 
         Args:
             mtg_format: MTG format (e.g., "Modern", "Standard")
             force_refresh: If True, bypass local cache and fetch fresh data
+            on_background_refresh: Optional callback invoked with fresh archetypes
+                once the background re-fetch completes (only used when stale cache
+                is returned via the stale-while-revalidate path).
 
         Returns:
             List of archetype dictionaries with keys: name, url, share, etc.
         """
-        # 1. Local cache
+        # 1. Fresh local cache
         if not force_refresh:
             cached = self._load_cached_archetypes(mtg_format)
             if cached is not None:
                 logger.debug(f"[local-cache] archetypes for {mtg_format}")
                 return cached
 
-        # 2. Remote snapshot
+            # 2. Stale-while-revalidate: return stale immediately and refresh in background
+            stale = self._load_cached_archetypes(mtg_format, max_age=None)
+            if stale is not None:
+                logger.info(f"[stale-while-revalidate] archetypes for {mtg_format}")
+                if on_background_refresh is not None:
+                    self._trigger_background_refresh(mtg_format, on_background_refresh)
+                return stale
+
+        # 3. Remote snapshot
         remote = self._remote_client_or_default()
         if remote is not None:
             try:
@@ -123,7 +141,7 @@ class MetagameRepository:
             except Exception as exc:
                 logger.warning(f"Remote snapshot archetypes failed for {mtg_format}: {exc}")
 
-        # 3. Live scrape
+        # 4. Live scrape
         logger.info(f"[live-scrape] archetypes for {mtg_format}")
         try:
             archetypes = get_archetypes(mtg_format)
@@ -131,7 +149,7 @@ class MetagameRepository:
             return archetypes
         except Exception as exc:
             logger.error(f"Failed to fetch archetypes: {exc}")
-            # 4. Stale cache as last resort
+            # 5. Stale cache as last resort
             cached = self._load_cached_archetypes(mtg_format, max_age=None)
             if cached:
                 logger.warning(f"[stale-cache] archetypes for {mtg_format}")
@@ -278,6 +296,35 @@ class MetagameRepository:
         from services.remote_snapshot_client import get_remote_snapshot_client
 
         return get_remote_snapshot_client()
+
+    def _trigger_background_refresh(
+        self, mtg_format: str, callback: Callable[[list[dict[str, Any]]], None]
+    ) -> None:
+        """Spawn a daemon thread to fetch fresh archetypes and call *callback* on success.
+
+        Resolution order mirrors the main fetch (remote snapshot → live scrape).
+        On failure the exception is logged and *callback* is not invoked.
+        """
+
+        def _do_refresh() -> None:
+            try:
+                remote = self._remote_client_or_default()
+                if remote is not None:
+                    try:
+                        fresh = remote.get_archetypes_for_format(mtg_format)
+                        if fresh is not None:
+                            self._save_cached_archetypes(mtg_format, fresh)
+                            callback(fresh)
+                            return
+                    except Exception:
+                        pass
+                fresh = get_archetypes(mtg_format)
+                self._save_cached_archetypes(mtg_format, fresh)
+                callback(fresh)
+            except Exception as exc:
+                logger.warning(f"[background-refresh] archetypes for {mtg_format} failed: {exc}")
+
+        threading.Thread(target=_do_refresh, daemon=True, name=f"archetype-bg-{mtg_format}").start()
 
     # ============= Cache Management =============
 

--- a/tests/test_metagame_repository.py
+++ b/tests/test_metagame_repository.py
@@ -233,6 +233,175 @@ def test_get_decks_returns_stale_cache_when_fetch_fails(
     assert result == stale_items
 
 
+# ============= Stale-While-Revalidate Tests =============
+
+
+def test_stale_while_revalidate_returns_stale_immediately(
+    archetype_cache_file, archetype_deck_cache_file
+):
+    """When cache is stale, get_archetypes_for_format returns it right away."""
+    repo = MetagameRepository(
+        cache_ttl=1,
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    stale_items = [{"name": "UR Murktide"}]
+    _write_cache(
+        archetype_cache_file,
+        {"Modern": {"timestamp": time.time() - 3600, "items": stale_items}},
+    )
+
+    result = repo.get_archetypes_for_format("Modern")
+
+    assert result == stale_items
+
+
+def test_stale_while_revalidate_triggers_background_refresh(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """Background refresh callback is invoked with fresh data when cache is stale."""
+    import threading
+
+    repo = MetagameRepository(
+        cache_ttl=1,
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    stale_items = [{"name": "UR Murktide"}]
+    fresh_items = [{"name": "UR Murktide"}, {"name": "Amulet Titan"}]
+    _write_cache(
+        archetype_cache_file,
+        {"Modern": {"timestamp": time.time() - 3600, "items": stale_items}},
+    )
+
+    monkeypatch.setattr(
+        "repositories.metagame_repository.get_archetypes",
+        lambda _fmt: fresh_items,
+    )
+
+    refresh_received: list[list] = []
+    done = threading.Event()
+
+    def on_refresh(items):
+        refresh_received.append(items)
+        done.set()
+
+    result = repo.get_archetypes_for_format("Modern", on_background_refresh=on_refresh)
+
+    assert result == stale_items
+    assert done.wait(timeout=5), "background refresh did not complete in time"
+    assert refresh_received == [fresh_items]
+
+
+def test_stale_while_revalidate_no_callback_no_background_thread(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """No background thread is started when on_background_refresh is not provided."""
+    repo = MetagameRepository(
+        cache_ttl=1,
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    stale_items = [{"name": "UR Murktide"}]
+    _write_cache(
+        archetype_cache_file,
+        {"Modern": {"timestamp": time.time() - 3600, "items": stale_items}},
+    )
+
+    triggered = []
+    monkeypatch.setattr(repo, "_trigger_background_refresh", lambda *a: triggered.append(a))
+
+    repo.get_archetypes_for_format("Modern")
+
+    assert triggered == [], "background refresh should not be triggered without a callback"
+
+
+def test_stale_while_revalidate_updates_cache_on_refresh(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """Background refresh persists fresh data to the cache."""
+    import threading
+
+    repo = MetagameRepository(
+        cache_ttl=1,
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    stale_items = [{"name": "UR Murktide"}]
+    fresh_items = [{"name": "UR Murktide"}, {"name": "Amulet Titan"}]
+    _write_cache(
+        archetype_cache_file,
+        {"Modern": {"timestamp": time.time() - 3600, "items": stale_items}},
+    )
+
+    monkeypatch.setattr(
+        "repositories.metagame_repository.get_archetypes",
+        lambda _fmt: fresh_items,
+    )
+
+    done = threading.Event()
+    repo.get_archetypes_for_format("Modern", on_background_refresh=lambda _: done.set())
+    done.wait(timeout=5)
+
+    # After background refresh the cache should be fresh
+    cached = repo._load_cached_archetypes("Modern")
+    assert cached == fresh_items
+
+
+def test_stale_while_revalidate_background_failure_is_silent(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """A failed background refresh does not invoke the callback and does not raise."""
+    import threading
+
+    repo = MetagameRepository(
+        cache_ttl=1,
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    stale_items = [{"name": "UR Murktide"}]
+    _write_cache(
+        archetype_cache_file,
+        {"Modern": {"timestamp": time.time() - 3600, "items": stale_items}},
+    )
+
+    monkeypatch.setattr(
+        "repositories.metagame_repository.get_archetypes",
+        lambda _fmt: (_ for _ in ()).throw(RuntimeError("network down")),
+    )
+
+    callback_called = threading.Event()
+    repo.get_archetypes_for_format("Modern", on_background_refresh=lambda _: callback_called.set())
+
+    # Give thread a moment to fail
+    callback_called.wait(timeout=1)
+    assert not callback_called.is_set(), "callback must not be called on refresh failure"
+
+
+def test_fresh_cache_does_not_trigger_background_refresh(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """When cache is fresh, no background refresh is triggered."""
+    repo = MetagameRepository(
+        cache_ttl=3600,
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    fresh_items = [{"name": "Cascade Crasher"}]
+    _write_cache(
+        archetype_cache_file,
+        {"Modern": {"timestamp": time.time(), "items": fresh_items}},
+    )
+
+    triggered = []
+    monkeypatch.setattr(repo, "_trigger_background_refresh", lambda *a: triggered.append(a))
+
+    result = repo.get_archetypes_for_format("Modern", on_background_refresh=lambda _: None)
+
+    assert result == fresh_items
+    assert triggered == [], "background refresh must not fire on a fresh cache hit"
+
+
 # ============= Stale Fallback Tests =============
 
 

--- a/widgets/handlers/app_event_handlers.py
+++ b/widgets/handlers/app_event_handlers.py
@@ -305,7 +305,12 @@ class AppEventHandlers:
         self.research_panel.enable_controls()
         count = len(self.archetypes)
         self._set_status("app.research.archetypes_loaded", count=count, format=self.current_format)
-        self.summary_text.ChangeValue(self._t("app.research.select_archetype_loaded", count=count))
+        # Skip overwriting the deck summary if a deck is already displayed — this handler
+        # may be called a second time by the background stale-while-revalidate refresh.
+        if not self._has_deck_loaded():
+            self.summary_text.ChangeValue(
+                self._t("app.research.select_archetype_loaded", count=count)
+            )
 
     def _on_archetypes_error(self: AppFrame, error: Exception) -> None:
         with self._loading_lock:


### PR DESCRIPTION
## Summary

- **Eliminates the blank archetype list window** for returning users: when the local cache is stale (expired but present) the cached list is returned immediately while a background daemon thread fetches fresh data and updates the UI silently once it arrives.
- **New resolution order** in `metagame_repository.get_archetypes_for_format()`: fresh cache → stale cache (+ background refresh) → remote snapshot → live scrape → last-resort stale fallback.
- **Controller wiring** (`app_controller.fetch_archetypes`): passes an `on_background_refresh` callback so the repository's background thread can push fresh results back to the UI without a second explicit fetch call.
- **Event handler guard** (`_on_archetypes_loaded`): skips overwriting the deck summary text when a deck is already loaded, preventing the silent refresh from clobbering in-progress deck work.
- **6 new tests** covering: immediate stale return, background callback invocation, no-callback no-thread path, cache update after refresh, silent failure handling, and fresh-cache no-op.

## Test plan

- [x] `pytest tests/test_metagame_repository.py` — 40 pass
- [x] `pytest tests/ --ignore=tests/ui` — 430 pass (3 pre-existing wx failures unchanged)
- [x] `ruff check` — no issues
- [x] `black --check` — clean after formatting with 26.3.1

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)