### PR TITLE
fix: detect format from card legalities instead of hardcoded strings

### DIFF
--- a/tests/test_gamelog_parser.py
+++ b/tests/test_gamelog_parser.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from utils.gamelog_parser import (
-    _detect_format_via_legalities,
     detect_format_from_cards,
     find_gamelog_files,
     infer_username_from_matches,

--- a/tests/test_gamelog_parser.py
+++ b/tests/test_gamelog_parser.py
@@ -152,7 +152,10 @@ class TestDetectFormatFromCards:
         assert detect_format_from_cards(["Force of Will"] * 10) == "Unknown"
 
     def test_returns_last_parsed_format_without_card_manager(self):
-        assert detect_format_from_cards(["Force of Will"] * 10, last_parsed_format="Modern") == "Modern"
+        assert (
+            detect_format_from_cards(["Force of Will"] * 10, last_parsed_format="Modern")
+            == "Modern"
+        )
 
     def test_returns_unknown_when_manager_not_loaded(self):
         manager = MagicMock()
@@ -162,7 +165,10 @@ class TestDetectFormatFromCards:
     def test_returns_last_parsed_format_when_manager_not_loaded(self):
         manager = MagicMock()
         manager.is_loaded = False
-        assert detect_format_from_cards(["Force of Will"] * 10, manager, last_parsed_format="Legacy") == "Legacy"
+        assert (
+            detect_format_from_cards(["Force of Will"] * 10, manager, last_parsed_format="Legacy")
+            == "Legacy"
+        )
 
     def test_detects_format_with_few_cards(self):
         # No minimum card count — even a single recognised card is enough
@@ -172,7 +178,10 @@ class TestDetectFormatFromCards:
     def test_returns_last_parsed_format_when_no_legality_data(self):
         # All cards unknown to the index → fall back to last_parsed_format
         manager = _make_manager({})
-        assert detect_format_from_cards(["token1", "token2"], manager, last_parsed_format="Modern") == "Modern"
+        assert (
+            detect_format_from_cards(["token1", "token2"], manager, last_parsed_format="Modern")
+            == "Modern"
+        )
 
     def test_detects_modern(self):
         deck = self._build_deck(self._modern_card())
@@ -228,7 +237,10 @@ class TestDetectFormatFromCards:
         }
         manager = _make_manager(deck)
         assert detect_format_from_cards(list(deck.keys()), manager) == "Unknown"
