### PR TITLE
Add MTG content creator lookup report

### DIFF
--- a/docs/research/mtg_content_creators_lookup_2026-04-02.md
+++ b/docs/research/mtg_content_creators_lookup_2026-04-02.md
@@ -1,0 +1,151 @@
+# Magic: The Gathering Content Creators Lookup (2026-04-02)
+
+Lookup date: 2026-04-02
+
+Activity cutoff used: 2026-02-02
+
+Primary filter:
+- YouTube channel has more than 100 subscribers.
+- Latest published YouTube upload is on or after 2026-02-02.
+
+Twitch note:
+- Public Twitch subscriber counts are not exposed consistently, so the threshold was applied using YouTube subscriber counts.
+- Twitch URLs are included when the creator linked them from the YouTube About page or clearly branded them on-channel.
+
+Normalization and edge cases:
+- `yellowhate` appears to refer to `yellowhat` (Gabriel Nassif).
+- `kanister`'s main YouTube channel did not meet the recency filter on 2026-04-02, so this report uses `kanister VODs`, which did.
+- If a profile says `No public description exposed`, the bio is inferred from linked channels, keywords, and recent uploads instead of direct bio text.
+
+## Quick Scan
+
+| Creator | YouTube | Twitch | Subscribers | Latest upload date |
+| --- | --- | --- | --- | --- |
+| Aspiringspike | [YouTube](https://www.youtube.com/@Aspiringspike) | [Twitch](https://www.twitch.tv/aspiringspike) | 44K | 2026-04-02 |
+| IamActuallyLvL1 | [YouTube](https://www.youtube.com/@IamActuallyLvL1) | [Twitch](https://www.twitch.tv/iamactuallylvl1) | 6.13K | 2026-04-01 |
+| YungDingo | [YouTube](https://www.youtube.com/@YungDingo) | [Twitch](https://www.twitch.tv/YungDingo) | 8.62K | 2026-04-02 |
+| kanister VODs | [YouTube](https://www.youtube.com/@kanisterVODs) | [Twitch](https://www.twitch.tv/kanister_mtg) | 5.79K | 2026-04-01 |
+| Luis Scott-Vargas | [YouTube](https://www.youtube.com/@LSVargas) | [Twitch](https://www.twitch.tv/LSV) | 61.2K | 2026-04-02 |
+| yellowhat | [YouTube](https://www.youtube.com/@yellowhatmtg) | [Twitch](https://www.twitch.tv/yellowhat) | 22.6K | 2026-04-02 |
+| Tolarian Community College | [YouTube](https://www.youtube.com/@TolarianCommunityCollege) | - | 1.28M | 2026-04-01 |
+| MTGGoldfish | [YouTube](https://www.youtube.com/@MTGGoldfish) | [Twitch](https://www.twitch.tv/mtggoldfish) | 371K | 2026-04-02 |
+| CovertGoBlue | [YouTube](https://www.youtube.com/@covertgoblue) | [Twitch](https://www.twitch.tv/covertgoblue) | 278K | 2026-04-02 |
+| NumotTheNummy | [YouTube](https://www.youtube.com/@NumotTheNummyYT) | [Twitch](https://www.twitch.tv/numotthenummy) | 104K | 2026-04-02 |
+| Andrea Mengucci | [YouTube](https://www.youtube.com/@AndreaMengucci) | [Twitch](https://www.twitch.tv/andreamengucci) | 59.7K | 2026-04-02 |
+| LegenVD | [YouTube](https://www.youtube.com/@LegenVD) | [Twitch](https://www.twitch.tv/legenvd) | 144K | 2026-04-02 |
+| Strictly Better MtG | [YouTube](https://www.youtube.com/@SBMTG) | - | 139K | 2026-04-02 |
+| Jim Davis | [YouTube](https://www.youtube.com/@JimDavisMTG) | [Twitch](https://www.twitch.tv/JimDavisMTG) | 79.6K | 2026-04-02 |
+| The Command Zone | [YouTube](https://www.youtube.com/@commandcast) | - | 846K | 2026-04-01 |
+
+## Creator Notes
+
+### Aspiringspike
+
+- Channels: [YouTube](https://www.youtube.com/@Aspiringspike), [Twitch](https://www.twitch.tv/aspiringspike)
+- Activity check: 44K YouTube subscribers; latest upload on 2026-04-02: `Aetherworks w/ Spawn Tokens, Oh My! | Fleshraker Marvel | Modern | MTGO`
+- Channel description: No public description exposed on the YouTube About page.
+- Creator bio: Modern-focused MTG deckbuilder and streamer. This bio is inferred from the channel keywords (`modern mtg`, `magic the gathering`), the linked Twitch account, and the current run of Modern MTGO uploads.
+
+### IamActuallyLvL1
+
+- Channels: [YouTube](https://www.youtube.com/@IamActuallyLvL1), [Twitch](https://www.twitch.tv/iamactuallylvl1)
+- Activity check: 6.13K YouTube subscribers; latest upload on 2026-04-01: `OOPS ... I made a bad deck worse`
+- Channel description: Vintage Magic: The Gathering videos on Monday, Wednesday, and Friday, plus Twitch streams on Wednesdays and Saturdays.
+- Creator bio: Vintage specialist and streamer whose channel centers on deck experimentation, Vintage gameplay, and regular cross-posted stream content.
+
+### YungDingo
+
+- Channels: [YouTube](https://www.youtube.com/@YungDingo), [Twitch](https://www.twitch.tv/YungDingo)
+- Activity check: 8.62K YouTube subscribers; latest upload on 2026-04-02: `Plan A: POG COMBO, Plan B: GRINDFEST | Sultai Living End | Modern | MTGO`
+- Channel description: Self-described as "the fastest magic player in the west" who is out to prove he is the fastest Magic player in his house.
+- Creator bio: Modern MTGO creator and brewer with a personality-driven style, recent league and challenge uploads, and an active linked Twitch presence.
+
+### kanister VODs
+
+- Channels: [YouTube VOD archive](https://www.youtube.com/@kanisterVODs), [Main YouTube channel](https://www.youtube.com/@kanister), [Twitch](https://www.twitch.tv/kanister_mtg)
+- Activity check: 5.79K YouTube subscribers; latest upload on 2026-04-01: `New Titan Tech is a BACKBREAKING PLAY | Amulet Titan | Modern Challenge | MTGO`
+- Channel description: Archive of VODs from the Twitch channel, with the main YouTube channel linked separately.
+- Creator bio: Competitive MTG creator using the VOD archive as the active YouTube outlet for challenge runs and deck-focused stream uploads. This is the kanister-branded channel that met the 2026-02-02 recency filter.
+
+### Luis Scott-Vargas
+
+- Channels: [YouTube](https://www.youtube.com/@LSVargas), [Twitch](https://www.twitch.tv/LSV)
+- Activity check: 61.2K YouTube subscribers; latest upload on 2026-04-02: `Nadu-Ing It In the Arena Powered Cube`
+- Channel description: Luis "LSV" Scott-Vargas says he posts new videos daily, works on and plays games, and has a special fondness for Vintage Cube drafts and nonsense.
+- Creator bio: One of the longest-running Magic personalities in the space, with current content still centered on cube play, drafting, and high-level Magic gameplay.
+
+### yellowhat
+
+- Channels: [YouTube](https://www.youtube.com/@yellowhatmtg), [Twitch](https://www.twitch.tv/yellowhat)
+- Activity check: 22.6K YouTube subscribers; latest upload on 2026-04-02: `FUN and Kind of BUSTED | March of the Machines Draft | MTG Arena`
+- Channel description: Gabriel Nassif says he is widely considered one of the five best Magic players of all time, notes his switch from poker back to full-time Magic in 2017, and says the channel mixes Twitch VODs with deck, spoiler, and improvement videos.
+- Creator bio: Gabriel "yellowhat" Nassif is a high-profile pro player and streamer whose current uploads mix Arena drafts, VOD-style gameplay, and deck-focused commentary.
+
+### Tolarian Community College
+
+- Channels: [YouTube](https://www.youtube.com/@TolarianCommunityCollege)
+- Activity check: 1.28M YouTube subscribers; latest upload on 2026-04-01: `These Magic: The Gathering Cards Stink!`
+- Channel description: General MTG channel for product reviews, unboxings, gameplay tips, strategy, lore, online analysis, and how-to-play coverage.
+- Creator bio: Broad-interest flagship Magic channel built around product criticism, player education, and opinion-driven commentary rather than single-format grinding.
+
+### MTGGoldfish
+
+- Channels: [YouTube](https://www.youtube.com/@MTGGoldfish), [Twitch](https://www.twitch.tv/mtggoldfish)
+- Activity check: 371K YouTube subscribers; latest upload on 2026-04-02: `The Secrets of Strixhaven Precons are Juiced (& Land Destruction in Standard) | Daily MTG Spoilers`
+- Channel description: Official MTGGoldfish channel for decks, reviews, and product openings, with links out to the MTGGoldfish site and sister channels.
+- Creator bio: Multi-format MTG media brand covering news, spoilers, product talk, and deck content at a much higher publishing volume than most individual creators.
+
+### CovertGoBlue
+
+- Channels: [YouTube](https://www.youtube.com/@covertgoblue), [Twitch](https://www.twitch.tv/covertgoblue)
+- Activity check: 278K YouTube subscribers; latest upload on 2026-04-02: `How I tune decks`
+- Channel description: `The One in Best-of-One`
+- Creator bio: Arena-focused creator whose positioning and recent uploads both emphasize best-of-one ladder play, deck tuning, and iterative refinement.
+
+### NumotTheNummy
+
+- Channels: [YouTube](https://www.youtube.com/@NumotTheNummyYT), [Twitch](https://www.twitch.tv/numotthenummy)
+- Activity check: 104K YouTube subscribers; latest upload on 2026-04-02: `Opening Power In Powered Cube | April 2, 2026`
+- Channel description: Kenji "NumotTheNummy" Egashira describes himself as a long-time Twitch streamer and full-time Magic creator focused on laidback, educational daily videos.
+- Creator bio: Long-running Limited and draft personality whose channel remains anchored in approachable teaching, stream VODs, and daily upload cadence.
+
+### Andrea Mengucci
+
+- Channels: [YouTube](https://www.youtube.com/@AndreaMengucci), [Twitch](https://www.twitch.tv/andreamengucci)
+- Activity check: 59.7K YouTube subscribers; latest upload on 2026-04-02: `The best Reanimator deck you'll ever see! | Vintage Cube! | MTGO`
+- Channel description: Multi-format Magic channel spanning Pauper to Vintage, with links to Twitch, Mengu's Workshop, and external decklist resources.
+- Creator bio: Multi-format pro/content creator whose channel covers both digital and paper Magic and regularly shifts between cube, constructed, and older formats.
+
+### LegenVD
+
+- Channels: [YouTube](https://www.youtube.com/@LegenVD), [Twitch](https://www.twitch.tv/legenvd)
+- Activity check: 144K YouTube subscribers; latest upload on 2026-04-02: `Storming off in Standard.`
+- Channel description: Magic: The Gathering strategy videos with a focus on MTG Arena.
+- Creator bio: Strategy-heavy Arena creator known for gameplay breakdowns, deck guides, and steady upload frequency across Standard and related digital formats.
+
+### Strictly Better MtG
+
+- Channels: [YouTube](https://www.youtube.com/@SBMTG)
+- Activity check: 139K YouTube subscribers; latest upload on 2026-04-02: `Secrets of Strixhaven Previews Day 2: Main-Set All-Star Land and 20 Awesome Commander Cards | MTG`
+- Channel description: `Literally all I do is make decks all day. That's my life. I love it.`
+- Creator bio: Deck brewer and spoiler/review creator whose keywords and recent uploads both point to constant build iteration, preview reactions, and format-wide deck coverage.
+
+### Jim Davis
+
+- Channels: [YouTube](https://www.youtube.com/@JimDavisMTG), [Twitch](https://www.twitch.tv/JimDavisMTG)
+- Activity check: 79.6K YouTube subscribers; latest upload on 2026-04-02: `Azorius Core Combo - Standard`
+- Channel description: Professional Magic player and content creator Jim Davis describes himself as a 25-year veteran who focuses mainly on Standard, Historic, and Pioneer while also posting set reviews and reaction videos.
+- Creator bio: Veteran pro/player-educator whose current content remains strongly tied to competitive digital constructed formats and day-to-day deck evolution.
+
+### The Command Zone
+
+- Channels: [YouTube](https://www.youtube.com/@commandcast)
+- Activity check: 846K YouTube subscribers; latest upload on 2026-04-01: `Level Up Your Deck Building w/ This One Hack | The Command Zone 733`
+- Channel description: Weekly Commander and EDH show with Jimmy Wong, Josh Lee Kwai, and Rachel Weeks, focused on gameplay, strategy, table politics, set reviews, deck building, and the Game Knights series.
+- Creator bio: One of the largest Commander-specific brands in MTG media, built around multiplayer strategy shows and polished personality-led production.
+
+## Source Pattern
+
+Each entry above was validated from:
+- The creator's YouTube About page for subscriber count, external links, and description text.
+- The creator's YouTube channel feed (`feeds/videos.xml`) for the most recent published upload date.


### PR DESCRIPTION
## Summary
- add a markdown report of active MTG content creators discovered from current YouTube channel data
- include YouTube and Twitch URLs where publicly linked, plus subscriber counts and recent upload dates
- note normalization/edge cases like yellowhat and kanister VODs

## Testing
- not run (research/documentation change)