### PR TITLE
Add deck source emoji labels for Both mode (#369)

### DIFF
--- a/services/bundle_snapshot_client.py
+++ b/services/bundle_snapshot_client.py
@@ -134,6 +134,7 @@ class BundleSnapshotClient:
             deck_texts,
             card_pool_entries,
             radar_entries,
+            mtgo_decklist_entries,
         ) = self._parse_bundle(bundle_bytes)
 
         generated_at = manifest.get("generated_at", "")
@@ -141,6 +142,7 @@ class BundleSnapshotClient:
 
         self._hydrate_archetype_lists(archetype_entries, now)
         self._hydrate_archetype_decks(deck_entries, now)
+        mtgo_merged = self._hydrate_mtgo_decklists(mtgo_decklist_entries, archetype_entries, now)
         card_pools = self._hydrate_format_card_pools(card_pool_entries)
         radars = self._hydrate_radars(radar_entries)
         inserted = self._hydrate_deck_texts(deck_texts)
@@ -149,6 +151,7 @@ class BundleSnapshotClient:
         logger.info(
             f"Bundle applied: {len(archetype_entries)} archetype lists, "
             f"{len(deck_entries)} deck lists, "
+            f"{mtgo_merged} MTGO decks merged, "
             f"{card_pools}/{len(card_pool_entries)} card pools, "
             f"{radars}/{len(radar_entries)} radars, "
             f"{inserted}/{len(deck_texts)} deck texts inserted (generated_at={generated_at})"
@@ -210,6 +213,7 @@ class BundleSnapshotClient:
         list[tuple[str, str, str]],
         list[dict[str, Any]],
         list[dict[str, Any]],
+        list[dict[str, Any]],
     ]:
         """Extract the bundle and return bundle entries grouped by artifact type.
 
@@ -218,6 +222,8 @@ class BundleSnapshotClient:
         JSON from ``latest/decks/{format}/{slug}.json``.  Each deck_texts element
         is a ``(deck_id, deck_text, source)`` tuple ready for ``DeckTextCache.bulk_set``,
         extracted from ``archive/deck-texts/{format}/{id}.json``.
+        Each mtgo_decklist entry is the full parsed JSON from
+        ``latest/mtgo-decklists/{format}.json``.
         """
         manifest: dict[str, Any] = {}
         archetype_entries: list[dict[str, Any]] = []
@@ -225,6 +231,7 @@ class BundleSnapshotClient:
         deck_texts: list[tuple[str, str, str]] = []
         card_pool_entries: list[dict[str, Any]] = []
         radar_entries: list[dict[str, Any]] = []
+        mtgo_decklist_entries: list[dict[str, Any]] = []
 
         with tarfile.open(fileobj=io.BytesIO(bundle_bytes), mode="r:gz") as tf:
             for member in tf.getmembers():
@@ -244,6 +251,8 @@ class BundleSnapshotClient:
 
                 if name.endswith("latest.json"):
                     manifest = data
+                elif name.startswith("latest/mtgo-decklists/") and name.endswith(".json"):
+                    mtgo_decklist_entries.append(data)
                 elif "/archetypes/" in name and name.endswith(".json"):
                     archetype_entries.append(data)
                 elif "/card-pools/" in name and name.endswith(".json"):
@@ -266,6 +275,7 @@ class BundleSnapshotClient:
             deck_texts,
             card_pool_entries,
             radar_entries,
+            mtgo_decklist_entries,
         )
 
     # ------------------------------------------------------------------ #
@@ -347,6 +357,109 @@ class BundleSnapshotClient:
         except Exception as exc:
             logger.warning(f"Failed to hydrate deck texts: {exc}")
             return 0
