### PR TITLE
Refactor session restore snapshots

### DIFF
--- a/controllers/session_manager.py
+++ b/controllers/session_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -217,38 +218,43 @@ class DeckSelectorSessionManager:
         return {zone: sanitize_zone_cards(cards) for zone, cards in zone_cards.items()}
 
     # ------------------------------------------------------------------ restoration ------------------------------------------------------------------
-    def restore_session_state(self, zone_cards: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
-        result: dict[str, Any] = {"left_mode": self.get_left_mode()}
+    def load_workspace_snapshot(self) -> dict[str, Any]:
+        snapshot: dict[str, Any] = {"left_mode": self.get_left_mode()}
 
-        saved_zones = self.settings.get("saved_zone_cards") or {}
-        changed = False
-        for zone in ("main", "side", "out"):
-            entries = saved_zones.get(zone, [])
-            if not isinstance(entries, list):
-                continue
-            sanitized = sanitize_zone_cards(entries)
-            if sanitized:
-                zone_cards[zone] = sanitized
-                changed = True
-        if changed:
-            result["zone_cards"] = zone_cards
+        saved_zones = self.settings.get("saved_zone_cards")
+        if isinstance(saved_zones, dict):
+            zone_cards: dict[str, list[dict[str, Any]]] = {"main": [], "side": [], "out": []}
+            has_zone_cards = False
+            for zone in ("main", "side", "out"):
+                entries = saved_zones.get(zone, [])
+                if not isinstance(entries, list):
+                    continue
+                sanitized = sanitize_zone_cards(entries)
+                if sanitized:
+                    zone_cards[zone] = sanitized
+                    has_zone_cards = True
+            if has_zone_cards:
+                snapshot["zone_cards"] = zone_cards
 
         saved_text = self.settings.get("saved_deck_text", "")
         if saved_text:
-            self.deck_repo.set_current_deck_text(saved_text)
-            result["deck_text"] = saved_text
+            snapshot["deck_text"] = saved_text
 
         saved_deck = self.settings.get("saved_deck_info")
         if isinstance(saved_deck, dict):
-            self.deck_repo.set_current_deck(saved_deck)
-            result["deck_info"] = saved_deck
+            snapshot["deck_info"] = deepcopy(saved_deck)
+
+        return snapshot
+
+    def load_window_preferences(self) -> dict[str, Any]:
+        preferences: dict[str, Any] = {}
 
         window_size = self.settings.get("window_size")
         if isinstance(window_size, list) and len(window_size) == 2:
-            result["window_size"] = tuple(window_size)
+            preferences["window_size"] = tuple(window_size)
 
         screen_pos = self.settings.get("screen_pos")
         if isinstance(screen_pos, list) and len(screen_pos) == 2:
-            result["screen_pos"] = tuple(screen_pos)
+            preferences["screen_pos"] = tuple(screen_pos)
 
-        return result
+        return preferences

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -22,21 +22,25 @@ class StubDeckRepo:
     def __init__(self) -> None:
         self._current_deck_text = ""
         self._current_deck: dict | None = None
+        self.set_current_deck_text_calls: list[str] = []
+        self.set_current_deck_calls: list[dict | None] = []
 
     def get_current_deck_text(self) -> str:
         return self._current_deck_text
 
     def set_current_deck_text(self, text: str) -> None:
         self._current_deck_text = text
+        self.set_current_deck_text_calls.append(text)
 
     def get_current_deck(self) -> dict | None:
         return self._current_deck
 
     def set_current_deck(self, deck: dict | None) -> None:
         self._current_deck = deck
+        self.set_current_deck_calls.append(deck)
 
 
-def test_session_manager_persists_and_restores(tmp_path):
+def test_session_manager_persists_and_loads_snapshots(tmp_path):
     settings_file = tmp_path / "settings.json"
     config_file = tmp_path / "config.json"
     default_dir = tmp_path / "decks"
@@ -62,16 +66,17 @@ def test_session_manager_persists_and_restores(tmp_path):
 
     repo.set_current_deck_text("")
     repo.set_current_deck(None)
-    restore_target = {"main": [], "side": [], "out": []}
-
-    restored = manager.restore_session_state(restore_target)
+    window_preferences = manager.load_window_preferences()
+    restored = manager.load_workspace_snapshot()
     assert restored["left_mode"] == "builder"
     assert restored["zone_cards"]["main"][0]["name"] == "Lightning Bolt"
     assert restored["zone_cards"]["main"][0]["qty"] == 4
-    assert restored["window_size"] == (1280, 720)
-    assert restored["screen_pos"] == (10, 20)
-    assert repo.get_current_deck_text() == "4 Lightning Bolt"
-    assert repo.get_current_deck() == {"name": "Burn"}
+    assert restored["deck_text"] == "4 Lightning Bolt"
+    assert restored["deck_info"] == {"name": "Burn"}
+    assert window_preferences["window_size"] == (1280, 720)
+    assert window_preferences["screen_pos"] == (10, 20)
+    assert repo.get_current_deck_text() == ""
+    assert repo.get_current_deck() is None
 
     data = json.loads(settings_file.read_text(encoding="utf-8"))
     assert data["saved_deck_text"] == "4 Lightning Bolt"
@@ -120,3 +125,52 @@ def test_session_manager_validates_defaults_and_config(tmp_path):
 
     config_data = json.loads(config_file.read_text(encoding="utf-8"))
     assert config_data["deck_selector_save_path"] == str(deck_dir)
+
+
+def test_startup_restore_applies_saved_deck_state_once(tmp_path):
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(
+        json.dumps(
+            {
+                "left_mode": "builder",
+                "saved_deck_text": "4 Lightning Bolt",
+                "saved_deck_info": {"name": "Burn"},
+                "saved_zone_cards": {
+                    "main": [{"name": "Lightning Bolt", "qty": 4}],
+                    "side": [],
+                    "out": [],
+                },
+                "window_size": [1280, 720],
+                "screen_pos": [10, 20],
+            }
+        ),
+        encoding="utf-8",
+    )
+    repo = StubDeckRepo()
+    manager = DeckSelectorSessionManager(
+        repo,
+        settings_file=settings_file,
+        config_file=tmp_path / "config.json",
+        default_deck_dir=tmp_path / "decks",
+    )
+    zone_cards = {"main": [], "side": [], "out": []}
+
+    assert manager.load_window_preferences() == {
+        "window_size": (1280, 720),
+        "screen_pos": (10, 20),
+    }
+    assert zone_cards == {"main": [], "side": [], "out": []}
+    assert repo.set_current_deck_text_calls == []
+    assert repo.set_current_deck_calls == []
+
+    snapshot = manager.load_workspace_snapshot()
+    if "zone_cards" in snapshot:
+        zone_cards = snapshot["zone_cards"]
+    if snapshot.get("deck_text"):
+        repo.set_current_deck_text(snapshot["deck_text"])
+    if isinstance(snapshot.get("deck_info"), dict):
+        repo.set_current_deck(snapshot["deck_info"])
+
+    assert zone_cards["main"] == [{"name": "Lightning Bolt", "qty": 4}]
+    assert repo.set_current_deck_text_calls == ["4 Lightning Bolt"]
+    assert repo.set_current_deck_calls == [{"name": "Burn"}]

--- a/widgets/app_frame.py
+++ b/widgets/app_frame.py
@@ -95,6 +95,7 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
         self._inspector_hover_timer: wx.Timer | None = None
         self._pending_hover: tuple[str, dict[str, Any]] | None = None
         self._pending_deck_restore: bool = False
+        self._workspace_snapshot_applied: bool = False
         self._is_first_deck_load: bool = True
         self._initial_any_load_triggered: bool = False
         self._all_loaded_decks: list[dict[str, Any]] = []
@@ -621,14 +622,28 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
         show_help(self, topic=topic)
 
     def _restore_session_state(self) -> None:
-        state = self.controller.session_manager.restore_session_state(self.controller.zone_cards)
+        if self._workspace_snapshot_applied:
+            return
+        self._workspace_snapshot_applied = True
+
+        state = self.controller.session_manager.load_workspace_snapshot()
         if not self.controller.session_manager.is_tutorial_shown():
             wx.CallAfter(self._open_tutorial)
 
+        zone_cards = state.get("zone_cards")
+        has_saved_deck = bool(zone_cards)
+        if has_saved_deck:
+            self.controller.zone_cards = zone_cards
+
+        if state.get("deck_text"):
+            self.controller.deck_repo.set_current_deck_text(state["deck_text"])
+
+        deck_info = state.get("deck_info")
+        if isinstance(deck_info, dict):
+            self.controller.deck_repo.set_current_deck(deck_info)
+
         # Restore left panel mode
         self._show_left_panel(state["left_mode"], force=True)
-
-        has_saved_deck = bool(state.get("zone_cards"))
 
         # Restore zone cards
         if has_saved_deck:
@@ -668,7 +683,7 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
         )
 
     def _apply_window_preferences(self) -> None:
