### PR TITLE
feat(automation): headless screenshot, open-app, close-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ pytest
 
 CI uses **black 26.3.1**. If formatting locally, match with `pip install black==26.3.1`.
 
+### Automation CLI
+
+The `automation` package can launch and control the wxPython app for manual UI
+checks and E2E scripts:
+
+```bash
+python -m automation.cli open-app --wait
+python -m automation.cli ping
+python -m automation.cli screenshot --path screenshots/current.png
+python -m automation.cli screenshot --headless --path screenshots/background.png
+python -m automation.cli close-app
+```
+
+`screenshot --headless` is self-contained once the app is running with
+automation enabled. It temporarily restores a minimized or hidden window for the
+capture and returns it to the previous state afterward; no extra `cmd.exe` or
+manual window-management step is required by the screenshot command itself.
+
+See `automation/README.md` for port options, WSL interop notes, and close-app
+behavior.
+
 ### GameLog / Match History Tests
 
 `tests/test_gamelog_parser.py` parses local MTGO GameLog files and requires the `MTGO_USERNAME` environment variable. The venv activation scripts set this automatically. Tests are skipped when no GameLog directory is found.
@@ -96,7 +117,7 @@ Configuration in `pyproject.toml`.
 │   ├── deck.py                     # Deck text parsing helpers
 │   └── mtgo_bridge_client.py       # IPC client for .NET bridge
 ├── dotnet/MTGOBridge/              # .NET bridge (MTGOSDK)
