### PR TITLE
Fix remote bundle URL to use data-publish branch

### DIFF
--- a/utils/constants/__init__.py
+++ b/utils/constants/__init__.py
@@ -242,7 +242,7 @@ MTGO_DECKLISTS_ENABLED = os.getenv("MTGO_DECKLISTS_ENABLED", "false").lower() ==
 REMOTE_SNAPSHOTS_ENABLED = os.getenv("REMOTE_SNAPSHOTS_ENABLED", "false").lower() == "true"
 REMOTE_SNAPSHOT_BASE_URL = os.getenv(
     "REMOTE_SNAPSHOT_BASE_URL",
-    "https://raw.githubusercontent.com/Pedrogush/MTGO_Scrapes_Repository/main",
+    "https://raw.githubusercontent.com/Pedrogush/MTGO_Scrapes_Repository/data-publish",
 )
 REMOTE_SNAPSHOT_BUNDLE_PATH = "data/latest/client-bundle.tar.gz"
 


### PR DESCRIPTION
## Summary
- Changes `REMOTE_SNAPSHOT_BASE_URL` default from `.../main` to `.../data-publish` so the app fetches the client bundle from the correct branch of the scrape repository

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)