-        state = self.controller.session_manager.restore_session_state(self.controller.zone_cards)
+        state = self.controller.session_manager.load_window_preferences()
 
         # Apply window size
         if "window_size" in state:


### PR DESCRIPTION
Closes #398

## Summary
- Split session loading into pure window preference and workspace snapshot methods.
- Apply the workspace snapshot in AppFrame startup restore, guarded so it runs once.
- Keep window preference application from mutating zone cards or deck repository state.

## Tests
- `pytest tests/test_session_manager.py`
- `python3 -m compileall controllers/session_manager.py widgets/app_frame.py tests/test_session_manager.py`
- `pytest tests --ignore=tests/ui --ignore=tests/test_card_box_panel_logic.py --ignore=tests/test_mana_icon_factory.py --ignore=tests/test_timer_alert_async.py --ignore=tests/test_identify_opponent_radar.py --ignore=tests/test_radar_service.py` (463 passed, 5 skipped)

## Environment notes
- `pytest tests/ui/test_deck_selector.py` does not run in this WSL/Linux shell because the project skips UI tests outside Windows.
- Broader non-UI collection needs additional wx-dependent modules ignored because `wx` is not installed here.
- `tests/test_radar_service.py` fails in this environment while initializing the default SQLite radar repository (`unable to open database file` / `disk I/O error`).