### PR TITLE
Refactor deck loading and deck text presentation

### DIFF
--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -30,7 +30,7 @@ from repositories.deck_repository import get_deck_repository
 from repositories.metagame_repository import get_metagame_repository
 from services.collection_service import get_collection_service
 from services.deck_service import get_deck_service
-from services.deck_workflow_service import DeckWorkflowService
+from services.deck_workflow_service import DeckLoadScope, DeckWorkflowService
 from services.image_service import get_image_service
 from services.search_service import get_search_service
 from services.store_service import get_store_service
@@ -226,25 +226,35 @@ class AppController:
             on_error=error_handler,
         )
 
-    def load_decks_for_archetype(
+    def load_decks(
         self,
-        archetype: dict[str, Any],
+        *,
+        scope: DeckLoadScope,
         on_success: Callable[[str, list[dict[str, Any]]], None],
         on_error: Callable[[Exception], None],
-        on_status: Callable[[str], None],
+        on_status: Callable[..., None],
+        archetype: dict[str, Any] | None = None,
     ) -> None:
+        if scope == "all":
+            name = "Any"
+        elif scope == "archetype" and archetype is not None:
+            name = archetype.get("name", "Unknown")
+        else:
+            on_error(ValueError(f"Invalid deck load scope: {scope}"))
+            return
+
         with self._loading_lock:
             if self.loading_decks:
                 return
             self.loading_decks = True
 
-        name = archetype.get("name", "Unknown")
         on_status("app.status.loading_decks", name=name)
-
         source_filter = self.get_deck_data_source()
 
-        def loader(arch: dict[str, Any]):
-            return self.workflow_service.load_decks_for_archetype(arch, source_filter=source_filter)
+        def loader(_: None):
+            return self.workflow_service.load_decks(
+                scope=scope, source_filter=source_filter, archetype=archetype
+            )
 
         def success_handler(decks: list[dict[str, Any]]):
             with self._loading_lock:
@@ -255,57 +265,20 @@ class AppController:
         def error_handler(error: Exception):
             with self._loading_lock:
                 self.loading_decks = False
-            logger.error(f"Failed to load decks: {error}")
-            on_error(error)
-
-        self._worker.submit(
-            loader,
-            archetype,
-            on_success=success_handler,
-            on_error=error_handler,
-        )
-
-    def load_all_decks(
-        self,
-        on_success: Callable[[str, list[dict[str, Any]]], None],
-        on_error: Callable[[Exception], None],
-        on_status: Callable[[str], None],
-    ) -> None:
-        with self._loading_lock:
-            if self.loading_decks:
-                return
-            self.loading_decks = True
-
-        on_status("app.status.loading_decks", name="Any")
-        source_filter = self.get_deck_data_source()
-
-        def loader(_: None):
-            return self.workflow_service.load_all_decks(source_filter=source_filter)
-
-        def success_handler(decks: list[dict[str, Any]]):
-            with self._loading_lock:
-                self.loading_decks = False
-            self.workflow_service.set_decks_list(decks)
-            on_success("Any", decks)
-
-        def error_handler(error: Exception):
-            with self._loading_lock:
-                self.loading_decks = False
-            logger.error(f"Failed to load all decks: {error}")
+            logger.error(f"Failed to load {scope} decks: {error}")
             on_error(error)
 
         self._worker.submit(loader, None, on_success=success_handler, on_error=error_handler)
 
     # ============= Deck Management =============
 
-    def download_and_display_deck(
+    def download_deck_text(
         self,
-        deck: dict[str, Any],
+        deck_number: str,
         on_success: Callable[[str], None],
         on_error: Callable[[Exception], None],
-        on_status: Callable[[str], None],
+        on_status: Callable[..., None],
     ) -> None:
-        deck_number = deck.get("number")
         if not deck_number:
             on_error(ValueError("Deck identifier missing"))
             return
@@ -497,23 +470,6 @@ class AppController:
     def set_event_logging_enabled(self, enabled: bool) -> None:
         self.event_logger.enabled = enabled
         self.session_manager.update_event_logging_enabled(enabled)
-
-    # ============= Business Logic Methods =============
-
-    def download_deck(
-        self,
-        deck_number: str,
-        on_success: Callable[[str], None],
-        on_error: Callable[[Exception], None],
-        on_status: Callable[[str], None],
-    ) -> None:
-        on_status("app.status.downloading_deck")
-        source_filter = self.get_deck_data_source()
-
-        def worker(number: str):
-            return self.workflow_service.download_deck_text(number, source_filter=source_filter)
-
-        self._worker.submit(worker, deck_number, on_success=on_success, on_error=on_error)
 
     # ============= State Accessors =============
 

--- a/services/deck_workflow_service.py
+++ b/services/deck_workflow_service.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal
 
 from loguru import logger
 
 from navigators.mtggoldfish import download_deck, get_archetypes
 from utils.deck import read_curr_deck_file
+
+DeckLoadScope = Literal["all", "archetype"]
 
 
 class DeckWorkflowService:
@@ -38,13 +40,22 @@ class DeckWorkflowService:
         return self._archetype_provider(mtg_format.lower(), allow_stale=not force)
 
     # ------------------------------------------------------------------ decks ------------------------------------------------------------------
-    def load_decks_for_archetype(
-        self, archetype: dict[str, Any], *, source_filter: str
+    def load_decks(
+        self,
+        *,
+        scope: DeckLoadScope,
+        source_filter: str,
+        archetype: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
-        return self.metagame_repo.get_decks_for_archetype(archetype, source_filter=source_filter)
-
-    def load_all_decks(self, *, source_filter: str) -> list[dict[str, Any]]:
-        return self.metagame_repo.get_all_cached_decks(source_filter=source_filter)
+        if scope == "all":
+            return self.metagame_repo.get_all_cached_decks(source_filter=source_filter)
+        if scope == "archetype":
+            if archetype is None:
+                raise ValueError("Archetype scope requires an archetype")
+            return self.metagame_repo.get_decks_for_archetype(
+                archetype, source_filter=source_filter
+            )
+        raise ValueError(f"Unsupported deck load scope: {scope}")
 
     @staticmethod
     def _default_deck_downloader(deck_number: str, source_filter: str | None = None) -> None:

--- a/tests/test_deck_workflow_service.py
+++ b/tests/test_deck_workflow_service.py
@@ -55,11 +55,15 @@ class FakeDeckRepo:
 
 class FakeMetagameRepo:
     def __init__(self) -> None:
-        self.calls: list[tuple[dict, str]] = []
+        self.calls: list[tuple[str, dict | None, str]] = []
 
     def get_decks_for_archetype(self, archetype, source_filter):
-        self.calls.append((archetype, source_filter))
+        self.calls.append(("archetype", archetype, source_filter))
         return [{"name": archetype.get("name"), "number": "1"}]
+
+    def get_all_cached_decks(self, source_filter):
+        self.calls.append(("all", None, source_filter))
+        return [{"name": "Any", "number": "2"}]
 
 
 class FakeDeckService:
@@ -105,6 +109,24 @@ def test_fetch_archetypes_respects_force_flag():
 
     assert result == [{"name": "Test"}]
     assert calls == [("modern", False)]
+
+
+def test_load_decks_routes_all_and_archetype_scopes_through_one_use_case():
+    metagame_repo = FakeMetagameRepo()
+    service = build_service(metagame_repo=metagame_repo)
+    archetype = {"name": "Dimir Control"}
+
+    archetype_result = service.load_decks(
+        scope="archetype", archetype=archetype, source_filter="mtggoldfish"
+    )
+    all_result = service.load_decks(scope="all", source_filter="mtgo")
+
+    assert archetype_result == [{"name": "Dimir Control", "number": "1"}]
+    assert all_result == [{"name": "Any", "number": "2"}]
+    assert metagame_repo.calls == [
+        ("archetype", archetype, "mtggoldfish"),
+        ("all", None, "mtgo"),
+    ]
 
 
 def test_download_deck_text_uses_injected_dependencies():

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -177,7 +177,7 @@ def ui_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     }.items():
         monkeypatch.setattr(mtggoldfish, attr, value, raising=False)
 
-    def fake_download(number: str) -> None:
+    def fake_download(number: str, source_filter: str | None = None) -> None:  # noqa: ARG001
         (decks / "curr_deck.txt").write_text(
             "4 Mountain\n4 Island\nSideboard\n2 Dispel\n", encoding="utf-8"
         )
@@ -314,27 +314,35 @@ def deck_selector_factory(wx_app) -> AppFrame:
         def fetch_archetypes_sync(force: bool = False) -> None:  # noqa: ARG001
             frame._on_archetypes_loaded(local_archetypes)
 
-        def load_decks_sync(archetype: dict[str, Any]) -> None:
+        def load_decks_sync(
+            *,
+            scope: str,
+            archetype: dict[str, Any] | None = None,
+        ) -> None:
+            if scope == "all":
+                frame._on_decks_loaded("Any", [])
+                return
+            assert archetype is not None
             decks = fake_archetype_decks(archetype.get("href", ""))
             frame._on_decks_loaded(archetype.get("name", "Unknown"), decks)
 
         frame.fetch_archetypes = fetch_archetypes_sync  # type: ignore[assignment]
-        frame._load_decks_for_archetype = load_decks_sync  # type: ignore[assignment]
+        frame._load_decks = load_decks_sync  # type: ignore[assignment]
         controller.fetch_archetypes = lambda **kwargs: kwargs["on_success"](local_archetypes)  # type: ignore[assignment]
-        controller.load_decks_for_archetype = lambda archetype, on_success, **_: on_success(
-            archetype.get("name", "Unknown"), fake_archetype_decks(archetype.get("href", ""))
+        controller.load_decks = lambda scope, on_success, archetype=None, **_: on_success(
+            "Any" if scope == "all" else archetype.get("name", "Unknown"),
+            [] if scope == "all" else fake_archetype_decks(archetype.get("href", "")),
         )  # type: ignore[assignment]
-        controller.load_all_decks = lambda on_success, **_: on_success("Any", [])  # type: ignore[assignment]
         controller.check_and_download_bulk_data = lambda *_, **__: None  # type: ignore[assignment]
         controller.run_initial_loads = lambda *_, **__: None  # type: ignore[assignment]
 
         fake_deck_text = "4 Mountain\n4 Island\nSideboard\n2 Dispel\n"
 
-        def fake_download_and_display_deck(deck, on_success, on_error, on_status):
+        def fake_download_deck_text(deck_number, on_success, on_error, on_status):  # noqa: ARG001
             on_status("Downloading deck…")
             on_success(fake_deck_text)
 
-        controller.download_and_display_deck = fake_download_and_display_deck  # type: ignore[assignment]
+        controller.download_deck_text = fake_download_deck_text  # type: ignore[assignment]
         return frame
 
     return _factory

--- a/tests/ui/test_deck_selector.py
+++ b/tests/ui/test_deck_selector.py
@@ -34,6 +34,28 @@ def test_deck_selector_loads_archetypes_and_mainboard_stats(
 
 
 @pytest.mark.usefixtures("wx_app")
+def test_present_deck_text_updates_ui_without_download_io(
+    deck_selector_factory,
+):
+    frame = deck_selector_factory()
+    try:
+        download_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+        frame.controller.download_deck_text = lambda *args, **kwargs: download_calls.append(
+            (args, kwargs)
+        )  # type: ignore[assignment]
+
+        frame.present_deck_text("4 Mountain\n4 Island\nSideboard\n2 Dispel\n")
+        pump_ui_events(wx.GetApp())
+
+        assert download_calls == []
+        assert frame.controller.deck_repo.get_current_deck_text().startswith("4 Mountain")
+        assert "8 card" in frame.main_table.count_label.GetLabel()
+        assert frame.deck_action_buttons.copy_button.IsEnabled()
+    finally:
+        frame.Destroy()
+
+
+@pytest.mark.usefixtures("wx_app")
 def test_builder_search_populates_results(
     deck_selector_factory,
 ):

--- a/widgets/app_frame.py
+++ b/widgets/app_frame.py
@@ -771,7 +771,7 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
         self.research_panel.populate_archetypes(archetype_names)
 
     def _on_deck_download_success(self, content: str) -> None:
-        self._on_deck_content_ready(content, source="mtggoldfish")
+        self.present_deck_text(content)
 
     def _has_deck_loaded(self) -> bool:
         return bool(self.zone_cards["main"] or self.zone_cards["side"])

--- a/widgets/handlers/app_event_handlers.py
+++ b/widgets/handlers/app_event_handlers.py
@@ -178,10 +178,10 @@ class AppEventHandlers:
         if idx < 0:
             return
         if idx == 0:  # "Any" — load all cached decks sorted by date
-            self._load_all_decks()
+            self._load_decks(scope="all")
             return
         archetype = self.filtered_archetypes[idx - 1]
-        self._load_decks_for_archetype(archetype)
+        self._load_decks(scope="archetype", archetype=archetype)
 
     def on_event_type_filter_changed(self: AppFrame) -> None:
         self._apply_deck_filters()
@@ -254,7 +254,7 @@ class AppEventHandlers:
         loading_label = self._t("deck.loading")
         self.main_table.show_loading(loading_label)
         self.side_table.show_loading(loading_label)
-        self._download_and_display_deck(deck)
+        self._download_deck_text(deck)
         self._schedule_settings_save()
 
     def on_daily_average_clicked(self: AppFrame, _event: wx.CommandEvent) -> None:
@@ -381,7 +381,7 @@ class AppEventHandlers:
         # Auto-load all recent decks on first archetype list arrival
         if not self._initial_any_load_triggered:
             self._initial_any_load_triggered = True
-            self._load_all_decks()
+            self._load_decks(scope="all")
 
     def _on_archetypes_error(self: AppFrame, error: Exception) -> None:
         with self._loading_lock:
@@ -724,7 +724,7 @@ class AppEventHandlers:
             wx.MessageBox(message, "Daily Average", wx.OK | wx.ICON_INFORMATION)
             return
 
-    def _download_and_display_deck(self, deck: dict[str, Any]) -> None:
+    def _download_deck_text(self, deck: dict[str, Any]) -> None:
         deck_number = deck.get("number")
         if not deck_number:
             wx.MessageBox("Deck identifier missing.", "Deck Error", wx.OK | wx.ICON_ERROR)
@@ -734,13 +734,15 @@ class AppEventHandlers:
         self.copy_button.Disable()
         self.save_button.Disable()
 
-        # Delegate to controller
-        self.controller.download_and_display_deck(
-            deck=deck,
-            on_success=lambda content: wx.CallAfter(self._on_deck_download_success, content),
+        self.controller.download_deck_text(
+            deck_number=deck_number,
+            on_success=lambda content: wx.CallAfter(self.present_deck_text, content),
             on_error=lambda error: wx.CallAfter(self._on_deck_download_error, error),
             on_status=lambda *a, **kw: wx.CallAfter(self._set_status, *a, **kw),
         )
+
+    def present_deck_text(self, content: str) -> None:
+        self._on_deck_content_ready(content, source="mtggoldfish")
 
     def _present_archetype_summary(self, archetype_name: str, decks: list[dict[str, Any]]) -> None:
         total = len(decks)
@@ -778,7 +780,20 @@ class AppEventHandlers:
         )
         self.summary_text.SetPage(html)
 
-    def _load_all_decks(self: AppFrame) -> None:
+    def _load_decks(
+        self: AppFrame,
+        *,
+        scope: str,
+        archetype: dict[str, Any] | None = None,
+    ) -> None:
+        if scope == "all":
+            name = "Any"
+        elif scope == "archetype" and archetype is not None:
+            name = archetype.get("name", "Unknown")
+        else:
+            wx.MessageBox("Archetype missing.", "Deck Error", wx.OK | wx.ICON_ERROR)
+            return
+
         self._all_loaded_decks = []
         if not self._is_first_deck_load:
             self.research_panel.reset_event_type_filter()
@@ -789,33 +804,10 @@ class AppEventHandlers:
         self.deck_list.Clear()
         self.deck_list.Append("Loading\u2026")
         self.deck_list.Disable()
-        self.summary_text.SetPage(_simple_summary_html("Any\n\nFetching deck results\u2026"))
-
-        self.controller.load_all_decks(
-            on_success=lambda archetype_name, decks: wx.CallAfter(
-                self._on_decks_loaded, archetype_name, decks
-            ),
-            on_error=lambda error: wx.CallAfter(self._on_decks_error, error),
-            on_status=lambda *a, **kw: wx.CallAfter(self._set_status, *a, **kw),
-        )
-
-    def _load_decks_for_archetype(self, archetype: dict[str, Any]) -> None:
-        name = archetype.get("name", "Unknown")
-        self._all_loaded_decks = []
-        if not self._is_first_deck_load:
-            self.research_panel.reset_event_type_filter()
-            self.research_panel.reset_result_filter()
-            self.research_panel.reset_player_name_filter()
-            self.research_panel.reset_date_filter()
-
-        # Update UI state immediately
-        self.deck_list.Clear()
-        self.deck_list.Append("Loading…")
-        self.deck_list.Disable()
         self.summary_text.SetPage(_simple_summary_html(f"{name}\n\nFetching deck results\u2026"))
 
-        # Delegate to controller
-        self.controller.load_decks_for_archetype(
+        self.controller.load_decks(
+            scope=scope,
             archetype=archetype,
             on_success=lambda archetype_name, decks: wx.CallAfter(
                 self._on_decks_loaded, archetype_name, decks


### PR DESCRIPTION
## Summary
- Replace separate all-decks/archetype deck loading methods with one scoped load_decks use case across the workflow service, controller, and UI handler.
- Split deck selection into controller download_deck_text and UI present_deck_text steps, removing the combined download/display method names.
- Update deck workflow coverage and UI fixtures/tests for the new seams.

## Tests
- python3 -m ruff check .
- python3 -m pytest tests/test_deck_results_filter.py tests/test_deck_workflow_service.py tests/test_metagame_repository.py
- python3 -m pytest tests --ignore=tests/ui --ignore=tests/test_card_box_panel_logic.py --ignore=tests/test_mana_icon_factory.py --ignore=tests/test_timer_alert_async.py --ignore=tests/test_identify_opponent_radar.py
- python3 -m py_compile tests/ui/conftest.py tests/ui/test_deck_selector.py widgets/handlers/app_event_handlers.py widgets/app_frame.py controllers/app_controller.py services/deck_workflow_service.py

## Environment Notes
- python3 -m pytest tests/ui/test_deck_selector.py cannot run on this Linux/WSL host because tests/ui/conftest.py requires Windows/wxPython.
- The full non-UI suite also requires wx for tests/test_card_box_panel_logic.py, tests/test_mana_icon_factory.py, tests/test_timer_alert_async.py, and tests/test_identify_opponent_radar.py; the non-wx subset above passed.

Closes #399