### PR TITLE
dev: Share cache data across worktrees

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import wx
 from loguru import logger
 
 from controllers.app_controller import get_deck_selector_controller
-from utils.constants import LOGS_DIR, ensure_base_dirs
+from utils.constants import BASE_DATA_DIR, LOGS_DIR, ensure_base_dirs
 from utils.logging_config import configure_logging
 from widgets.splash_frame import LoadingFrame
 
@@ -120,6 +120,7 @@ def main() -> None:
     log_file = configure_logging(LOGS_DIR)
     if log_file:
         logger.info(f"Writing logs to {log_file}")
+    logger.info(f"Using base data directory: {BASE_DATA_DIR}")
 
     if _automation_enabled:
         logger.info(f"Automation mode enabled on port {_automation_port}")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,58 @@
+"""Tests for filesystem base-data path resolution."""
+
+from __future__ import annotations
+
+import utils.constants.paths as paths
+
+
+def test_default_base_dir_honors_env_override(tmp_path, monkeypatch):
+    base_dir = tmp_path / "shared-data"
+
+    monkeypatch.setenv(paths.BASE_DATA_DIR_ENV_VAR, str(base_dir))
+
+    assert paths._default_base_dir() == base_dir.resolve()
+
+
+def test_default_base_dir_uses_repo_root_for_regular_checkout(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    subdir = repo_root / "scripts"
+    (repo_root / ".git").mkdir(parents=True)
+    subdir.mkdir()
+
+    monkeypatch.delenv(paths.BASE_DATA_DIR_ENV_VAR, raising=False)
+    monkeypatch.chdir(subdir)
+
+    assert paths._default_base_dir() == repo_root.resolve()
+
+
+def test_default_base_dir_uses_primary_repo_root_for_sibling_worktree(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    worktree_root = tmp_path / "repo-issue-123"
+    worktree_subdir = worktree_root / "scripts"
+    gitdir = repo_root / ".git" / "worktrees" / "repo-issue-123"
+    gitdir.mkdir(parents=True)
+    worktree_subdir.mkdir(parents=True)
+    (worktree_root / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+
+    monkeypatch.delenv(paths.BASE_DATA_DIR_ENV_VAR, raising=False)
+    monkeypatch.chdir(worktree_subdir)
+
+    assert paths._default_base_dir() == repo_root.resolve()
+
+
+def test_default_base_dir_uses_primary_repo_root_for_relative_worktree_gitdir(
+    tmp_path, monkeypatch
+):
+    repo_root = tmp_path / "repo"
+    worktree_root = repo_root / ".worktrees" / "issue-123"
+    gitdir = repo_root / ".git" / "worktrees" / "issue-123"
+    gitdir.mkdir(parents=True)
+    worktree_root.mkdir(parents=True)
+    (worktree_root / ".git").write_text(
+        "gitdir: ../../.git/worktrees/issue-123\n", encoding="utf-8"
+    )
+
+    monkeypatch.delenv(paths.BASE_DATA_DIR_ENV_VAR, raising=False)
+    monkeypatch.chdir(worktree_root)
+
+    assert paths._default_base_dir() == repo_root.resolve()

--- a/utils/constants/paths.py
+++ b/utils/constants/paths.py
@@ -1,14 +1,92 @@
 """Filesystem paths and config/cache locations."""
 
+from __future__ import annotations
+
+import os
 import sys
 from pathlib import Path
+
+BASE_DATA_DIR_ENV_VAR = "MTGO_TOOLS_BASE_DATA_DIR"
+
+
+def _resolved_env_base_dir() -> Path | None:
+    """Return an explicit base-data directory override, if configured."""
+    raw_value = os.getenv(BASE_DATA_DIR_ENV_VAR)
+    if not raw_value:
+        return None
+    return Path(raw_value).expanduser().resolve()
+
+
+def _safe_cwd() -> Path | None:
+    try:
+        return Path.cwd().resolve()
+    except OSError:
+        return None
+
+
+def _find_git_marker(start: Path) -> Path | None:
+    """Find the nearest .git marker from a directory inside a worktree."""
+    current = start if start.is_dir() else start.parent
+    for candidate in (current, *current.parents):
+        marker = candidate / ".git"
+        if marker.exists():
+            return marker
+    return None
+
+
+def _resolve_gitdir(worktree_git_marker: Path) -> Path | None:
+    """Resolve a .git directory or linked-worktree gitdir file."""
+    if worktree_git_marker.is_dir():
+        return worktree_git_marker.resolve()
+    try:
+        content = worktree_git_marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    prefix = "gitdir:"
+    if not content.startswith(prefix):
+        return None
+    gitdir = Path(content[len(prefix) :].strip()).expanduser()
+    if not gitdir.is_absolute():
+        gitdir = worktree_git_marker.parent / gitdir
+    return gitdir.resolve()
+
+
+def _primary_worktree_root_from_marker(worktree_git_marker: Path) -> Path:
+    """Return the primary checkout root for a Git worktree marker."""
+    gitdir = _resolve_gitdir(worktree_git_marker)
+    if gitdir is None:
+        return worktree_git_marker.parent.resolve()
+
+    if gitdir.parent.name == "worktrees":
+        common_git_dir = gitdir.parent.parent
+        if common_git_dir.name == ".git":
+            return common_git_dir.parent.resolve()
+
+    if gitdir.name == ".git":
+        return gitdir.parent.resolve()
+
+    return worktree_git_marker.parent.resolve()
+
+
+def _base_dir_from_cwd() -> Path | None:
+    """Resolve the shared data root from the current working directory."""
+    cwd = _safe_cwd()
+    if cwd is None:
+        return None
+    git_marker = _find_git_marker(cwd)
+    if git_marker is None:
+        return None
+    return _primary_worktree_root_from_marker(git_marker)
 
 
 def _default_base_dir() -> Path:
     """Return the writable base directory for config/cache/logging."""
+    env_base_dir = _resolved_env_base_dir()
+    if env_base_dir is not None:
+        return env_base_dir
     if getattr(sys, "frozen", False):
         return Path(sys.executable).resolve().parent
-    return Path(__file__).resolve().parent.parent.parent
+    return _base_dir_from_cwd() or Path(__file__).resolve().parent.parent.parent
 
 
 BASE_DATA_DIR = _default_base_dir()


### PR DESCRIPTION
Summary:
- Add base-data path resolution that maps linked git worktrees back to the primary checkout root.
- Keep cache, data, config, logs, and card image paths shared across worktree runs; add MTGO_TOOLS_BASE_DATA_DIR override.
- Log the selected base data directory during main.py startup and cover worktree path detection with tests.

Tests:
- python3 -m pytest tests/test_paths.py
- python3 -m pytest tests/test_card_images_cache.py
- python3 -m ruff check main.py utils/constants/paths.py tests/test_paths.py