-        assert detect_format_from_cards(list(deck.keys()), manager, last_parsed_format="Modern") == "Modern"
+        assert (
+            detect_format_from_cards(list(deck.keys()), manager, last_parsed_format="Modern")
+            == "Modern"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gamelog_parser.py
+++ b/tests/test_gamelog_parser.py
@@ -151,14 +151,28 @@ class TestDetectFormatFromCards:
     def test_returns_unknown_without_card_manager(self):
         assert detect_format_from_cards(["Force of Will"] * 10) == "Unknown"
 
+    def test_returns_last_parsed_format_without_card_manager(self):
+        assert detect_format_from_cards(["Force of Will"] * 10, last_parsed_format="Modern") == "Modern"
+
     def test_returns_unknown_when_manager_not_loaded(self):
         manager = MagicMock()
         manager.is_loaded = False
         assert detect_format_from_cards(["Force of Will"] * 10, manager) == "Unknown"
 
-    def test_returns_unknown_when_fewer_than_5_cards_found(self):
+    def test_returns_last_parsed_format_when_manager_not_loaded(self):
+        manager = MagicMock()
+        manager.is_loaded = False
+        assert detect_format_from_cards(["Force of Will"] * 10, manager, last_parsed_format="Legacy") == "Legacy"
+
+    def test_detects_format_with_few_cards(self):
+        # No minimum card count — even a single recognised card is enough
         manager = _make_manager({"card0": self._modern_card()})
-        assert detect_format_from_cards(["card0"] * 3, manager) == "Unknown"
+        assert detect_format_from_cards(["card0"] * 3, manager) == "Modern"
+
+    def test_returns_last_parsed_format_when_no_legality_data(self):
+        # All cards unknown to the index → fall back to last_parsed_format
+        manager = _make_manager({})
+        assert detect_format_from_cards(["token1", "token2"], manager, last_parsed_format="Modern") == "Modern"
 
     def test_detects_modern(self):
         deck = self._build_deck(self._modern_card())
@@ -205,15 +219,16 @@ class TestDetectFormatFromCards:
         result = detect_format_from_cards(list(deck.keys()), manager)
         assert result == "Modern"
 
-    def test_returns_unknown_when_no_common_format(self):
-        # Two cards each legal in mutually exclusive formats — pathological case
+    def test_returns_last_parsed_format_when_no_common_format(self):
+        # Two cards each legal in mutually exclusive formats — intersection is empty,
+        # falls back to last_parsed_format (default "Unknown")
         deck = {
             **{f"vintage_only_{i}": {"vintage": "Legal"} for i in range(5)},
             **{f"standard_only_{i}": {"standard": "Legal"} for i in range(5)},
         }
         manager = _make_manager(deck)
-        result = detect_format_from_cards(list(deck.keys()), manager)
-        assert result == "Unknown"
+        assert detect_format_from_cards(list(deck.keys()), manager) == "Unknown"
+        assert detect_format_from_cards(list(deck.keys()), manager, last_parsed_format="Modern") == "Modern"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gamelog_parser.py
+++ b/tests/test_gamelog_parser.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from utils.gamelog_parser import (
+    _detect_format_via_legalities,
+    detect_format_from_cards,
     find_gamelog_files,
     infer_username_from_matches,
     parse_gamelog_file,
@@ -96,6 +99,121 @@ class TestInferUsername:
         username = os.environ.get("MTGO_USERNAME", "testplayer")
         matches = [{"players": [username, f"opp{i}"]} for i in range(100)]
         assert infer_username_from_matches(matches) == username
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for detect_format_from_cards
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(card_legalities: dict[str, dict[str, str]]) -> MagicMock:
+    """Build a mock CardDataManager where each card name maps to given legalities."""
+    manager = MagicMock()
+    manager.is_loaded = True
+
+    def get_card(name: str):
+        legalities = card_legalities.get(name.lower())
+        if legalities is None:
+            return None
+        entry = MagicMock()
+        entry.legalities = legalities
+        return entry
+
+    manager.get_card.side_effect = get_card
+    return manager
+
+
+class TestDetectFormatFromCards:
+    def _modern_card(self) -> dict[str, str]:
+        return {"modern": "Legal", "legacy": "Legal", "vintage": "Legal"}
+
+    def _legacy_only_card(self) -> dict[str, str]:
+        return {"legacy": "Legal", "vintage": "Legal"}
+
+    def _vintage_only_card(self) -> dict[str, str]:
+        return {"vintage": "Legal"}
+
+    def _pioneer_card(self) -> dict[str, str]:
+        return {"pioneer": "Legal", "modern": "Legal", "legacy": "Legal", "vintage": "Legal"}
+
+    def _standard_card(self) -> dict[str, str]:
+        return {
+            "standard": "Legal",
+            "pioneer": "Legal",
+            "modern": "Legal",
+            "legacy": "Legal",
+            "vintage": "Legal",
+        }
+
+    def _build_deck(self, legalities: dict[str, str], count: int = 10) -> dict[str, dict[str, str]]:
+        return {f"card{i}": legalities for i in range(count)}
+
+    def test_returns_unknown_without_card_manager(self):
+        assert detect_format_from_cards(["Force of Will"] * 10) == "Unknown"
+
+    def test_returns_unknown_when_manager_not_loaded(self):
+        manager = MagicMock()
+        manager.is_loaded = False
+        assert detect_format_from_cards(["Force of Will"] * 10, manager) == "Unknown"
+
+    def test_returns_unknown_when_fewer_than_5_cards_found(self):
+        manager = _make_manager({"card0": self._modern_card()})
+        assert detect_format_from_cards(["card0"] * 3, manager) == "Unknown"
+
+    def test_detects_modern(self):
+        deck = self._build_deck(self._modern_card())
+        manager = _make_manager(deck)
+        result = detect_format_from_cards(list(deck.keys()), manager)
+        assert result == "Modern"
+
+    def test_detects_legacy_when_non_modern_card_present(self):
+        deck = {
+            **self._build_deck(self._modern_card(), 9),
+            "force_of_will": self._legacy_only_card(),
+        }
+        manager = _make_manager(deck)
+        result = detect_format_from_cards(list(deck.keys()), manager)
+        assert result == "Legacy"
+
+    def test_detects_vintage_when_power_card_present(self):
+        deck = {
+            **self._build_deck(self._modern_card(), 9),
+            "black_lotus": self._vintage_only_card(),
+        }
+        manager = _make_manager(deck)
+        result = detect_format_from_cards(list(deck.keys()), manager)
+        assert result == "Vintage"
+
+    def test_detects_standard_when_all_standard_legal(self):
+        deck = self._build_deck(self._standard_card())
+        manager = _make_manager(deck)
+        result = detect_format_from_cards(list(deck.keys()), manager)
+        assert result == "Standard"
+
+    def test_skips_cards_not_found_in_index(self):
+        # 10 modern-legal + 5 unknown (tokens, etc.) — should still detect Modern
+        deck = self._build_deck(self._modern_card())
+        manager = _make_manager(deck)
+        cards = list(deck.keys()) + ["token1", "token2", "token3", "token4", "token5"]
+        result = detect_format_from_cards(cards, manager)
+        assert result == "Modern"
+
+    def test_skips_cards_with_empty_legalities(self):
+        # Cards with {} legalities (e.g. MDFCs with alias collision) are ignored
+        deck = {**self._build_deck(self._modern_card()), "mdfc_alias": {}}
+        manager = _make_manager(deck)
+        result = detect_format_from_cards(list(deck.keys()), manager)
+        assert result == "Modern"
+
+    def test_returns_unknown_when_no_common_format(self):
+        # Two cards each legal in mutually exclusive formats — pathological case
+        deck = {
+            **{f"vintage_only_{i}": {"vintage": "Legal"} for i in range(5)},
+            **{f"standard_only_{i}": {"standard": "Legal"} for i in range(5)},
+        }
+        manager = _make_manager(deck)
+        result = detect_format_from_cards(list(deck.keys()), manager)
+        assert result == "Unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/utils/gamelog_parser.py
+++ b/utils/gamelog_parser.py
@@ -65,22 +65,24 @@ def get_current_username() -> str | None:
 def detect_format_from_cards(
     cards: list[str],
     card_manager: CardDataManager | None = None,
+    last_parsed_format: str = "Unknown",
 ) -> str:
     """Detect the MTGO format from a card list using legality data.
 
     When *card_manager* is supplied and loaded the function intersects each
     card's legal competitive formats and returns the most restrictive one that
-    covers the whole deck.  Requires at least 5 cards with legality data to
-    make a confident call; returns ``"Unknown"`` otherwise.
+    covers the whole deck.  Falls back to *last_parsed_format* when the format
+    cannot be determined (e.g. no cards with legality data were played).
     """
     if card_manager is not None and card_manager.is_loaded:
-        return _detect_format_via_legalities(cards, card_manager)
-    return "Unknown"
+        return _detect_format_via_legalities(cards, card_manager, last_parsed_format)
+    return last_parsed_format
 
 
 def _detect_format_via_legalities(
     cards: list[str],
     card_manager: CardDataManager,
+    last_parsed_format: str = "Unknown",
 ) -> str:
     legal_format_sets: list[set[str]] = []
     for card_name in set(cards):
@@ -91,8 +93,8 @@ def _detect_format_via_legalities(
         if legal:
             legal_format_sets.append(legal)
 
-    if len(legal_format_sets) < 5:
-        return "Unknown"
+    if not legal_format_sets:
+        return last_parsed_format
 
     common: set[str] = legal_format_sets[0].copy()
     for s in legal_format_sets[1:]:
@@ -102,7 +104,7 @@ def _detect_format_via_legalities(
         if fmt in common:
             return _FORMAT_DISPLAY[fmt]
 
-    return "Unknown"
+    return last_parsed_format
 
 
 def detect_archetype(cards: list[str]) -> str:

--- a/utils/gamelog_parser.py
+++ b/utils/gamelog_parser.py
@@ -13,16 +13,33 @@ Key modifications:
 - Added support for locating log files via MTGOSDK
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re
 import subprocess  # nosec B404 - used to invoke trusted MTGO bridge helper
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
 from utils.constants import BRIDGE_PATH
+
+if TYPE_CHECKING:
+    from utils.card_data import CardDataManager
+
+# MTGO competitive formats in priority order (most → least restrictive card pool)
+_COMPETITIVE_FORMATS: list[str] = ["standard", "pioneer", "modern", "legacy", "vintage", "pauper"]
+_FORMAT_DISPLAY: dict[str, str] = {
+    "standard": "Standard",
+    "pioneer": "Pioneer",
+    "modern": "Modern",
+    "legacy": "Legacy",
+    "vintage": "Vintage",
+    "pauper": "Pauper",
+}
 
 
 def get_current_username() -> str | None:
@@ -45,58 +62,45 @@ def get_current_username() -> str | None:
     return None
 
 
-def detect_format_from_cards(cards: list[str]) -> str:
-    """Attempt to detect format from card list."""
-    # Common Modern-only cards (not in Standard, Pioneer, Legacy staples)
-    modern_indicators = {
-        "Thoughtseize",
-        "Fatal Push",
-        "Lightning Bolt",
-        "Counterspell",
-        "Urza's Saga",
-        "Ragavan, Nimble Pilferer",
-        "Solitude",
-        "Fury",
-        "Grief",
-        "Omnath, Locus of Creation",
-        "Wrenn and Six",
-        "Lurrus of the Dream-Den",
-        "Mishra's Bauble",
-        "Aether Vial",
-    }
+def detect_format_from_cards(
+    cards: list[str],
+    card_manager: CardDataManager | None = None,
+) -> str:
+    """Detect the MTGO format from a card list using legality data.
 
-    # Vintage/Legacy indicators (Power 9, reserved list)
-    vintage_legacy_indicators = {
-        "Black Lotus",
-        "Mox Pearl",
-        "Mox Sapphire",
-        "Mox Jet",
-        "Mox Ruby",
-        "Mox Emerald",
-        "Time Walk",
-        "Ancestral Recall",
-        "Force of Will",
-        "Brainstorm",
-        "Wasteland",
-        "Daze",
-    }
+    When *card_manager* is supplied and loaded the function intersects each
+    card's legal competitive formats and returns the most restrictive one that
+    covers the whole deck.  Requires at least 5 cards with legality data to
+    make a confident call; returns ``"Unknown"`` otherwise.
+    """
+    if card_manager is not None and card_manager.is_loaded:
+        return _detect_format_via_legalities(cards, card_manager)
+    return "Unknown"
 
-    # Standard rotates frequently, harder to detect
-    # For now, check for recent sets
 
-    card_set = set(cards)
+def _detect_format_via_legalities(
+    cards: list[str],
+    card_manager: CardDataManager,
+) -> str:
+    legal_format_sets: list[set[str]] = []
+    for card_name in set(cards):
+        entry = card_manager.get_card(card_name)
+        if entry is None:
+            continue
+        legal = {fmt for fmt in _COMPETITIVE_FORMATS if entry.legalities.get(fmt) == "Legal"}
+        if legal:
+            legal_format_sets.append(legal)
 
-    # Check for Vintage/Legacy
-    if any(card in vintage_legacy_indicators for card in card_set):
-        return "Legacy"  # Could also be Vintage, but Legacy is more common
+    if len(legal_format_sets) < 5:
+        return "Unknown"
 
-    # Check for Modern indicators
-    if any(card in modern_indicators for card in card_set):
-        return "Modern"
+    common: set[str] = legal_format_sets[0].copy()
+    for s in legal_format_sets[1:]:
+        common &= s
 
-    # Default to Modern as most common format on MTGO
-    if len(cards) > 10:  # If we have a decent card list
-        return "Modern"
+    for fmt in _COMPETITIVE_FORMATS:
+        if fmt in common:
+            return _FORMAT_DISPLAY[fmt]
 
     return "Unknown"
 
@@ -504,7 +508,10 @@ def parse_game_results(content: str) -> list[dict[str, str]]:
     return games
 
 
-def parse_gamelog_file(file_path: str) -> dict | None:
+def parse_gamelog_file(
+    file_path: str,
+    card_manager: CardDataManager | None = None,
+) -> dict | None:
     try:
         with open(file_path, encoding="latin1") as f:
             content = f.read()
@@ -565,7 +572,7 @@ def parse_gamelog_file(file_path: str) -> dict | None:
         match_id = os.path.basename(file_path).replace("Match_GameLog_", "").replace(".dat", "")
 
         # Detect format and archetypes
-        detected_format = detect_format_from_cards(player1_deck + player2_deck)
+        detected_format = detect_format_from_cards(player1_deck + player2_deck, card_manager)
         player1_archetype = detect_archetype(player1_deck)
         player2_archetype = detect_archetype(player2_deck)
 
@@ -651,6 +658,7 @@ def parse_all_gamelogs(
     directory: str | list[str] | None = None,
     limit: int = None,
     progress_callback=None,
+    card_manager: CardDataManager | None = None,
 ) -> list[dict]:
     if directory is None:
         directories = find_all_gamelog_dirs()
@@ -681,7 +689,7 @@ def parse_all_gamelogs(
         if progress_callback:
             progress_callback(i + 1, total_files)
 
-        match_data = parse_gamelog_file(file_path)
+        match_data = parse_gamelog_file(file_path, card_manager)
         if match_data:
             matches.append(match_data)
 


### PR DESCRIPTION
## Summary
- Replaces stale hardcoded card-name sets in `detect_format_from_cards` with a legality-intersection approach using `CardDataManager` vendor data
- The function now intersects each card's competitive legal formats (`standard → pioneer → modern → legacy → vintage → pauper`) and returns the most restrictive one covering the full deck
- Threads an optional `card_manager` parameter through `parse_gamelog_file` and `parse_all_gamelogs` so callers with a loaded manager can enable reliable format detection
- Returns `"Unknown"` when no manager is provided, the manager isn't loaded, or fewer than 5 cards have legality data

Closes #393

## Test plan
- [ ] `TestDetectFormatFromCards::test_returns_unknown_without_card_manager` — no manager → Unknown
- [ ] `TestDetectFormatFromCards::test_returns_unknown_when_manager_not_loaded` — unloaded manager → Unknown
- [ ] `TestDetectFormatFromCards::test_detects_modern` — all Modern-legal cards → Modern
- [ ] `TestDetectFormatFromCards::test_detects_legacy_when_non_modern_card_present` — Force of Will-style card → Legacy
- [ ] `TestDetectFormatFromCards::test_detects_vintage_when_power_card_present` — Power 9-style card → Vintage
- [ ] `TestDetectFormatFromCards::test_detects_standard_when_all_standard_legal` — Standard-only cards → Standard
- [ ] `TestDetectFormatFromCards::test_skips_cards_not_found_in_index` — unknown tokens skipped safely
- [ ] `TestDetectFormatFromCards::test_skips_cards_with_empty_legalities` — MDFC alias collisions skipped safely
- [ ] `TestDetectFormatFromCards::test_returns_unknown_when_no_common_format` — mutually-exclusive formats → Unknown

🤖 Generated with [Claude Code](https://claude.com/claude-code)