-├── automation/                     # E2E test automation server
+├── automation/                     # Automation CLI, server, and E2E helpers
 └── tests/                          # pytest test suite
 ```
 

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,57 @@
+# Automation CLI
+
+The automation package exposes a local socket server inside the wxPython app and
+a CLI for manual testing, E2E scripts, and debugging UI regressions.
+
+## Common Workflow
+
+```bash
+python -m automation.cli open-app --wait
+python -m automation.cli ping
+python -m automation.cli screenshot --path screenshots/current.png
+python -m automation.cli screenshot --headless --path screenshots/background.png
+python -m automation.cli close-app
+```
+
+`open-app --wait` launches `main.py --automation` and blocks until the
+automation server responds. Use `--port` if you need to avoid the default port:
+
+```bash
+python -m automation.cli --port 19857 open-app --wait
+python -m automation.cli --port 19857 ping
+python -m automation.cli --port 19857 close-app
+```
+
+## Headless Screenshots
+
+`screenshot --headless` is self-contained once the app is running with
+automation enabled. If the main window is minimized or hidden, the server
+temporarily restores it, captures the screenshot, and returns it to the previous
+minimized or hidden state afterward.
+
+No extra shell, `cmd.exe`, or manual window-management step is required by
+`screenshot --headless` itself. The only WSL-specific concern is how you invoke
+the Windows Python process when running the CLI from WSL.
+
+## WSL Interop Note
+
+On a normal WSL setup, `cmd.exe /c ...` can run the Windows venv directly. If
+bare `cmd.exe` returns `Exec format error` because WSLInterop binfmt registration
+is missing, invoke it through `/init`:
+
+```bash
+/init /mnt/c/Windows/System32/cmd.exe /c "cd /d C:\Users\Pedro\Documents\GitHub\mtgo_tools && env\Scripts\python.exe -m automation.cli --help"
+```
+
+This is only an interop workaround for launching Windows commands from WSL. It
+does not change how the automation CLI commands behave once they are running.
+
+## Close Behavior
+
+`close-app` sends a graceful close request to the running app. The server
+acknowledges the command before scheduling the wx frame close, so scripts should
+receive a clean response:
+
+```json
+{"closed": true}
+```

--- a/automation/cli.py
+++ b/automation/cli.py
@@ -469,9 +469,7 @@ Examples:
     subparsers.add_parser("close-app", help="Close the running application")
 
     # open-app
-    p = subparsers.add_parser(
-        "open-app", help="Launch the application with the automation flag"
-    )
+    p = subparsers.add_parser("open-app", help="Launch the application with the automation flag")
     p.add_argument(
         "--wait",
         action="store_true",

--- a/automation/cli.py
+++ b/automation/cli.py
@@ -3,8 +3,10 @@
 Command-line interface for controlling the MTGO Tools application.
 
 Usage:
+    python -m automation.cli open-app [--wait]
     python -m automation.cli ping
     python -m automation.cli screenshot --path output.png
+    python -m automation.cli screenshot --headless
     python -m automation.cli status
     python -m automation.cli set-format Modern
     python -m automation.cli list-archetypes
@@ -13,6 +15,7 @@ Usage:
     python -m automation.cli select-deck 0
     python -m automation.cli get-deck
     python -m automation.cli switch-tab Stats
+    python -m automation.cli close-app
 """
 
 import argparse
@@ -59,7 +62,7 @@ def cmd_ping(client: AutomationClient, args: argparse.Namespace) -> int:
 
 def cmd_screenshot(client: AutomationClient, args: argparse.Namespace) -> int:
     """Take a screenshot."""
-    result = client.screenshot(args.path)
+    result = client.screenshot(args.path, headless=args.headless)
     print(format_output(result, args.json))
     return 0
 
@@ -278,14 +281,68 @@ def cmd_toggle_adv_filters(client: AutomationClient, args: argparse.Namespace) -
     return 0 if result.get("toggled") else 1
 
 
+def cmd_close_app(client: AutomationClient, args: argparse.Namespace) -> int:
+    """Close the running application."""
+    result = client.close_app()
+    print(format_output(result, args.json))
+    return 0 if result.get("closed") else 1
+
+
+def cmd_open_app(args: argparse.Namespace) -> int:
+    """Launch the application with the automation flag.
+
+    This command does not require the app to already be running.
+    """
+    import subprocess
+    from pathlib import Path
+
+    # Locate main.py relative to this module (automation/ → repo root)
+    repo_root = Path(__file__).parent.parent
+    main_py = repo_root / "main.py"
+
+    if not main_py.exists():
+        print(f"main.py not found at {main_py}", file=sys.stderr)
+        return 1
+
+    cmd = [sys.executable, str(main_py), "--automation"]
+    if args.port != DEFAULT_PORT:
+        cmd += ["--automation-port", str(args.port)]
+
+    proc = subprocess.Popen(cmd)
+
+    if args.wait:
+        client = AutomationClient(host=args.host, port=args.port, timeout=args.timeout)
+        if not client.wait_for_server(timeout=args.wait_timeout):
+            print(
+                f"App launched (PID {proc.pid}) but did not respond within"
+                f" {args.wait_timeout}s",
+                file=sys.stderr,
+            )
+            return 1
+        if not args.json:
+            print(f"App ready (PID {proc.pid})")
+        else:
+            print(json.dumps({"pid": proc.pid, "ready": True}))
+    else:
+        if not args.json:
+            print(f"App launched (PID {proc.pid})")
+        else:
+            print(json.dumps({"pid": proc.pid}))
+
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Control the MTGO Tools application from the command line.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
+  %(prog)s open-app                                Launch app with automation flag
+  %(prog)s open-app --wait                         Launch and wait until ready
   %(prog)s ping                                    Check if app is running
   %(prog)s screenshot --path test.png              Take a screenshot
+  %(prog)s screenshot --headless                   Screenshot even when minimized
   %(prog)s status                                  Get status bar text
   %(prog)s set-format Modern                       Set format to Modern
   %(prog)s list-archetypes                         List available archetypes
@@ -294,6 +351,7 @@ Examples:
   %(prog)s select-deck 0                           Select first deck
   %(prog)s get-deck                                Print current deck
   %(prog)s switch-tab Stats                        Switch to Stats tab
+  %(prog)s close-app                               Close the running app
         """,
     )
 
@@ -312,6 +370,11 @@ Examples:
     # screenshot
     p = subparsers.add_parser("screenshot", help="Take a screenshot")
     p.add_argument("--path", "-p", help="Path to save screenshot (default: auto-generated)")
+    p.add_argument(
+        "--headless",
+        action="store_true",
+        help="Restore window if minimized before capturing, then re-minimize",
+    )
 
     # status
     subparsers.add_parser("status", help="Get status bar text")
@@ -402,6 +465,26 @@ Examples:
     # toggle-adv-filters
     subparsers.add_parser("toggle-adv-filters", help="Toggle advanced filters in builder panel")
 
+    # close-app
+    subparsers.add_parser("close-app", help="Close the running application")
+
+    # open-app
+    p = subparsers.add_parser(
+        "open-app", help="Launch the application with the automation flag"
+    )
+    p.add_argument(
+        "--wait",
+        action="store_true",
+        help="Wait for the automation server to be ready before returning",
+    )
+    p.add_argument(
+        "--wait-timeout",
+        type=float,
+        default=30.0,
+        dest="wait_timeout",
+        help="Seconds to wait for the server when --wait is used (default: 30)",
+    )
+
     args = parser.parse_args()
 
     if not args.command:
@@ -435,7 +518,12 @@ Examples:
         "open-widget": cmd_open_widget,
         "get-deck-notes": cmd_get_deck_notes,
         "toggle-adv-filters": cmd_toggle_adv_filters,
+        "close-app": cmd_close_app,
     }
+
+    # open-app does not need a running server — handle it before connecting.
+    if args.command == "open-app":
+        return cmd_open_app(args)
 
     handler = handlers.get(args.command)
     if handler is None:

--- a/automation/cli.py
+++ b/automation/cli.py
@@ -16,6 +16,21 @@ Usage:
     python -m automation.cli get-deck
     python -m automation.cli switch-tab Stats
     python -m automation.cli close-app
+
+Common workflow:
+    python -m automation.cli open-app --wait
+    python -m automation.cli ping
+    python -m automation.cli screenshot --path screenshots/current.png
+    python -m automation.cli screenshot --headless --path screenshots/background.png
+    python -m automation.cli close-app
+
+Notes:
+    The --headless screenshot flag is self-contained once the app is running
+    with automation enabled. It temporarily restores a minimized or hidden
+    window for capture, then returns it to the previous minimized/hidden state.
+    WSL callers may need to invoke the Windows Python through WSL interop, but
+    no extra shell or window-management steps are required by screenshot
+    --headless itself.
 """
 
 import argparse
@@ -343,6 +358,7 @@ Examples:
   %(prog)s ping                                    Check if app is running
   %(prog)s screenshot --path test.png              Take a screenshot
   %(prog)s screenshot --headless                   Screenshot even when minimized
+  %(prog)s screenshot --headless --path bg.png      Capture minimized/hidden app
   %(prog)s status                                  Get status bar text
   %(prog)s set-format Modern                       Set format to Modern
   %(prog)s list-archetypes                         List available archetypes
@@ -352,6 +368,11 @@ Examples:
   %(prog)s get-deck                                Print current deck
   %(prog)s switch-tab Stats                        Switch to Stats tab
   %(prog)s close-app                               Close the running app
+
+Notes:
+  screenshot --headless is self-contained once the app is running with
+  automation enabled: it restores a minimized/hidden window for capture and
+  returns it to the previous minimized/hidden state afterward.
         """,
     )
 

--- a/automation/client.py
+++ b/automation/client.py
@@ -66,19 +66,24 @@ class AutomationClient:
                 time.sleep(interval)
         return False
 
-    def screenshot(self, path: str | None = None) -> dict[str, Any]:
+    def screenshot(self, path: str | None = None, headless: bool = False) -> dict[str, Any]:
         """Take a screenshot of the application window.
 
         Args:
             path: Optional path to save the screenshot. If not provided,
                   a timestamped filename will be generated.
+            headless: When True, temporarily restores the window if it is
+                      minimized so the capture succeeds even when the app
+                      is running in the background.
 
         Returns:
             Dict with 'path', 'width', and 'height' keys.
         """
-        kwargs = {}
+        kwargs: dict[str, Any] = {}
         if path is not None:
             kwargs["path"] = path
+        if headless:
+            kwargs["headless"] = True
         return self._send_command("screenshot", **kwargs)
 
     def get_status(self) -> str:
@@ -264,6 +269,19 @@ class AutomationClient:
     def set_current_deck(self, deck: dict[str, Any] | None) -> dict[str, Any]:
         """Set the current deck identity used for deck-scoped data."""
         return self._send_command("set_current_deck", deck=deck)
+
+
+    def close_app(self) -> dict[str, Any]:
+        """Close the application.
+
+        Sends a close request to the running app.  The app will shut down
+        after acknowledging the command, so the response may arrive just
+        before the connection drops.
+
+        Returns:
+            Dict with 'closed': True on success.
+        """
+        return self._send_command("close_app")
 
 
 def connect(

--- a/automation/client.py
+++ b/automation/client.py
@@ -270,7 +270,6 @@ class AutomationClient:
         """Set the current deck identity used for deck-scoped data."""
         return self._send_command("set_current_deck", deck=deck)
 
-
     def close_app(self) -> dict[str, Any]:
         """Close the application.
 

--- a/automation/e2e_tests/__init__.py
+++ b/automation/e2e_tests/__init__.py
@@ -11,11 +11,14 @@ These tests run against the live application and cover:
 - Card face image loading in the deck zones
 
 Usage:
-    # 1. Start the app with automation enabled (Windows):
-    cmd.exe /c "start python C:\\Users\\Pedro\\Documents\\GitHub\\mtgo_tools\\main.py --automation"
+    # 1. Start the app with automation enabled and wait for readiness:
+    python -m automation.cli open-app --wait
 
-    # 2. Wait for the server to come up, then run:
+    # 2. Run the tests:
     python -m automation.e2e_tests
+
+    # 3. Close the app when finished:
+    python -m automation.cli close-app
 
     # Or run a specific test group:
     python -m automation.e2e_tests --only builder
@@ -31,6 +34,9 @@ Convention:
   When a UI bug is reproduced via the automation CLI, add a test to the
   relevant module in automation/e2e_tests/ that replicates the same command
   sequence so the fix can be verified automatically.
+
+  Use automation.cli screenshot --headless for screenshots when the app may be
+  minimized or hidden; the command handles restore/capture/re-minimize itself.
 """
 
 from __future__ import annotations

--- a/automation/server.py
+++ b/automation/server.py
@@ -190,9 +190,7 @@ class AutomationServer:
         """Handle ping command."""
         return {"status": "ok", "timestamp": time.time()}
 
-    def _handle_screenshot(
-        self, path: str | None = None, headless: bool = False
-    ) -> dict[str, Any]:
+    def _handle_screenshot(self, path: str | None = None, headless: bool = False) -> dict[str, Any]:
         """Take a screenshot of the application window.
 
         When *headless* is True the frame is temporarily restored if it is

--- a/automation/server.py
+++ b/automation/server.py
@@ -67,6 +67,7 @@ class AutomationServer:
             "get_deck_notes": self._handle_get_deck_notes,
             "set_current_deck": self._handle_set_current_deck,
             "toggle_adv_filters": self._handle_toggle_adv_filters,
+            "close_app": self._handle_close_app,
         }
 
     def register_handler(self, command: str, handler: Callable[..., Any]) -> None:
@@ -189,8 +190,15 @@ class AutomationServer:
         """Handle ping command."""
         return {"status": "ok", "timestamp": time.time()}
 
-    def _handle_screenshot(self, path: str | None = None) -> dict[str, Any]:
-        """Take a screenshot of the application window."""
+    def _handle_screenshot(
+        self, path: str | None = None, headless: bool = False
+    ) -> dict[str, Any]:
+        """Take a screenshot of the application window.
+
+        When *headless* is True the frame is temporarily restored if it is
+        iconized (minimized) so the capture works even when the window is not
+        visible on screen, then returned to its previous state afterward.
+        """
         import os
         import tempfile
         from datetime import datetime
@@ -205,16 +213,34 @@ class AutomationServer:
         if save_dir and not os.path.isdir(save_dir):
             path = os.path.join(tempfile.gettempdir(), os.path.basename(path))
 
-        # Get the frame's screen position and size
-        rect = self.frame.GetScreenRect()
-        x, y, width, height = rect.x, rect.y, rect.width, rect.height
+        was_iconized = self.frame.IsIconized()
+        was_hidden = not self.frame.IsShown()
 
-        # Create a bitmap to capture the screen
-        screen_dc = wx.ScreenDC()
-        bmp = wx.Bitmap(width, height)
-        mem_dc = wx.MemoryDC(bmp)
-        mem_dc.Blit(0, 0, width, height, screen_dc, x, y)
-        mem_dc.SelectObject(wx.NullBitmap)
+        if headless and (was_iconized or was_hidden):
+            if was_iconized:
+                self.frame.Iconize(False)
+            if was_hidden:
+                self.frame.Show()
+            self.frame.Raise()
+            wx.SafeYield()
+
+        try:
+            # Get the frame's screen position and size
+            rect = self.frame.GetScreenRect()
+            x, y, width, height = rect.x, rect.y, rect.width, rect.height
+
+            # Create a bitmap to capture the screen
+            screen_dc = wx.ScreenDC()
+            bmp = wx.Bitmap(width, height)
+            mem_dc = wx.MemoryDC(bmp)
+            mem_dc.Blit(0, 0, width, height, screen_dc, x, y)
+            mem_dc.SelectObject(wx.NullBitmap)
+        finally:
+            if headless:
+                if was_iconized:
+                    self.frame.Iconize(True)
+                if was_hidden:
+                    self.frame.Hide()
 
         # Save to file — use wx.LogNull to suppress any wx error dialogs on failure
         image = bmp.ConvertToImage()
@@ -650,6 +676,13 @@ class AutomationServer:
             return {"opened": False, "error": f"Method not found: {method_name}"}
         method()
         return {"opened": True, "widget": widget_name}
+
+    def _handle_close_app(self) -> dict[str, Any]:
+        """Close the application after sending the response."""
+        # Schedule Close on the next event-loop iteration so the response is
+        # sent back to the client before the wx app exits.
+        wx.CallAfter(self.frame.Close, True)
+        return {"closed": True}
 
     def _handle_get_card_images_loaded(self, zone: str = "main") -> dict[str, Any]:
         """Count how many card panels in a zone have successfully loaded images."""


### PR DESCRIPTION
## Summary

- **Headless screenshot**: `screenshot --headless` temporarily restores a minimized/hidden window before capturing, so E2E tests can take screenshots even when the app is running in the background. The window is returned to its previous state (minimized/hidden) after the capture.
- **`open-app`**: launches `main.py --automation` as a subprocess. Accepts `--wait` to block until the automation server responds (useful in CI scripts).
- **`close-app`**: sends a graceful close request to the running app. The app acknowledges before shutting down so the response is received cleanly.

## Test plan

- [ ] Start app with `open-app --wait` and verify it responds to `ping`
- [ ] Minimize the app, run `screenshot --headless`, verify a valid PNG is produced
- [ ] Run `close-app` and verify the app exits
- [ ] Existing `screenshot` (no `--headless`) continues to work as before

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)