### PR TITLE
Refactor DeckRepository persistence stores

### DIFF
--- a/repositories/__init__.py
+++ b/repositories/__init__.py
@@ -6,7 +6,11 @@ and retrieval operations, isolating the UI and business logic from data access d
 """
 
 from repositories.card_repository import CardRepository, get_card_repository
+from repositories.deck_db_store import DeckDbStore
+from repositories.deck_file_store import DeckFileStore
 from repositories.deck_repository import DeckRepository, get_deck_repository
+from repositories.deck_side_data_store import DeckSideDataStore
+from repositories.deck_workspace_state import DeckWorkspaceState
 from repositories.format_card_pool_repository import (
     FormatCardPoolRepository,
     get_format_card_pool_repository,
@@ -16,7 +20,11 @@ from repositories.radar_repository import RadarRepository, get_radar_repository
 
 __all__ = [
     "CardRepository",
+    "DeckDbStore",
+    "DeckFileStore",
     "DeckRepository",
+    "DeckSideDataStore",
+    "DeckWorkspaceState",
     "FormatCardPoolRepository",
     "MetagameRepository",
     "RadarRepository",

--- a/repositories/deck_db_store.py
+++ b/repositories/deck_db_store.py
@@ -1,0 +1,144 @@
+"""MongoDB persistence for saved decks."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pymongo
+from loguru import logger
+
+
+class DeckDbStore:
+    """Store for MongoDB deck CRUD operations."""
+
+    def __init__(
+        self,
+        mongo_client: pymongo.MongoClient | None = None,
+        *,
+        database_name: str = "lm_scraper",
+    ) -> None:
+        self._client = mongo_client
+        self._db = None
+        self._database_name = database_name
+
+    def _get_db(self):
+        if self._db is None:
+            if self._client is None:
+                self._client = pymongo.MongoClient("mongodb://localhost:27017/")
+            self._db = self._client.get_database(self._database_name)
+        return self._db
+
+    def save_to_db(
+        self,
+        deck_name: str,
+        deck_content: str,
+        format_type: str | None = None,
+        archetype: str | None = None,
+        player: str | None = None,
+        source: str = "manual",
+        metadata: dict[str, Any] | None = None,
+    ):
+        db = self._get_db()
+
+        deck_doc = {
+            "name": deck_name,
+            "content": deck_content,
+            "format": format_type,
+            "archetype": archetype,
+            "player": player,
+            "source": source,
+            "date_saved": datetime.now(),
+            "metadata": metadata or {},
+        }
+
+        result = db.decks.insert_one(deck_doc)
+        logger.info(f"Saved deck '{deck_name}' to database with ID: {result.inserted_id}")
+        return result.inserted_id
+
+    def get_decks(
+        self,
+        format_type: str | None = None,
+        archetype: str | None = None,
+        sort_by: str = "date_saved",
+    ) -> list[dict[str, Any]]:
+        db = self._get_db()
+
+        query = {}
+        if format_type:
+            query["format"] = format_type
+        if archetype:
+            query["archetype"] = archetype
+
+        decks = list(db.decks.find(query).sort(sort_by, pymongo.DESCENDING))
+        logger.debug(f"Retrieved {len(decks)} decks from database")
+        return decks
+
+    def load_from_db(self, deck_id):
+        db = self._get_db()
+
+        if isinstance(deck_id, str):
+            from bson import ObjectId
+
+            deck_id = ObjectId(deck_id)
+
+        deck = db.decks.find_one({"_id": deck_id})
+        if deck:
+            logger.debug(f"Loaded deck: {deck['name']}")
+        else:
+            logger.warning(f"Deck with ID {deck_id} not found")
+
+        return deck
+
+    def delete_from_db(self, deck_id) -> bool:
+        db = self._get_db()
+
+        if isinstance(deck_id, str):
+            from bson import ObjectId
+
+            deck_id = ObjectId(deck_id)
+
+        result = db.decks.delete_one({"_id": deck_id})
+
+        if result.deleted_count > 0:
+            logger.info(f"Deleted deck with ID: {deck_id}")
+            return True
+
+        logger.warning(f"Deck with ID {deck_id} not found for deletion")
+        return False
+
+    def update_in_db(
+        self,
+        deck_id,
+        deck_content: str | None = None,
+        deck_name: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        db = self._get_db()
+
+        if isinstance(deck_id, str):
+            from bson import ObjectId
+
+            deck_id = ObjectId(deck_id)
+
+        update_fields = {"date_modified": datetime.now()}
+
+        if deck_content is not None:
+            update_fields["content"] = deck_content
+        if deck_name is not None:
+            update_fields["name"] = deck_name
+        if metadata is not None:
+            existing_deck = db.decks.find_one({"_id": deck_id})
+            if existing_deck:
+                merged_metadata = existing_deck.get("metadata", {})
+                merged_metadata.update(metadata)
+                update_fields["metadata"] = merged_metadata
+
+        result = db.decks.update_one({"_id": deck_id}, {"$set": update_fields})
+
+        if result.modified_count > 0:
+            logger.info(f"Updated deck with ID: {deck_id}")
+            return True
+
+        logger.warning(f"Deck with ID {deck_id} not found or no changes made")
+        return False

--- a/repositories/deck_file_store.py
+++ b/repositories/deck_file_store.py
@@ -1,0 +1,81 @@
+"""Filesystem persistence for current deck and saved deck files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+from utils.atomic_io import atomic_write_text, locked_path
+from utils.constants import CURR_DECK_FILE, DECKS_DIR
+from utils.deck import sanitize_filename
+
+LEGACY_CURR_DECK_CACHE = Path("cache") / "curr_deck.txt"
+LEGACY_CURR_DECK_ROOT = Path("curr_deck.txt")
+
+
+class DeckFileStore:
+    """Store for deck files on disk."""
+
+    def __init__(
+        self,
+        *,
+        current_deck_file: Path = CURR_DECK_FILE,
+        decks_dir: Path = DECKS_DIR,
+        legacy_current_deck_files: tuple[Path, ...] | None = None,
+    ) -> None:
+        self.current_deck_file = current_deck_file
+        self.decks_dir = decks_dir
+        self.legacy_current_deck_files = legacy_current_deck_files or (
+            LEGACY_CURR_DECK_CACHE,
+            LEGACY_CURR_DECK_ROOT,
+        )
+
+    def read_current_deck_file(self) -> str:
+        candidates = [self.current_deck_file, *self.legacy_current_deck_files]
+        for candidate in candidates:
+            if candidate.exists():
+                with locked_path(candidate):
+                    with candidate.open("r", encoding="utf-8") as fh:
+                        contents = fh.read()
+                if candidate != self.current_deck_file:
+                    self._migrate_current_deck_file(candidate, contents)
+                return contents
+        raise FileNotFoundError("Current deck file not found")
+
+    def _migrate_current_deck_file(self, legacy_path: Path, contents: str) -> None:
+        try:
+            atomic_write_text(self.current_deck_file, contents)
+            try:
+                legacy_path.unlink()
+            except OSError:
+                logger.debug(f"Unable to remove legacy deck file {legacy_path}")
+        except OSError as exc:
+            logger.debug(f"Failed to migrate curr_deck.txt from {legacy_path}: {exc}")
+
+    def save_deck_to_file(
+        self, deck_name: str, deck_content: str, directory: Path | None = None
+    ) -> Path:
+        directory = directory or self.decks_dir
+        directory.mkdir(parents=True, exist_ok=True)
+
+        safe_name = sanitize_filename(deck_name, fallback="saved_deck")
+        file_path = directory / f"{safe_name}.txt"
+
+        counter = 1
+        while file_path.exists():
+            file_path = directory / f"{safe_name}_{counter}.txt"
+            counter += 1
+
+        atomic_write_text(file_path, deck_content)
+
+        logger.info(f"Saved deck to file: {file_path}")
+        return file_path
+
+    def list_deck_files(self, directory: Path | None = None) -> list[Path]:
+        directory = directory or self.decks_dir
+
+        if not directory.exists():
+            return []
+
+        return sorted(directory.glob("*.txt"))

--- a/repositories/deck_repository.py
+++ b/repositories/deck_repository.py
@@ -1,57 +1,38 @@
-"""
-Deck Repository - Centralized data access layer for deck operations.
+"""Compatibility facade for deck persistence stores and workspace state."""
 
-This module handles all deck-related data persistence including:
-- Database operations (MongoDB)
-- File system operations
-- Cache management
-- Deck file format conversion
-"""
+from __future__ import annotations
 
-import json
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import pymongo
-from loguru import logger
 
-from utils.atomic_io import atomic_write_json, atomic_write_text, locked_path
-from utils.constants import (
-    CACHE_DIR,
-    CURR_DECK_FILE,
-    DECKS_DIR,
-)
-from utils.deck import sanitize_filename
-
-# Legacy file paths for migration
-LEGACY_CURR_DECK_CACHE = Path("cache") / "curr_deck.txt"
-LEGACY_CURR_DECK_ROOT = Path("curr_deck.txt")
-NOTES_STORE = CACHE_DIR / "deck_notes.json"
-OUTBOARD_STORE = CACHE_DIR / "deck_outboard.json"
-GUIDE_STORE = CACHE_DIR / "deck_sbguides.json"
+from repositories.deck_db_store import DeckDbStore
+from repositories.deck_file_store import DeckFileStore
+from repositories.deck_side_data_store import DeckSideDataStore
+from repositories.deck_workspace_state import DeckWorkspaceState
 
 
 class DeckRepository:
-    """Repository for deck data access operations and deck state management."""
+    """Facade preserving the historical deck repository API.
 
-    def __init__(self, mongo_client: pymongo.MongoClient | None = None):
-        self._client = mongo_client
-        self._db = None
+    Persistence is handled by focused stores, while transient UI/workspace state
+    lives in DeckWorkspaceState.
+    """
 
-        # State management for UI layer
-        self._decks: list[dict[str, Any]] = []
-        self._current_deck: dict[str, Any] | None = None
-        self._current_deck_text: str = ""
-        self._deck_buffer: dict[str, float] = {}
-        self._decks_added: int = 0
-
-    def _get_db(self):
-        if self._db is None:
-            if self._client is None:
-                self._client = pymongo.MongoClient("mongodb://localhost:27017/")
-            self._db = self._client.get_database("lm_scraper")
-        return self._db
+    def __init__(
+        self,
+        mongo_client: pymongo.MongoClient | None = None,
+        *,
+        db_store: DeckDbStore | None = None,
+        file_store: DeckFileStore | None = None,
+        side_data_store: DeckSideDataStore | None = None,
+        workspace_state: DeckWorkspaceState | None = None,
+    ) -> None:
+        self.db_store = db_store or DeckDbStore(mongo_client)
+        self.file_store = file_store or DeckFileStore()
+        self.side_data_store = side_data_store or DeckSideDataStore()
+        self.workspace_state = workspace_state or DeckWorkspaceState()
 
     # ============= Database Operations =============
 
@@ -63,293 +44,126 @@ class DeckRepository:
         archetype: str | None = None,
         player: str | None = None,
         source: str = "manual",
-        metadata: dict | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
-        db = self._get_db()
-
-        deck_doc = {
-            "name": deck_name,
-            "content": deck_content,
-            "format": format_type,
-            "archetype": archetype,
-            "player": player,
-            "source": source,
-            "date_saved": datetime.now(),
-            "metadata": metadata or {},
-        }
-
-        result = db.decks.insert_one(deck_doc)
-        logger.info(f"Saved deck '{deck_name}' to database with ID: {result.inserted_id}")
-        return result.inserted_id
+        return self.db_store.save_to_db(
+            deck_name=deck_name,
+            deck_content=deck_content,
+            format_type=format_type,
+            archetype=archetype,
+            player=player,
+            source=source,
+            metadata=metadata,
+        )
 
     def get_decks(
         self,
         format_type: str | None = None,
         archetype: str | None = None,
         sort_by: str = "date_saved",
-    ) -> list[dict]:
-        db = self._get_db()
-
-        query = {}
-        if format_type:
-            query["format"] = format_type
-        if archetype:
-            query["archetype"] = archetype
-
-        decks = list(db.decks.find(query).sort(sort_by, pymongo.DESCENDING))
-        logger.debug(f"Retrieved {len(decks)} decks from database")
-        return decks
+    ) -> list[dict[str, Any]]:
+        return self.db_store.get_decks(
+            format_type=format_type,
+            archetype=archetype,
+            sort_by=sort_by,
+        )
 
     def load_from_db(self, deck_id):
-        db = self._get_db()
-
-        if isinstance(deck_id, str):
-            from bson import ObjectId
-
-            deck_id = ObjectId(deck_id)
-
-        deck = db.decks.find_one({"_id": deck_id})
-        if deck:
-            logger.debug(f"Loaded deck: {deck['name']}")
-        else:
-            logger.warning(f"Deck with ID {deck_id} not found")
-
-        return deck
+        return self.db_store.load_from_db(deck_id)
 
     def delete_from_db(self, deck_id) -> bool:
-        db = self._get_db()
-
-        if isinstance(deck_id, str):
-            from bson import ObjectId
-
-            deck_id = ObjectId(deck_id)
-
-        result = db.decks.delete_one({"_id": deck_id})
-
-        if result.deleted_count > 0:
-            logger.info(f"Deleted deck with ID: {deck_id}")
-            return True
-        else:
-            logger.warning(f"Deck with ID {deck_id} not found for deletion")
-            return False
+        return self.db_store.delete_from_db(deck_id)
 
     def update_in_db(
         self,
         deck_id,
         deck_content: str | None = None,
         deck_name: str | None = None,
-        metadata: dict | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> bool:
-        db = self._get_db()
-
-        if isinstance(deck_id, str):
-            from bson import ObjectId
-
-            deck_id = ObjectId(deck_id)
-
-        update_fields = {"date_modified": datetime.now()}
-
-        if deck_content is not None:
-            update_fields["content"] = deck_content
-        if deck_name is not None:
-            update_fields["name"] = deck_name
-        if metadata is not None:
-            # Merge metadata
-            existing_deck = db.decks.find_one({"_id": deck_id})
-            if existing_deck:
-                merged_metadata = existing_deck.get("metadata", {})
-                merged_metadata.update(metadata)
-                update_fields["metadata"] = merged_metadata
-
-        result = db.decks.update_one({"_id": deck_id}, {"$set": update_fields})
-
-        if result.modified_count > 0:
-            logger.info(f"Updated deck with ID: {deck_id}")
-            return True
-        else:
-            logger.warning(f"Deck with ID {deck_id} not found or no changes made")
-            return False
+        return self.db_store.update_in_db(
+            deck_id,
+            deck_content=deck_content,
+            deck_name=deck_name,
+            metadata=metadata,
+        )
 
     # ============= File System Operations =============
 
     def read_current_deck_file(self) -> str:
-        candidates = [CURR_DECK_FILE, LEGACY_CURR_DECK_CACHE, LEGACY_CURR_DECK_ROOT]
-        for candidate in candidates:
-            if candidate.exists():
-                with locked_path(candidate):
-                    with candidate.open("r", encoding="utf-8") as fh:
-                        contents = fh.read()
-                # Migrate from legacy locations
-                if candidate != CURR_DECK_FILE:
-                    try:
-                        atomic_write_text(CURR_DECK_FILE, contents)
-                        try:
-                            candidate.unlink()
-                        except OSError:
-                            logger.debug(f"Unable to remove legacy deck file {candidate}")
-                    except OSError as exc:
-                        logger.debug(f"Failed to migrate curr_deck.txt from {candidate}: {exc}")
-                return contents
-        raise FileNotFoundError("Current deck file not found")
+        return self.file_store.read_current_deck_file()
 
     def save_deck_to_file(
         self, deck_name: str, deck_content: str, directory: Path | None = None
     ) -> Path:
-        if directory is None:
-            directory = DECKS_DIR
-
-        directory.mkdir(parents=True, exist_ok=True)
-
-        # Sanitize filename with fallback for empty/whitespace names
-        safe_name = sanitize_filename(deck_name, fallback="saved_deck")
-        file_path = directory / f"{safe_name}.txt"
-
-        # Handle duplicate names
-        counter = 1
-        while file_path.exists():
-            file_path = directory / f"{safe_name}_{counter}.txt"
-            counter += 1
-
-        atomic_write_text(file_path, deck_content)
-
-        logger.info(f"Saved deck to file: {file_path}")
-        return file_path
+        return self.file_store.save_deck_to_file(deck_name, deck_content, directory)
 
     def list_deck_files(self, directory: Path | None = None) -> list[Path]:
-        if directory is None:
-            directory = DECKS_DIR
-
-        if not directory.exists():
-            return []
-
-        return sorted(directory.glob("*.txt"))
+        return self.file_store.list_deck_files(directory)
 
     # ============= Deck Metadata/Notes Storage =============
 
     def load_notes(self, deck_key: str) -> str:
-        data = self._load_json_store(NOTES_STORE)
-        return data.get(deck_key, "")
+        return self.side_data_store.load_notes(deck_key)
 
     def save_notes(self, deck_key: str, notes: str) -> None:
-        data = self._load_json_store(NOTES_STORE)
-        data[deck_key] = notes
-        self._save_json_store(NOTES_STORE, data)
+        self.side_data_store.save_notes(deck_key, notes)
 
     def load_outboard(self, deck_key: str) -> list[dict[str, Any]]:
-        data = self._load_json_store(OUTBOARD_STORE)
-        return data.get(deck_key, [])
+        return self.side_data_store.load_outboard(deck_key)
 
     def save_outboard(self, deck_key: str, outboard: list[dict[str, Any]]) -> None:
-        data = self._load_json_store(OUTBOARD_STORE)
-        data[deck_key] = outboard
-        self._save_json_store(OUTBOARD_STORE, data)
+        self.side_data_store.save_outboard(deck_key, outboard)
 
     def load_sideboard_guide(self, deck_key: str) -> list[dict[str, Any]]:
-        data = self._load_json_store(GUIDE_STORE)
-        return data.get(deck_key, [])
+        return self.side_data_store.load_sideboard_guide(deck_key)
 
     def save_sideboard_guide(self, deck_key: str, guide: list[dict[str, Any]]) -> None:
-        data = self._load_json_store(GUIDE_STORE)
-        data[deck_key] = guide
-        self._save_json_store(GUIDE_STORE, data)
+        self.side_data_store.save_sideboard_guide(deck_key, guide)
 
-    # ============= State Management (for UI layer) =============
+    # ============= Workspace State =============
 
     def get_decks_list(self) -> list[dict[str, Any]]:
-        return self._decks
+        return self.workspace_state.get_decks_list()
 
     def set_decks_list(self, decks: list[dict[str, Any]]) -> None:
-        self._decks = decks
+        self.workspace_state.set_decks_list(decks)
 
     def clear_decks_list(self) -> None:
-        self._decks = []
+        self.workspace_state.clear_decks_list()
 
     def get_current_deck(self) -> dict[str, Any] | None:
-        return self._current_deck
+        return self.workspace_state.get_current_deck()
 
     def get_current_deck_key(self) -> str:
-        current_deck = self.get_current_deck()
-        if current_deck:
-            return current_deck.get("href") or current_deck.get("name", "manual").lower()
-        return "manual"
+        return self.workspace_state.get_current_deck_key()
 
     def get_current_decklist_hash(self) -> str:
-        # Each unique 75-card configuration gets its own guide; the same exact
-        # deck loaded multiple times retains its guide.
-        import hashlib
-
-        deck_text = self.get_current_deck_text()
-        if not deck_text:
-            return "empty"
-
-        lines = [line.strip() for line in deck_text.strip().split("\n") if line.strip()]
-        lines.sort()
-        normalized_text = "\n".join(lines)
-
-        hash_obj = hashlib.sha256(normalized_text.encode("utf-8"))
-        return hash_obj.hexdigest()[:16]
+        return self.workspace_state.get_current_decklist_hash()
 
     def set_current_deck(self, deck: dict[str, Any] | None) -> None:
-        self._current_deck = deck
+        self.workspace_state.set_current_deck(deck)
 
     def get_current_deck_text(self) -> str:
-        return self._current_deck_text
+        return self.workspace_state.get_current_deck_text()
 
     def set_current_deck_text(self, deck_text: str) -> None:
-        self._current_deck_text = deck_text
+        self.workspace_state.set_current_deck_text(deck_text)
 
     def get_deck_buffer(self) -> dict[str, float]:
-        return self._deck_buffer
+        return self.workspace_state.get_deck_buffer()
 
     def set_deck_buffer(self, buffer: dict[str, float]) -> None:
-        self._deck_buffer = buffer
+        self.workspace_state.set_deck_buffer(buffer)
 
     def get_decks_added_count(self) -> int:
-        return self._decks_added
+        return self.workspace_state.get_decks_added_count()
 
     def set_decks_added_count(self, count: int) -> None:
-        self._decks_added = count
+        self.workspace_state.set_decks_added_count(count)
 
     def reset_averaging_state(self) -> None:
-        self._deck_buffer = {}
-        self._decks_added = 0
-
-    def build_daily_average_deck(
-        self,
-        decks: list[dict[str, Any]],
-        download_func,
-        read_func,
-        add_to_buffer_func,
-        progress_callback=None,
-    ) -> dict[str, float]:
-        buffer: dict[str, float] = {}
-        total = len(decks)
-        for index, deck in enumerate(decks, start=1):
-            download_func(deck["number"])
-            deck_content = read_func()
-            buffer = add_to_buffer_func(buffer, deck_content)
-            if progress_callback:
-                progress_callback(index, total)
-        return buffer
-
-    # ============= Private Helper Methods =============
-
-    def _load_json_store(self, path: Path) -> dict[str, Any]:
-        if not path.exists():
-            return {}
-        try:
-            with locked_path(path):
-                with path.open("r", encoding="utf-8") as f:
-                    return json.load(f)
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning(f"Failed to load {path}: {exc}")
-            return {}
-
-    def _save_json_store(self, path: Path, data: dict[str, Any]) -> None:
-        try:
-            atomic_write_json(path, data, indent=2)
-        except OSError as exc:
-            logger.error(f"Failed to save {path}: {exc}")
+        self.workspace_state.reset_averaging_state()
 
 
 # Global instance for backward compatibility

--- a/repositories/deck_side_data_store.py
+++ b/repositories/deck_side_data_store.py
@@ -1,0 +1,71 @@
+"""JSON side-data persistence for deck notes, outboards, and sideboard guides."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from utils.atomic_io import atomic_write_json, locked_path
+from utils.constants import GUIDE_STORE, NOTES_STORE, OUTBOARD_STORE
+
+
+class DeckSideDataStore:
+    """Store for deck side-data keyed by deck identity."""
+
+    def __init__(
+        self,
+        *,
+        notes_store: Path = NOTES_STORE,
+        outboard_store: Path = OUTBOARD_STORE,
+        guide_store: Path = GUIDE_STORE,
+    ) -> None:
+        self.notes_store = notes_store
+        self.outboard_store = outboard_store
+        self.guide_store = guide_store
+
+    def load_notes(self, deck_key: str) -> str:
+        data = self._load_json_store(self.notes_store)
+        return data.get(deck_key, "")
+
+    def save_notes(self, deck_key: str, notes: str) -> None:
+        data = self._load_json_store(self.notes_store)
+        data[deck_key] = notes
+        self._save_json_store(self.notes_store, data)
+
+    def load_outboard(self, deck_key: str) -> list[dict[str, Any]]:
+        data = self._load_json_store(self.outboard_store)
+        return data.get(deck_key, [])
+
+    def save_outboard(self, deck_key: str, outboard: list[dict[str, Any]]) -> None:
+        data = self._load_json_store(self.outboard_store)
+        data[deck_key] = outboard
+        self._save_json_store(self.outboard_store, data)
+
+    def load_sideboard_guide(self, deck_key: str) -> list[dict[str, Any]]:
+        data = self._load_json_store(self.guide_store)
+        return data.get(deck_key, [])
+
+    def save_sideboard_guide(self, deck_key: str, guide: list[dict[str, Any]]) -> None:
+        data = self._load_json_store(self.guide_store)
+        data[deck_key] = guide
+        self._save_json_store(self.guide_store, data)
+
+    def _load_json_store(self, path: Path) -> dict[str, Any]:
+        if not path.exists():
+            return {}
+        try:
+            with locked_path(path):
+                with path.open("r", encoding="utf-8") as f:
+                    return json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning(f"Failed to load {path}: {exc}")
+            return {}
+
+    def _save_json_store(self, path: Path, data: dict[str, Any]) -> None:
+        try:
+            atomic_write_json(path, data, indent=2)
+        except OSError as exc:
+            logger.error(f"Failed to save {path}: {exc}")

--- a/repositories/deck_workspace_state.py
+++ b/repositories/deck_workspace_state.py
@@ -1,0 +1,72 @@
+"""Transient workspace state for deck selection and averaging."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+
+class DeckWorkspaceState:
+    """In-memory deck workspace state kept separate from persistence stores."""
+
+    def __init__(self) -> None:
+        self._decks: list[dict[str, Any]] = []
+        self._current_deck: dict[str, Any] | None = None
+        self._current_deck_text: str = ""
+        self._deck_buffer: dict[str, float] = {}
+        self._decks_added: int = 0
+
+    def get_decks_list(self) -> list[dict[str, Any]]:
+        return self._decks
+
+    def set_decks_list(self, decks: list[dict[str, Any]]) -> None:
+        self._decks = decks
+
+    def clear_decks_list(self) -> None:
+        self._decks = []
+
+    def get_current_deck(self) -> dict[str, Any] | None:
+        return self._current_deck
+
+    def get_current_deck_key(self) -> str:
+        current_deck = self.get_current_deck()
+        if current_deck:
+            return current_deck.get("href") or current_deck.get("name", "manual").lower()
+        return "manual"
+
+    def get_current_decklist_hash(self) -> str:
+        deck_text = self.get_current_deck_text()
+        if not deck_text:
+            return "empty"
+
+        lines = [line.strip() for line in deck_text.strip().split("\n") if line.strip()]
+        lines.sort()
+        normalized_text = "\n".join(lines)
+
+        hash_obj = hashlib.sha256(normalized_text.encode("utf-8"))
+        return hash_obj.hexdigest()[:16]
+
+    def set_current_deck(self, deck: dict[str, Any] | None) -> None:
+        self._current_deck = deck
+
+    def get_current_deck_text(self) -> str:
+        return self._current_deck_text
+
+    def set_current_deck_text(self, deck_text: str) -> None:
+        self._current_deck_text = deck_text
+
+    def get_deck_buffer(self) -> dict[str, float]:
+        return self._deck_buffer
+
+    def set_deck_buffer(self, buffer: dict[str, float]) -> None:
+        self._deck_buffer = buffer
+
+    def get_decks_added_count(self) -> int:
+        return self._decks_added
+
+    def set_decks_added_count(self, count: int) -> None:
+        self._decks_added = count
+
+    def reset_averaging_state(self) -> None:
+        self._deck_buffer = {}
+        self._decks_added = 0

--- a/services/deck_averager.py
+++ b/services/deck_averager.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from loguru import logger
 
-from repositories.deck_repository import DeckRepository
 from repositories.metagame_repository import MetagameRepository
 from services.deck_parser import DeckParser
 from utils.constants import DEFAULT_MAX_DECKS
@@ -169,14 +168,34 @@ class DeckAverager:
         today = today or time.strftime("%Y-%m-%d").lower()
         return [deck for deck in decks if today in str(deck.get("date", "")).lower()]
 
+    def build_average_buffer(
+        self,
+        decks: list[dict[str, Any]],
+        download_deck: Callable[[str], None],
+        read_deck_file: Callable[[], str],
+        add_to_buffer: Callable[[dict[str, Any], str], dict[str, Any]] | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> dict[str, Any]:
+        buffer: dict[str, Any] = {}
+        total = len(decks)
+        add_func = add_to_buffer or self.add_deck_to_buffer
+
+        for index, deck in enumerate(decks, start=1):
+            download_deck(deck["number"])
+            deck_content = read_deck_file()
+            buffer = add_func(buffer, deck_content)
+            if progress_callback:
+                progress_callback(index, total)
+
+        return buffer
+
     def build_average_text(
         self,
         todays_decks: list[dict[str, Any]],
         download_deck: Callable[[str], None],
         read_deck_file: Callable[[], str],
-        deck_repo: DeckRepository,
     ) -> str:
-        buffer = deck_repo.build_daily_average_deck(
+        buffer = self.build_average_buffer(
             todays_decks,
             download_deck,
             read_deck_file,

--- a/services/deck_service.py
+++ b/services/deck_service.py
@@ -114,7 +114,22 @@ class DeckService:
             todays_decks,
             download_deck,
             read_deck_file,
-            self.deck_repo,
+        )
+
+    def build_average_buffer(
+        self,
+        todays_decks: list[dict[str, Any]],
+        download_deck: Callable[[str], None],
+        read_deck_file: Callable[[], str],
+        add_to_buffer: Callable[[dict[str, Any], str], dict[str, Any]],
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> dict[str, Any]:
+        return self.deck_averager.build_average_buffer(
+            todays_decks,
+            download_deck,
+            read_deck_file,
+            add_to_buffer,
+            progress_callback=progress_callback,
         )
 
 

--- a/services/deck_workflow_service.py
+++ b/services/deck_workflow_service.py
@@ -143,7 +143,7 @@ class DeckWorkflowService:
             else self.deck_service.add_deck_to_buffer
         )
 
-        return self.deck_repo.build_daily_average_deck(
+        return self.deck_service.build_average_buffer(
             rows,
             download_with_filter,
             self._deck_reader,

--- a/tests/test_deck_averager.py
+++ b/tests/test_deck_averager.py
@@ -118,3 +118,21 @@ def test_render_average_deck_fractional(averager):
 def test_render_average_deck_empty(averager):
     assert averager.render_average_deck({}, 5) == ""
     assert averager.render_average_deck({"x": 1.0}, 0) == ""
+
+
+def test_build_average_buffer_downloads_reads_and_reports_progress(averager):
+    downloads: list[str] = []
+    reads = iter(["1 Island", "2 Island"])
+    progress_calls: list[tuple[int, int]] = []
+
+    buffer = averager.build_average_buffer(
+        [{"number": "a"}, {"number": "b"}],
+        lambda number: downloads.append(number),
+        lambda: next(reads),
+        averager.add_deck_to_buffer,
+        progress_callback=lambda index, total: progress_calls.append((index, total)),
+    )
+
+    assert downloads == ["a", "b"]
+    assert buffer == {"Island": 3.0}
+    assert progress_calls == [(1, 2), (2, 2)]

--- a/tests/test_deck_repository.py
+++ b/tests/test_deck_repository.py
@@ -1,9 +1,12 @@
-import tempfile
-from pathlib import Path
+from __future__ import annotations
 
-import pytest
+import pymongo
 
+from repositories.deck_db_store import DeckDbStore
+from repositories.deck_file_store import DeckFileStore
 from repositories.deck_repository import DeckRepository
+from repositories.deck_side_data_store import DeckSideDataStore
+from repositories.deck_workspace_state import DeckWorkspaceState
 
 SAMPLE_DECK = """4 Lightning Bolt
 4 Counterspell
@@ -13,91 +16,170 @@ SAMPLE_DECK = """4 Lightning Bolt
 """
 
 
-@pytest.fixture
-def temp_dir():
-    """Create a temporary directory for deck files."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield Path(tmpdir)
+class FakeInsertResult:
+    def __init__(self, inserted_id: str) -> None:
+        self.inserted_id = inserted_id
 
 
-@pytest.fixture
-def deck_repo():
-    """Create a DeckRepository instance."""
-    return DeckRepository()
+class FakeDeleteResult:
+    def __init__(self, deleted_count: int) -> None:
+        self.deleted_count = deleted_count
 
 
-def test_save_deck_with_blank_name_uses_fallback(deck_repo, temp_dir):
-    """Verify that blank deck names use the fallback 'saved_deck'."""
-    result_path = deck_repo.save_deck_to_file("", SAMPLE_DECK, directory=temp_dir)
+class FakeUpdateResult:
+    def __init__(self, modified_count: int) -> None:
+        self.modified_count = modified_count
+
+
+class FakeCursor:
+    def __init__(self, rows: list[dict], collection: FakeDeckCollection) -> None:
+        self.rows = rows
+        self.collection = collection
+
+    def sort(self, sort_by: str, direction: int) -> FakeCursor:
+        self.collection.last_sort = (sort_by, direction)
+        return self
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class FakeDeckCollection:
+    def __init__(self) -> None:
+        self.docs: list[dict] = []
+        self.last_find_query: dict | None = None
+        self.last_sort: tuple[str, int] | None = None
+
+    def insert_one(self, doc: dict) -> FakeInsertResult:
+        self.docs.append(doc)
+        return FakeInsertResult("deck-id")
+
+    def find(self, query: dict) -> FakeCursor:
+        self.last_find_query = query
+        rows = [
+            doc for doc in self.docs if all(doc.get(key) == value for key, value in query.items())
+        ]
+        return FakeCursor(rows, self)
+
+    def find_one(self, query: dict) -> dict | None:
+        for doc in self.docs:
+            if all(doc.get(key) == value for key, value in query.items()):
+                return doc
+        return None
+
+    def delete_one(self, query: dict) -> FakeDeleteResult:
+        original_len = len(self.docs)
+        self.docs = [
+            doc
+            for doc in self.docs
+            if not all(doc.get(key) == value for key, value in query.items())
+        ]
+        return FakeDeleteResult(original_len - len(self.docs))
+
+    def update_one(self, query: dict, update: dict) -> FakeUpdateResult:
+        doc = self.find_one(query)
+        if doc is None:
+            return FakeUpdateResult(0)
+        doc.update(update["$set"])
+        return FakeUpdateResult(1)
+
+
+class FakeDb:
+    def __init__(self) -> None:
+        self.decks = FakeDeckCollection()
+
+
+class FakeMongoClient:
+    def __init__(self, db: FakeDb) -> None:
+        self.db = db
+        self.database_name: str | None = None
+
+    def get_database(self, name: str) -> FakeDb:
+        self.database_name = name
+        return self.db
+
+
+def make_side_data_store(tmp_path) -> DeckSideDataStore:
+    return DeckSideDataStore(
+        notes_store=tmp_path / "notes.json",
+        outboard_store=tmp_path / "outboard.json",
+        guide_store=tmp_path / "guide.json",
+    )
+
+
+def test_deck_db_store_saves_and_filters_decks():
+    db = FakeDb()
+    store = DeckDbStore(FakeMongoClient(db))
+
+    inserted_id = store.save_to_db(
+        deck_name="Burn",
+        deck_content=SAMPLE_DECK,
+        format_type="Modern",
+        archetype="Burn",
+        player="Tester",
+        source="manual",
+        metadata={"source_id": 1},
+    )
+    result = store.get_decks(format_type="Modern", archetype="Burn", sort_by="name")
+
+    assert inserted_id == "deck-id"
+    assert result == db.decks.docs
+    assert db.decks.docs[0]["date_saved"] is not None
+    assert db.decks.last_find_query == {"format": "Modern", "archetype": "Burn"}
+    assert db.decks.last_sort == ("name", pymongo.DESCENDING)
+
+
+def test_deck_db_store_update_merges_metadata():
+    db = FakeDb()
+    deck_id = object()
+    db.decks.docs.append({"_id": deck_id, "metadata": {"existing": True}, "name": "Old"})
+    store = DeckDbStore(FakeMongoClient(db))
+
+    updated = store.update_in_db(deck_id, deck_name="New", metadata={"new": True})
+
+    assert updated is True
+    assert db.decks.docs[0]["name"] == "New"
+    assert db.decks.docs[0]["metadata"] == {"existing": True, "new": True}
+    assert db.decks.docs[0]["date_modified"] is not None
+
+
+def test_file_store_save_deck_with_blank_name_uses_fallback(tmp_path):
+    store = DeckFileStore(decks_dir=tmp_path)
+
+    result_path = store.save_deck_to_file("", SAMPLE_DECK)
 
     assert result_path.name == "saved_deck.txt"
     assert result_path.exists()
     assert result_path.read_text() == SAMPLE_DECK
 
 
-def test_save_deck_with_whitespace_name_uses_fallback(deck_repo, temp_dir):
-    """Verify that whitespace-only deck names use the fallback."""
-    result_path = deck_repo.save_deck_to_file("   ", SAMPLE_DECK, directory=temp_dir)
+def test_file_store_save_deck_with_valid_name(tmp_path):
+    store = DeckFileStore(decks_dir=tmp_path)
 
-    assert result_path.name == "saved_deck.txt"
-    assert result_path.exists()
-
-
-def test_save_deck_with_special_chars_only_uses_fallback(deck_repo, temp_dir):
-    """Verify that names with only special characters use the fallback."""
-    result_path = deck_repo.save_deck_to_file("***///***", SAMPLE_DECK, directory=temp_dir)
-
-    assert result_path.name == "saved_deck.txt"
-    assert result_path.exists()
-
-
-def test_save_deck_with_valid_name(deck_repo, temp_dir):
-    """Verify that valid deck names are preserved."""
-    result_path = deck_repo.save_deck_to_file("My Awesome Deck", SAMPLE_DECK, directory=temp_dir)
+    result_path = store.save_deck_to_file("My Awesome Deck", SAMPLE_DECK)
 
     assert result_path.name == "My Awesome Deck.txt"
     assert result_path.exists()
 
 
-def test_save_deck_handles_duplicates_with_fallback(deck_repo, temp_dir):
-    """Verify that duplicate blank deck names get unique filenames."""
-    # Save first blank deck
-    path1 = deck_repo.save_deck_to_file("", SAMPLE_DECK, directory=temp_dir)
+def test_file_store_save_deck_handles_duplicates(tmp_path):
+    store = DeckFileStore(decks_dir=tmp_path)
+
+    path1 = store.save_deck_to_file("", SAMPLE_DECK)
+    path2 = store.save_deck_to_file("", SAMPLE_DECK)
+    path3 = store.save_deck_to_file("   ", SAMPLE_DECK)
+
     assert path1.name == "saved_deck.txt"
-
-    # Save second blank deck - should get _1 suffix
-    path2 = deck_repo.save_deck_to_file("", SAMPLE_DECK, directory=temp_dir)
     assert path2.name == "saved_deck_1.txt"
-
-    # Save third blank deck - should get _2 suffix
-    path3 = deck_repo.save_deck_to_file("   ", SAMPLE_DECK, directory=temp_dir)
     assert path3.name == "saved_deck_2.txt"
-
-    # All files should exist and be distinct
-    assert path1.exists() and path2.exists() and path3.exists()
     assert len({path1, path2, path3}) == 3
 
 
-def test_save_deck_handles_duplicates_with_normal_names(deck_repo, temp_dir):
-    """Verify that duplicate normal deck names get unique filenames."""
-    # Save first deck
-    path1 = deck_repo.save_deck_to_file("Test Deck", SAMPLE_DECK, directory=temp_dir)
-    assert path1.name == "Test Deck.txt"
+def test_file_store_save_deck_sanitizes_invalid_chars(tmp_path):
+    store = DeckFileStore(decks_dir=tmp_path)
 
-    # Save duplicate - should get _1 suffix
-    path2 = deck_repo.save_deck_to_file("Test Deck", SAMPLE_DECK, directory=temp_dir)
-    assert path2.name == "Test Deck_1.txt"
+    result_path = store.save_deck_to_file("Deck:With/Invalid*Chars?", SAMPLE_DECK)
 
-    assert path1.exists() and path2.exists()
-
-
-def test_save_deck_sanitizes_invalid_chars(deck_repo, temp_dir):
-    """Verify that invalid filename characters are replaced."""
-    result_path = deck_repo.save_deck_to_file(
-        "Deck:With/Invalid*Chars?", SAMPLE_DECK, directory=temp_dir
-    )
-
-    # Should replace invalid chars with underscores
     assert ":" not in result_path.name
     assert "/" not in result_path.name
     assert "*" not in result_path.name
@@ -105,12 +187,98 @@ def test_save_deck_sanitizes_invalid_chars(deck_repo, temp_dir):
     assert result_path.exists()
 
 
-def test_save_deck_creates_directory(deck_repo, temp_dir):
-    """Verify that save_deck_to_file creates the directory if it doesn't exist."""
-    nested_dir = temp_dir / "nested" / "path"
-    assert not nested_dir.exists()
+def test_file_store_save_deck_creates_directory(tmp_path):
+    nested_dir = tmp_path / "nested" / "path"
+    store = DeckFileStore(decks_dir=nested_dir)
 
-    result_path = deck_repo.save_deck_to_file("Test", SAMPLE_DECK, directory=nested_dir)
+    result_path = store.save_deck_to_file("Test", SAMPLE_DECK)
 
     assert nested_dir.exists()
     assert result_path.exists()
+
+
+def test_file_store_reads_and_migrates_legacy_current_deck_file(tmp_path):
+    current_file = tmp_path / "decks" / "curr_deck.txt"
+    legacy_file = tmp_path / "curr_deck.txt"
+    legacy_file.write_text(SAMPLE_DECK, encoding="utf-8")
+    store = DeckFileStore(
+        current_deck_file=current_file,
+        legacy_current_deck_files=(legacy_file,),
+    )
+
+    contents = store.read_current_deck_file()
+
+    assert contents == SAMPLE_DECK
+    assert current_file.read_text(encoding="utf-8") == SAMPLE_DECK
+    assert not legacy_file.exists()
+
+
+def test_file_store_lists_deck_files(tmp_path):
+    (tmp_path / "b.txt").write_text("", encoding="utf-8")
+    (tmp_path / "a.txt").write_text("", encoding="utf-8")
+    (tmp_path / "ignore.json").write_text("", encoding="utf-8")
+    store = DeckFileStore(decks_dir=tmp_path)
+
+    result = store.list_deck_files()
+
+    assert [path.name for path in result] == ["a.txt", "b.txt"]
+
+
+def test_side_data_store_persists_notes_outboard_and_guides(tmp_path):
+    store = make_side_data_store(tmp_path)
+
+    store.save_notes("deck-key", "Mulligan notes")
+    store.save_outboard("deck-key", [{"name": "Card", "qty": 2}])
+    store.save_sideboard_guide("deck-key", [{"matchup": "Mirror"}])
+
+    assert store.load_notes("deck-key") == "Mulligan notes"
+    assert store.load_outboard("deck-key") == [{"name": "Card", "qty": 2}]
+    assert store.load_sideboard_guide("deck-key") == [{"matchup": "Mirror"}]
+
+
+def test_side_data_store_handles_invalid_json(tmp_path):
+    notes_store = tmp_path / "notes.json"
+    notes_store.write_text("{", encoding="utf-8")
+    store = DeckSideDataStore(
+        notes_store=notes_store,
+        outboard_store=tmp_path / "outboard.json",
+        guide_store=tmp_path / "guide.json",
+    )
+
+    assert store.load_notes("deck-key") == ""
+
+
+def test_workspace_state_tracks_deck_selection_and_hash():
+    state = DeckWorkspaceState()
+
+    state.set_decks_list([{"name": "Deck"}])
+    state.set_current_deck({"name": "Manual Deck"})
+    state.set_current_deck_text("2 Island\n1 Mountain")
+    first_hash = state.get_current_decklist_hash()
+    state.set_current_deck_text("1 Mountain\n2 Island")
+
+    assert state.get_decks_list() == [{"name": "Deck"}]
+    assert state.get_current_deck_key() == "manual deck"
+    assert state.get_current_decklist_hash() == first_hash
+    state.clear_decks_list()
+    assert state.get_decks_list() == []
+
+
+def test_repository_facade_delegates_to_injected_stores(tmp_path):
+    db = FakeDb()
+    repo = DeckRepository(
+        db_store=DeckDbStore(FakeMongoClient(db)),
+        file_store=DeckFileStore(decks_dir=tmp_path),
+        side_data_store=make_side_data_store(tmp_path),
+        workspace_state=DeckWorkspaceState(),
+    )
+
+    file_path = repo.save_deck_to_file("Burn", SAMPLE_DECK)
+    repo.save_notes("burn", "notes")
+    repo.set_current_deck({"href": "burn"})
+    inserted_id = repo.save_to_db("Burn", SAMPLE_DECK)
+
+    assert file_path.exists()
+    assert repo.load_notes("burn") == "notes"
+    assert repo.get_current_deck_key() == "burn"
+    assert inserted_id == "deck-id"

--- a/tests/test_deck_workflow_service.py
+++ b/tests/test_deck_workflow_service.py
@@ -11,7 +11,6 @@ class FakeDeckRepo:
         self.current_deck_text = ""
         self.current_deck: dict[str, str] = {}
         self.saved_payload: dict | None = None
-        self.daily_average_rows: list[list[dict]] = []
 
     def set_decks_list(self, decks: list[dict]) -> None:
         self.decks_list = decks
@@ -42,16 +41,6 @@ class FakeDeckRepo:
         self.saved_payload = payload
         return 123
 
-    def build_daily_average_deck(
-        self, rows, download_func, reader_func, add_to_buffer, progress_callback
-    ):
-        self.daily_average_rows.append(rows)
-        for index, row in enumerate(rows, start=1):
-            download_func(row["number"])
-            progress_callback(index, len(rows))
-        add_to_buffer({"name": "Card"}, 0.5)
-        return {"Card": 0.5}
-
 
 class FakeMetagameRepo:
     def __init__(self) -> None:
@@ -70,6 +59,7 @@ class FakeDeckService:
     def __init__(self) -> None:
         self.zone_calls: list[dict] = []
         self.buffer_calls = 0
+        self.daily_average_rows: list[list[dict]] = []
 
     def build_deck_text_from_zones(self, zones):
         self.zone_calls.append(json.loads(json.dumps(zones)))
@@ -80,6 +70,17 @@ class FakeDeckService:
 
     def add_deck_to_karsten_buffer(self, *_args, **_kwargs):
         self.buffer_calls += 1
+
+    def build_average_buffer(
+        self, rows, download_func, reader_func, add_to_buffer, progress_callback
+    ):
+        self.daily_average_rows.append(rows)
+        for index, row in enumerate(rows, start=1):
+            download_func(row["number"])
+            reader_func()
+            progress_callback(index, len(rows))
+        add_to_buffer({"name": "Card"}, "deck text")
+        return {"Card": 0.5}
 
 
 def build_service(
@@ -158,7 +159,12 @@ def test_build_daily_average_buffer_wires_dependencies():
     def downloader(deck_number: str, source_filter: str | None = None):
         downloads.append(f"{deck_number}:{source_filter}")
 
-    service = build_service(deck_repo=repo, deck_service=deck_service, deck_downloader=downloader)
+    service = build_service(
+        deck_repo=repo,
+        deck_service=deck_service,
+        deck_downloader=downloader,
+        deck_reader=lambda: "deck text",
+    )
     rows = [{"number": "a"}, {"number": "b"}]
     buffer = service.build_daily_average_buffer(
         rows,
@@ -170,7 +176,7 @@ def test_build_daily_average_buffer_wires_dependencies():
     assert downloads == ["a:both", "b:both"]
     assert progress_calls == [(1, 2), (2, 2)]
     assert deck_service.buffer_calls == 1
-    assert repo.daily_average_rows == [rows]
+    assert deck_service.daily_average_rows == [rows]
 
 
 def test_save_deck_persists_file_and_db(tmp_path):


### PR DESCRIPTION
## Summary
- Split DeckRepository internals into DeckDbStore, DeckFileStore, DeckSideDataStore, and DeckWorkspaceState while keeping the existing repository facade API for callers.
- Moved daily-average buffer iteration out of DeckRepository into DeckAverager/DeckService and updated DeckWorkflowService to use that path.
- Expanded tests to target the smaller stores directly, including Mongo CRUD fakes, deck file save/list/migration behavior, side-data JSON stores, workspace state, and average-buffer iteration.

Closes #397

## Verification
- `python3 -m ruff check repositories/deck_db_store.py repositories/deck_file_store.py repositories/deck_side_data_store.py repositories/deck_workspace_state.py repositories/deck_repository.py repositories/__init__.py services/deck_averager.py services/deck_service.py services/deck_workflow_service.py tests/test_deck_repository.py tests/test_deck_workflow_service.py tests/test_deck_averager.py`
- `python3 -m black --check repositories/deck_db_store.py repositories/deck_file_store.py repositories/deck_side_data_store.py repositories/deck_workspace_state.py repositories/deck_repository.py repositories/__init__.py services/deck_averager.py services/deck_service.py services/deck_workflow_service.py tests/test_deck_repository.py tests/test_deck_workflow_service.py tests/test_deck_averager.py`
- `python3 -m pytest tests/test_deck_service.py tests/test_deck_workflow_service.py tests/test_deck_averager.py tests/test_deck_repository.py` (37 passed)
- `python3 -m pytest` was attempted locally but this WSL interpreter is missing `wx`, causing collection errors in `tests/test_card_box_panel_logic.py`, `tests/test_mana_icon_factory.py`, and `tests/test_timer_alert_async.py`.
- `python3 -m pytest --ignore=tests/test_card_box_panel_logic.py --ignore=tests/test_mana_icon_factory.py --ignore=tests/test_timer_alert_async.py` was attempted; it reached 487 passed / 6 skipped, then still failed on wx imports in `tests/test_identify_opponent_radar.py` and an unrelated `tests/test_image_service.py::test_download_request_404_no_retry` timing assertion.
- `timeout 600 ./run_pytest_on_host.sh` was attempted after pushing the branch, but SSH host key verification failed because `ssh-askpass` is unavailable in this shell.