+
+    def _hydrate_mtgo_decklists(
+        self,
+        mtgo_decklist_entries: list[dict[str, Any]],
+        archetype_entries: list[dict[str, Any]],
+        now: float,
+    ) -> int:
+        """Merge MTGO event decklists from bundle into the archetype deck cache.
+
+        Builds a name→href lookup from ``archetype_entries``, then for each MTGO
+        deck whose ``archetype`` field matches a known archetype name, injects the
+        deck metadata into the archetype deck cache and stores the inline deck text
+        in the SQLite deck text cache.
+
+        Returns the number of MTGO decks merged.
+        """
+        if not mtgo_decklist_entries:
+            return 0
+
+        # Build {format: {archetype_name: href}} from the archetype list entries
+        name_to_href: dict[str, dict[str, str]] = {}
+        for entry in archetype_entries:
+            fmt = entry.get("format", "").lower()
+            for arch in entry.get("archetypes", []):
+                name = arch.get("name", "")
+                href = arch.get("href", "")
+                if name and href:
+                    name_to_href.setdefault(fmt, {})[name] = href
+
+        # Collect deck texts and per-href metadata from all MTGO events
+        deck_texts: list[tuple[str, str, str]] = []
+        decks_by_href: dict[str, list[dict[str, Any]]] = {}
+
+        for entry in mtgo_decklist_entries:
+            fmt = entry.get("format", "").lower()
+            fmt_lookup = name_to_href.get(fmt, {})
+            for event in entry.get("events", []):
+                for deck in event.get("decks", []):
+                    arch_name = deck.get("archetype", "")
+                    href = fmt_lookup.get(arch_name)
+                    if not href:
+                        continue
+                    deck_id = deck.get("number", "")
+                    deck_text = deck.get("deck_text", "")
+                    if deck_id and deck_text:
+                        deck_texts.append((deck_id, deck_text, "mtgo"))
+                    date_raw = deck.get("date", "")
+                    metadata: dict[str, Any] = {
+                        "date": date_raw[:10] if date_raw else "",
+                        "number": deck_id,
+                        "player": deck.get("player", ""),
+                        "event": deck.get("event", ""),
+                        "result": deck.get("result", ""),
+                        "name": deck.get("name", ""),
+                        "source": "mtgo",
+                    }
+                    decks_by_href.setdefault(href, []).append(metadata)
+
+        if not decks_by_href:
+            logger.debug("No MTGO decks could be matched to known archetypes")
+            return 0
+
+        # Store deck texts
+        if deck_texts:
+            try:
+                from utils.deck_text_cache import get_deck_cache
+
+                get_deck_cache().bulk_set(deck_texts, skip_existing=True)
+            except Exception as exc:
+                logger.warning(f"Failed to insert MTGO deck texts: {exc}")
+
+        # Merge into archetype decks cache
+        total = 0
+        with locked_path(self.archetype_decks_cache_file):
+            existing: dict[str, Any] = {}
+            if self.archetype_decks_cache_file.exists():
+                try:
+                    existing = json.loads(
+                        self.archetype_decks_cache_file.read_text(encoding="utf-8")
+                    )
+                except (OSError, json.JSONDecodeError):
+                    pass
+
+            for href, mtgo_decks in decks_by_href.items():
+                existing_entry = existing.get(href, {})
+                existing_items = existing_entry.get("items", [])
+                # Replace any previously merged MTGO entries to avoid duplicates
+                goldfish_items = [d for d in existing_items if d.get("source") != "mtgo"]
+                existing[href] = {
+                    "timestamp": existing_entry.get("timestamp", now),
+                    "items": goldfish_items + mtgo_decks,
+                }
+                total += len(mtgo_decks)
+
+            try:
+                atomic_write_json(self.archetype_decks_cache_file, existing, indent=2)
+                logger.debug(
+                    f"Merged {total} MTGO decks into {len(decks_by_href)} archetype cache entries"
+                )
+            except OSError as exc:
+                logger.warning(f"Failed to write archetype decks cache with MTGO decks: {exc}")
+
+        return total
 
     def _hydrate_format_card_pools(self, card_pool_entries: list[dict[str, Any]]) -> int:
         """Insert or replace precomputed format card pools into SQLite."""

--- a/tests/test_bundle_snapshot_client.py
+++ b/tests/test_bundle_snapshot_client.py
@@ -35,6 +35,7 @@ def _make_bundle(
     deck_texts: list[dict[str, Any]] | None = None,
     card_pools: list[dict[str, Any]] | None = None,
     radars: list[dict[str, Any]] | None = None,
+    mtgo_decklists: list[dict[str, Any]] | None = None,
 ) -> bytes:
     """Build an in-memory client-bundle.tar.gz for testing."""
     if manifest is None:
@@ -166,6 +167,10 @@ def _make_bundle(
             fmt = radar.get("format", "modern")
             href = radar.get("archetype", {}).get("href", "unknown")
             _add(f"latest/radars/{fmt}/{href}.json", radar)
+        if mtgo_decklists:
+            for mtgo_entry in mtgo_decklists:
+                fmt = mtgo_entry.get("format", "modern")
+                _add(f"latest/mtgo-decklists/{fmt}.json", mtgo_entry)
 
     return buf.getvalue()
 
@@ -513,3 +518,161 @@ def test_singleton_reset() -> None:
     c2 = get_bundle_snapshot_client()
     assert c1 is c2
     reset_bundle_snapshot_client()
+
+
+# ---------------------------------------------------------------------------
+# MTGO decklist hydration
+# ---------------------------------------------------------------------------
+
+_MTGO_DECKLIST_ENTRY = {
+    "schema_version": 1,
+    "kind": "mtgo_decklists",
+    "format": _FORMAT,
+    "source": "mtgo.com",
+    "days": 7,
+    "events": [
+        {
+            "id": "modern-challenge-64-2026-03-31",
+            "url": "https://www.mtgo.com/decklist/modern-challenge-64-2026-03-31",
+            "title": "Modern Challenge 64",
+            "publish_date": "2026-03-31T20:00:00Z",
+            "event_type": "challenge",
+            "decks_total": 2,
+            "decks_cached": 2,
+            "path": f"archive/mtgo-decklists/{_FORMAT}/modern-challenge-64-2026-03-31.json",
+            "decks": [
+                {
+                    "number": "9001",
+                    "date": "2026-03-31T20:00:00Z",
+                    "event": "Modern Challenge 64",
+                    "result": "7-0",
+                    "player": "heroic_player",
+                    "archetype": "Boros Energy",
+                    "name": "Boros Energy",
+                    "source": "mtgo",
+                    "format": _FORMAT,
+                    "deck_text": "4 Lightning Bolt\n\nSideboard\n2 Path to Exile\n",
+                },
+                {
+                    "number": "9002",
+                    "date": "2026-03-31T20:00:00Z",
+                    "event": "Modern Challenge 64",
+                    "result": "6-1",
+                    "player": "another_player",
+                    "archetype": "Unknown Archetype",  # should be skipped
+                    "name": "Something Weird",
+                    "source": "mtgo",
+                    "format": _FORMAT,
+                    "deck_text": "4 Dark Ritual\n",
+                },
+            ],
+        }
+    ],
+}
+
+
+def test_apply_merges_mtgo_decklists_into_archetype_cache(
+    tmp_client: BundleSnapshotClient, tmp_path: Path
+) -> None:
+    """MTGO decks with matching archetype names are merged into the deck cache."""
+    from utils.deck_text_cache import DeckTextCache
+
+    db_path = tmp_path / "deck_cache.db"
+    cache = DeckTextCache(db_path=db_path)
+    bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
+
+    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+        with patch("utils.deck_text_cache.get_deck_cache", return_value=cache):
+            tmp_client.apply()
+
+    data = json.loads(tmp_client.archetype_decks_cache_file.read_text())
+    assert _SLUG in data
+    items = data[_SLUG]["items"]
+    mtgo_items = [d for d in items if d.get("source") == "mtgo"]
+    assert len(mtgo_items) == 1
+    assert mtgo_items[0]["player"] == "heroic_player"
+    assert mtgo_items[0]["result"] == "7-0"
+    assert mtgo_items[0]["date"] == "2026-03-31"
+    assert mtgo_items[0]["number"] == "9001"
+
+
+def test_apply_mtgo_deck_text_stored_in_cache(
+    tmp_client: BundleSnapshotClient, tmp_path: Path
+) -> None:
+    """Inline deck_text from MTGO bundle entries is stored in the deck text cache."""
+    from utils.deck_text_cache import DeckTextCache
+
+    db_path = tmp_path / "deck_cache.db"
+    cache = DeckTextCache(db_path=db_path)
+    bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
+
+    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+        with patch("utils.deck_text_cache.get_deck_cache", return_value=cache):
+            tmp_client.apply()
+
+    text = cache.get("9001")
+    assert text is not None
+    assert "Lightning Bolt" in text
+
+
+def test_apply_mtgo_unmatched_archetype_skipped(
+    tmp_client: BundleSnapshotClient, tmp_path: Path
+) -> None:
+    """MTGO decks whose archetype name has no match in the archetype list are skipped."""
+    from utils.deck_text_cache import DeckTextCache
+
+    db_path = tmp_path / "deck_cache.db"
+    cache = DeckTextCache(db_path=db_path)
+    bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
+
+    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+        with patch("utils.deck_text_cache.get_deck_cache", return_value=cache):
+            tmp_client.apply()
+
+    # "Unknown Archetype" (deck 9002) should not be stored
+    text = cache.get("9002")
+    assert text is None
+
+
+def test_apply_mtgo_preserves_goldfish_decks(
+    tmp_client: BundleSnapshotClient, tmp_path: Path
+) -> None:
+    """MTGGoldfish decks in the cache are preserved alongside merged MTGO decks."""
+    from utils.deck_text_cache import DeckTextCache
+
+    db_path = tmp_path / "deck_cache.db"
+    cache = DeckTextCache(db_path=db_path)
+    bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
+
+    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+        with patch("utils.deck_text_cache.get_deck_cache", return_value=cache):
+            tmp_client.apply()
+
+    data = json.loads(tmp_client.archetype_decks_cache_file.read_text())
+    items = data[_SLUG]["items"]
+    goldfish_items = [d for d in items if d.get("source") == "mtggoldfish"]
+    mtgo_items = [d for d in items if d.get("source") == "mtgo"]
+    assert len(goldfish_items) == 1  # from default _make_bundle decks
+    assert len(mtgo_items) == 1
+
+
+def test_apply_mtgo_deduplicates_on_re_hydration(
+    tmp_client: BundleSnapshotClient, tmp_path: Path
+) -> None:
+    """Re-applying the bundle replaces previous MTGO entries rather than duplicating them."""
+    from utils.deck_text_cache import DeckTextCache
+
+    db_path = tmp_path / "deck_cache.db"
+    cache = DeckTextCache(db_path=db_path)
+    bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
+
+    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+        with patch("utils.deck_text_cache.get_deck_cache", return_value=cache):
+            tmp_client.apply()
+            # Force a second apply by clearing the stamp
+            tmp_client.stamp_file.unlink()
+            tmp_client.apply()
+
+    data = json.loads(tmp_client.archetype_decks_cache_file.read_text())
+    mtgo_items = [d for d in data[_SLUG]["items"] if d.get("source") == "mtgo"]
+    assert len(mtgo_items) == 1  # not doubled

--- a/widgets/deck_results_list.py
+++ b/widgets/deck_results_list.py
@@ -13,7 +13,7 @@ class DeckResultsList(wx.VListBox):
 
     def __init__(self, parent: wx.Window) -> None:
         super().__init__(parent, style=wx.BORDER_NONE)
-        self._items: list[tuple[str, str]] = []
+        self._items: list[tuple[str, str, str]] = []  # (emoji_prefix, line_one, line_two)
         self._line_one_color = wx.Colour(*LIGHT_TEXT)
         self._line_two_color = wx.Colour(*SUBDUED_TEXT)
         self._card_bg = wx.Colour(*DARK_PANEL)
@@ -25,7 +25,8 @@ class DeckResultsList(wx.VListBox):
 
     def Append(self, text: str) -> None:
         line_one, line_two = self._split_lines(text)
-        self._items.append((line_one, line_two))
+        emoji_prefix, line_one_text = self._split_emoji_prefix(line_one)
+        self._items.append((emoji_prefix, line_one_text, line_two))
         self.SetItemCount(len(self._items))
         self.Refresh()
 
@@ -41,8 +42,19 @@ class DeckResultsList(wx.VListBox):
         """Return the display text for item n (compatible with wx.ListBox API)."""
         if n < 0 or n >= len(self._items):
             return ""
-        line_one, line_two = self._items[n]
-        return f"{line_one}\n{line_two}" if line_two else line_one
+        emoji, line_one, line_two = self._items[n]
+        full_line_one = emoji + line_one if emoji else line_one
+        return f"{full_line_one}\n{line_two}" if line_two else full_line_one
+
+    @staticmethod
+    def _split_emoji_prefix(line: str) -> tuple[str, str]:
+        """Split a leading non-ASCII emoji prefix (e.g. '🐠 ') from the rest of the line."""
+        if not line or ord(line[0]) < 128:
+            return "", line
+        idx = line.find(" ")
+        if idx == -1:
+            return line, ""
+        return line[: idx + 1], line[idx + 1 :]
 
     def _split_lines(self, text: str) -> tuple[str, str]:
         lines = [line.strip() for line in text.splitlines() if line.strip()]
@@ -90,7 +102,7 @@ class DeckResultsList(wx.VListBox):
     def OnDrawItem(self, dc: wx.DC, rect: wx.Rect, n: int) -> None:
         if n < 0 or n >= len(self._items):
             return
-        line_one, line_two = self._items[n]
+        emoji_prefix, line_one, line_two = self._items[n]
         is_selected = self.IsSelected(n)
         card_bg = self._card_border if is_selected else self._card_bg
         card_fg = self._selection_fg if is_selected else self._line_one_color
@@ -109,8 +121,15 @@ class DeckResultsList(wx.VListBox):
         font = self.GetFont()
         font.SetWeight(wx.FONTWEIGHT_BOLD)
         dc.SetFont(font)
+
+        # Measure emoji prefix (drawn independently to preserve its natural color)
+        emoji_w = 0
+        if emoji_prefix:
+            emoji_w, _ = dc.GetTextExtent(emoji_prefix)
+
         dc.SetTextForeground(card_fg)
         line_one_width, line_one_height = dc.GetTextExtent(line_one)
+        total_line_one_width = emoji_w + line_one_width
 
         base_font = self.GetFont()
         base_font.SetWeight(wx.FONTWEIGHT_NORMAL)
@@ -130,11 +149,19 @@ class DeckResultsList(wx.VListBox):
 
         center_x = card_rect.x + (card_rect.width // 2)
         start_y = card_rect.y + (card_rect.height - content_height) // 2
+        line_one_start_x = center_x - (total_line_one_width // 2)
 
-        dc.SetTextForeground(card_fg)
         font.SetWeight(wx.FONTWEIGHT_BOLD)
         dc.SetFont(font)
-        dc.DrawText(line_one, center_x - (line_one_width // 2), start_y)
+
+        # Draw emoji with its own consistent color (not affected by selection state)
+        if emoji_prefix:
+            dc.SetTextForeground(self._line_one_color)
+            dc.DrawText(emoji_prefix, line_one_start_x, start_y)
+
+        # Draw line one text with card_fg
+        dc.SetTextForeground(card_fg)
+        dc.DrawText(line_one, line_one_start_x + emoji_w, start_y)
 
         if line_two:
             dc.SetFont(line_two_font)
@@ -148,6 +175,6 @@ class DeckResultsList(wx.VListBox):
     def OnMeasureItem(self, n: int) -> int:
         line_height = self.GetCharHeight()
         content_height = line_height
-        if 0 <= n < len(self._items) and self._items[n][1]:
+        if 0 <= n < len(self._items) and self._items[n][2]:
             content_height = line_height * 2 + 2
         return content_height + (self._ITEM_MARGIN * 2) + (self._CARD_PADDING * 2)

--- a/widgets/handlers/app_event_handlers.py
+++ b/widgets/handlers/app_event_handlers.py
@@ -132,13 +132,17 @@ class AppEventHandlers:
         return f"{line_one} | {line_two}".strip(" |")
 
     @staticmethod
-    def format_deck_list_entry(deck: dict[str, Any]) -> str:
+    def format_deck_list_entry(deck: dict[str, Any], show_source: bool = False) -> str:
         date = AppEventHandlers._normalize_date(deck.get("date", ""))
         player = deck.get("player", "")
         event = AppEventHandlers._strip_extra_dates(deck.get("event", ""))
         result = deck.get("result", "")
         line_parts = [part for part in (player, result, date) if part]
         line_one = ", ".join(line_parts) if line_parts else "Unknown"
+        if show_source:
+            source = deck.get("source", "")
+            emoji = "🐠" if source == "mtggoldfish" else "🧙🏾‍♂️"
+            line_one = f"{emoji} {line_one}"
         line_two = event
         return f"{line_one}\n{line_two}".strip()
 
@@ -335,8 +339,9 @@ class AppEventHandlers:
             self._set_status("deck_results.no_decks_for", archetype=archetype_name)
             self.summary_text.ChangeValue(f"{archetype_name}\n\nNo deck data available.")
             return
+        show_source = self.controller.get_deck_data_source() == "both"
         for deck in decks:
-            self.deck_list.Append(self.format_deck_list_entry(deck))
+            self.deck_list.Append(self.format_deck_list_entry(deck, show_source=show_source))
         self.deck_list.Enable()
         self.daily_average_button.Enable()
         self._present_archetype_summary(archetype_name, decks)


### PR DESCRIPTION
## Summary
- When the deck data source is set to **Both**, each deck result card now shows a source emoji: 🐠 for MTGGoldfish decks, 🧙🏾‍♂️ for MTGO decks
- Emoji is prepended to line one of the card (player, result, date)
- When source is set to `mtggoldfish` or `mtgo` exclusively, no emoji is shown (the source is already implicit)

## Test plan
- [ ] Set deck source to **Both** — verify 🐠/🧙🏾‍♂️ appears on the appropriate cards in the deck results list
- [ ] Set deck source to **MTGGoldfish only** — verify no emoji is shown
- [ ] Set deck source to **MTGO only** — verify no emoji is shown
- [ ] All existing tests pass (one pre-existing unrelated test failure in `test_mtggoldfish.py::TestGetArchetypeDecks::test_get_archetype_decks_success` due to filesystem cache)

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)