### PR TITLE
Refactor app controller bootstrap wiring

### DIFF
--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,13 +1,17 @@
 """Controllers module - Application-level controllers for coordinating business logic."""
 
+from controllers.app_bootstrap import create_deck_selector_controller
 from controllers.app_controller import (
     AppController,
     get_deck_selector_controller,
     reset_deck_selector_controller,
+    set_deck_selector_controller,
 )
 
 __all__ = [
     "AppController",
+    "create_deck_selector_controller",
     "get_deck_selector_controller",
     "reset_deck_selector_controller",
+    "set_deck_selector_controller",
 ]

--- a/controllers/app_bootstrap.py
+++ b/controllers/app_bootstrap.py
@@ -1,0 +1,151 @@
+"""Application composition boundary for the deck selector."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from controllers.app_controller_helpers import AppControllerUIHelpers
+from controllers.bulk_data_helpers import BulkDataHelpers
+from controllers.mtgo_background_helpers import MtgoBackgroundHelpers
+from controllers.session_manager import DeckSelectorSessionManager
+from repositories.card_repository import get_card_repository
+from repositories.deck_repository import get_deck_repository
+from repositories.metagame_repository import get_metagame_repository
+from services.collection_service import get_collection_service
+from services.deck_service import get_deck_service
+from services.deck_workflow_service import DeckWorkflowService
+from services.image_service import get_image_service
+from services.search_service import get_search_service
+from services.store_service import get_store_service
+from utils.background_worker import BackgroundWorker
+from utils.constants import LOGS_DIR, MTGO_DECKLISTS_ENABLED, ensure_base_dirs
+from utils.diagnostics import EventLogger
+
+if TYPE_CHECKING:
+    import wx
+
+    from controllers.app_controller import AppController
+    from widgets.app_frame import AppFrame
+
+
+@dataclass(slots=True)
+class AppControllerDependencies:
+    deck_repo: Any
+    metagame_repo: Any
+    card_repo: Any
+    deck_service: Any
+    search_service: Any
+    collection_service: Any
+    image_service: Any
+    store_service: Any
+    session_manager: DeckSelectorSessionManager
+    deck_workflow_service: DeckWorkflowService
+    event_logger: EventLogger
+    worker: BackgroundWorker
+    bulk_data_helpers: BulkDataHelpers
+    mtgo_background_helpers: MtgoBackgroundHelpers
+
+
+def build_app_controller_dependencies(
+    *,
+    frame_provider: Callable[[], AppFrame | None],
+) -> AppControllerDependencies:
+    ensure_base_dirs()
+
+    deck_repo = get_deck_repository()
+    metagame_repo = get_metagame_repository()
+    card_repo = get_card_repository()
+    deck_service = get_deck_service()
+    search_service = get_search_service()
+    collection_service = get_collection_service()
+    image_service = get_image_service()
+    store_service = get_store_service()
+    session_manager = DeckSelectorSessionManager(deck_repo)
+    deck_workflow_service = DeckWorkflowService(
+        deck_repo=deck_repo,
+        metagame_repo=metagame_repo,
+        deck_service=deck_service,
+    )
+    event_logger = EventLogger(
+        LOGS_DIR,
+        enabled=session_manager.get_event_logging_enabled(),
+    )
+    worker = BackgroundWorker()
+
+    return AppControllerDependencies(
+        deck_repo=deck_repo,
+        metagame_repo=metagame_repo,
+        card_repo=card_repo,
+        deck_service=deck_service,
+        search_service=search_service,
+        collection_service=collection_service,
+        image_service=image_service,
+        store_service=store_service,
+        session_manager=session_manager,
+        deck_workflow_service=deck_workflow_service,
+        event_logger=event_logger,
+        worker=worker,
+        bulk_data_helpers=BulkDataHelpers(
+            image_service=image_service,
+            worker=worker,
+            frame_provider=frame_provider,
+        ),
+        mtgo_background_helpers=MtgoBackgroundHelpers(worker=worker),
+    )
+
+
+def create_deck_selector_controller(parent: wx.Window | None = None) -> AppController:
+    from controllers.app_controller import AppController, set_deck_selector_controller
+
+    controller: AppController | None = None
+    dependencies = build_app_controller_dependencies(
+        frame_provider=lambda: controller.frame if controller else None,
+    )
+    controller = AppController(
+        deck_repo=dependencies.deck_repo,
+        metagame_repo=dependencies.metagame_repo,
+        card_repo=dependencies.card_repo,
+        deck_service=dependencies.deck_service,
+        search_service=dependencies.search_service,
+        collection_service=dependencies.collection_service,
+        image_service=dependencies.image_service,
+        store_service=dependencies.store_service,
+        session_manager=dependencies.session_manager,
+        deck_workflow_service=dependencies.deck_workflow_service,
+        event_logger=dependencies.event_logger,
+        worker=dependencies.worker,
+        bulk_data_helpers=dependencies.bulk_data_helpers,
+    )
+    attach_app_frame(controller, parent=parent)
+    start_mtgo_background_fetch(dependencies.mtgo_background_helpers)
+    set_deck_selector_controller(controller)
+    return controller
+
+
+def attach_app_frame(
+    controller: AppController,
+    parent: wx.Window | None = None,
+) -> AppFrame:
+    import wx
+
+    from widgets.app_frame import AppFrame
+
+    frame = AppFrame(controller=controller, parent=parent)
+    callbacks = AppControllerUIHelpers(controller, frame).build_callbacks()
+    controller.attach_frame(frame, callbacks)
+
+    wx.CallAfter(frame._restore_session_state)
+    wx.CallAfter(lambda: controller.run_initial_loads(deck_save_dir=controller.deck_save_dir))
+
+    return frame
+
+
+def start_mtgo_background_fetch(helper: MtgoBackgroundHelpers) -> None:
+    if MTGO_DECKLISTS_ENABLED:
+        helper.start_background_fetch()
+    else:
+        logger.info("MTGO decklists disabled; skipping background fetch.")

--- a/controllers/app_controller.py
+++ b/controllers/app_controller.py
@@ -19,32 +19,20 @@ from loguru import logger
 if TYPE_CHECKING:
     import wx
 
+    from controllers.bulk_data_helpers import BulkDataHelpers
     from widgets.app_frame import AppFrame
 
-from controllers.app_controller_helpers import AppControllerUIHelpers, UICallbacks
-from controllers.bulk_data_helpers import BulkDataHelpers
-from controllers.mtgo_background_helpers import MtgoBackgroundHelpers
+from controllers.app_controller_helpers import UICallbacks
 from controllers.session_manager import DeckSelectorSessionManager
-from repositories.card_repository import get_card_repository
-from repositories.deck_repository import get_deck_repository
-from repositories.metagame_repository import get_metagame_repository
-from services.collection_service import get_collection_service
-from services.deck_service import get_deck_service
 from services.deck_workflow_service import DeckLoadScope, DeckWorkflowService
-from services.image_service import get_image_service
-from services.search_service import get_search_service
-from services.store_service import get_store_service
 from utils.background_worker import BackgroundWorker
 from utils.card_data import CardDataManager
 from utils.constants import (
     COLLECTION_CACHE_MAX_AGE_SECONDS,
     GUIDE_STORE,
-    LOGS_DIR,
     MTGO_BRIDGE_SHUTDOWN_TIMEOUT_SECONDS,
-    MTGO_DECKLISTS_ENABLED,
     NOTES_STORE,
     OUTBOARD_STORE,
-    ensure_base_dirs,
 )
 from utils.diagnostics import EventLogger
 from utils.i18n import normalize_locale
@@ -55,35 +43,32 @@ class AppController:
     def __init__(
         self,
         *,
-        deck_repo=None,
-        metagame_repo=None,
-        card_repo=None,
-        deck_service=None,
-        search_service=None,
-        collection_service=None,
-        image_service=None,
-        store_service=None,
-        session_manager: DeckSelectorSessionManager | None = None,
-        deck_workflow_service: DeckWorkflowService | None = None,
+        deck_repo: Any,
+        metagame_repo: Any,
+        card_repo: Any,
+        deck_service: Any,
+        search_service: Any,
+        collection_service: Any,
+        image_service: Any,
+        store_service: Any,
+        session_manager: DeckSelectorSessionManager,
+        deck_workflow_service: DeckWorkflowService,
+        event_logger: EventLogger,
+        worker: BackgroundWorker,
+        bulk_data_helpers: BulkDataHelpers,
     ):
-        ensure_base_dirs()
+        # Services and repositories are composed by controllers.app_bootstrap.
+        self.deck_repo = deck_repo
+        self.metagame_repo = metagame_repo
+        self.card_repo = card_repo
+        self.deck_service = deck_service
+        self.search_service = search_service
+        self.collection_service = collection_service
+        self.image_service = image_service
+        self.store_service = store_service
 
-        # Services and repositories
-        self.deck_repo = deck_repo or get_deck_repository()
-        self.metagame_repo = metagame_repo or get_metagame_repository()
-        self.card_repo = card_repo or get_card_repository()
-        self.deck_service = deck_service or get_deck_service()
-        self.search_service = search_service or get_search_service()
-        self.collection_service = collection_service or get_collection_service()
-        self.image_service = image_service or get_image_service()
-        self.store_service = store_service or get_store_service()
-
-        self.session_manager = session_manager or DeckSelectorSessionManager(self.deck_repo)
-        self.workflow_service = deck_workflow_service or DeckWorkflowService(
-            deck_repo=self.deck_repo,
-            metagame_repo=self.metagame_repo,
-            deck_service=self.deck_service,
-        )
+        self.session_manager = session_manager
+        self.workflow_service = deck_workflow_service
 
         # Settings management
         self.current_format = self.session_manager.get_current_format()
@@ -99,10 +84,7 @@ class AppController:
         self._average_hours = self.session_manager.get_average_hours()
 
         # Event logger (opt-in, local-only)
-        self.event_logger = EventLogger(
-            LOGS_DIR,
-            enabled=self.session_manager.get_event_logging_enabled(),
-        )
+        self.event_logger = event_logger
 
         # Config-backed deck save directory
         self.deck_save_dir = self.session_manager.ensure_deck_save_dir()
@@ -132,22 +114,13 @@ class AppController:
         self._ui_callbacks: UICallbacks | None = None
 
         # Background worker for tasks with lifecycle control
-        self._worker = BackgroundWorker()
+        self._worker = worker
         self.frame: AppFrame | None = None
-        self._bulk_data_helpers = BulkDataHelpers(
-            image_service=self.image_service,
-            worker=self._worker,
-            frame_provider=lambda: self.frame,
-        )
-        self._mtgo_background_helpers = MtgoBackgroundHelpers(worker=self._worker)
+        self._bulk_data_helpers = bulk_data_helpers
 
-        self.frame = self.create_frame()
-
-        # Start background MTGO data fetch
-        if MTGO_DECKLISTS_ENABLED:
-            self._mtgo_background_helpers.start_background_fetch()
-        else:
-            logger.info("MTGO decklists disabled; skipping background fetch.")
+    def attach_frame(self, frame: AppFrame, callbacks: UICallbacks) -> None:
+        self.frame = frame
+        self._ui_callbacks = callbacks
 
     # ============= Card Data Management =============
 
@@ -569,25 +542,9 @@ class AppController:
     # ============= Frame Factory =============
 
     def create_frame(self, parent: wx.Window | None = None) -> AppFrame:
-        import wx
+        from controllers.app_bootstrap import attach_app_frame
 
-        from widgets.app_frame import AppFrame
-
-        # Create the frame
-        frame = AppFrame(controller=self, parent=parent)
-        self._ui_callbacks = AppControllerUIHelpers(self, frame).build_callbacks()
-
-        # Restore UI state from controller's session data
-        wx.CallAfter(frame._restore_session_state)
-
-        # Trigger initial loading after frame is ready
-        wx.CallAfter(
-            lambda: self.run_initial_loads(
-                deck_save_dir=self.deck_save_dir,
-            )
-        )
-
-        return frame
+        return attach_app_frame(self, parent=parent)
 
     def shutdown(self, timeout: float = MTGO_BRIDGE_SHUTDOWN_TIMEOUT_SECONDS) -> None:
         logger.info("Shutting down AppController background workers...")
@@ -602,10 +559,17 @@ _controller_instance: AppController | None = None
 def get_deck_selector_controller() -> AppController:
     global _controller_instance
     if _controller_instance is None:
-        _controller_instance = AppController()
+        from controllers.app_bootstrap import create_deck_selector_controller
+
+        _controller_instance = create_deck_selector_controller()
     return _controller_instance
 
 
 def reset_deck_selector_controller() -> None:
     global _controller_instance
     _controller_instance = None
+
+
+def set_deck_selector_controller(controller: AppController | None) -> None:
+    global _controller_instance
+    _controller_instance = controller

--- a/controllers/bulk_data_helpers.py
+++ b/controllers/bulk_data_helpers.py
@@ -13,6 +13,16 @@ if TYPE_CHECKING:
     from widgets.app_frame import AppFrame
 
 
+def _wx_call_after(callback: Callable[..., None], *args: Any) -> None:
+    import wx
+
+    wx.CallAfter(callback, *args)
+
+
+def _noop(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
 class BulkDataHelpers:
     def __init__(
         self,
@@ -20,10 +30,12 @@ class BulkDataHelpers:
         image_service: Any,
         worker: BackgroundWorker,
         frame_provider: Callable[[], AppFrame | None],
+        call_after: Callable[..., None] | None = None,
     ) -> None:
         self._image_service = image_service
         self._worker = worker
         self._frame_provider = frame_provider
+        self._call_after = call_after or _wx_call_after
         self._bulk_check_worker_active = False
 
     def check_and_download_bulk_data(self, callbacks: UICallbacks | None) -> None:
@@ -31,12 +43,10 @@ class BulkDataHelpers:
             logger.debug("Bulk data check already running")
             return
 
-        on_status = callbacks.on_status if callbacks else lambda msg: None
-        on_download_needed = callbacks.on_bulk_download_needed if callbacks else lambda reason: None
-        on_download_complete = (
-            callbacks.on_bulk_download_complete if callbacks else lambda msg: None
-        )
-        on_download_failed = callbacks.on_bulk_download_failed if callbacks else lambda msg: None
+        on_status = callbacks.on_status if callbacks else _noop
+        on_download_needed = callbacks.on_bulk_download_needed if callbacks else _noop
+        on_download_complete = callbacks.on_bulk_download_complete if callbacks else _noop
+        on_download_failed = callbacks.on_bulk_download_failed if callbacks else _noop
 
         on_status("bulk.status.checking")
         self._bulk_check_worker_active = True
@@ -86,21 +96,17 @@ class BulkDataHelpers:
         on_status("bulk.status.preparing_cache")
 
         def success_callback(data, stats):
-            import wx
-
             # Persist bulk data and notify UI
             self._image_service.set_bulk_data(data)
             frame = self._frame_provider()
             if frame:
-                wx.CallAfter(frame._on_bulk_data_loaded, data, stats)
+                self._call_after(frame._on_bulk_data_loaded, data, stats)
 
         def error_callback(msg):
-            import wx
-
             logger.warning(f"Bulk data load issue: {msg}")
             frame = self._frame_provider()
             if frame:
-                wx.CallAfter(frame._on_bulk_data_load_failed, msg)
+                self._call_after(frame._on_bulk_data_load_failed, msg)
 
         started = self._image_service.load_printing_index_async(
             force=force,
@@ -109,20 +115,18 @@ class BulkDataHelpers:
         )
 
         if not started:
-            on_status(self._t("app.status.ready"))
+            on_status("app.status.ready")
 
     def force_bulk_data_update(self, callbacks: UICallbacks | None) -> None:
         if self._bulk_check_worker_active:
             logger.debug("Bulk data update already running")
             return
 
-        on_status = callbacks.on_status if callbacks else lambda msg: None
-        on_download_complete = (
-            callbacks.on_bulk_download_complete if callbacks else lambda msg: None
-        )
-        on_download_failed = callbacks.on_bulk_download_failed if callbacks else lambda msg: None
+        on_status = callbacks.on_status if callbacks else _noop
+        on_download_complete = callbacks.on_bulk_download_complete if callbacks else _noop
+        on_download_failed = callbacks.on_bulk_download_failed if callbacks else _noop
 
-        on_status(self._t("bulk.status.downloading"))
+        on_status("bulk.status.downloading")
         self._bulk_check_worker_active = True
 
         def _on_download_complete(msg: str) -> None:
@@ -133,7 +137,7 @@ class BulkDataHelpers:
         def _on_download_failed(msg: str) -> None:
             self._bulk_check_worker_active = False
             on_download_failed(msg)
-            on_status(self._t("app.status.ready"))
+            on_status("app.status.ready")
 
         self._image_service.download_bulk_metadata_async(
             on_success=_on_download_complete,

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import argparse
 import wx
 from loguru import logger
 
-from controllers.app_controller import get_deck_selector_controller
+from controllers.app_bootstrap import create_deck_selector_controller
 from utils.constants import BASE_DATA_DIR, LOGS_DIR, ensure_base_dirs
 from utils.logging_config import configure_logging
 from widgets.splash_frame import LoadingFrame
@@ -34,7 +34,7 @@ class MetagameWxApp(wx.App):
         return True
 
     def _build_main_window(self) -> None:
-        controller = get_deck_selector_controller()
+        controller = create_deck_selector_controller()
         self.controller = controller
         self.SetTopWindow(controller.frame)
 

--- a/tests/test_bulk_data_helpers.py
+++ b/tests/test_bulk_data_helpers.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from controllers.app_controller_helpers import UICallbacks
+from controllers.bulk_data_helpers import BulkDataHelpers
+
+
+def _noop(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+class ImmediateWorker:
+    def submit(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        on_success: Callable[[Any], None] | None = None,
+        on_error: Callable[[Exception], None] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        try:
+            result = func(*args, **kwargs)
+        except Exception as exc:
+            if on_error:
+                on_error(exc)
+            return
+
+        if on_success:
+            on_success(result)
+
+
+class FakeImageService:
+    def __init__(self, *, check_result: tuple[bool, str] = (True, "current")) -> None:
+        self.check_result = check_result
+        self.check_error: Exception | None = None
+        self.bulk_data: dict[str, list[dict[str, Any]]] | None = None
+        self.load_started = True
+        self.load_data = {"lightning bolt": [{"set": "lea"}]}
+        self.load_stats = {"total_printings": 1}
+        self.load_error: str | None = None
+        self.download_error: str | None = None
+        self.download_msg = "downloaded"
+        self.load_calls: list[bool] = []
+        self.download_calls: list[bool] = []
+
+    def check_bulk_data_exists(self) -> tuple[bool, str]:
+        if self.check_error:
+            raise self.check_error
+        return self.check_result
+
+    def download_bulk_metadata_async(
+        self,
+        *,
+        on_success: Callable[[str], None],
+        on_error: Callable[[str], None],
+        force: bool = False,
+    ) -> None:
+        self.download_calls.append(force)
+        if self.download_error is not None:
+            on_error(self.download_error)
+            return
+        on_success(self.download_msg)
+
+    def load_printing_index_async(
+        self,
+        *,
+        force: bool,
+        on_success: Callable[[dict[str, list[dict[str, Any]]], dict[str, Any]], None],
+        on_error: Callable[[str], None],
+    ) -> bool:
+        self.load_calls.append(force)
+        if not self.load_started:
+            return False
+        if self.load_error is not None:
+            on_error(self.load_error)
+            return True
+        on_success(self.load_data, self.load_stats)
+        return True
+
+    def set_bulk_data(self, bulk_data: dict[str, list[dict[str, Any]]]) -> None:
+        self.bulk_data = bulk_data
+
+    def get_bulk_data(self) -> dict[str, list[dict[str, Any]]] | None:
+        return self.bulk_data
+
+
+def _make_callbacks(
+    *,
+    statuses: list[str],
+    needed: list[str] | None = None,
+    completed: list[str] | None = None,
+    failed: list[str] | None = None,
+) -> UICallbacks:
+    needed = needed if needed is not None else []
+    completed = completed if completed is not None else []
+    failed = failed if failed is not None else []
+    return UICallbacks(
+        on_status=lambda msg, *_args, **_kwargs: statuses.append(msg),
+        on_archetypes_success=_noop,
+        on_archetypes_error=_noop,
+        on_collection_loaded=_noop,
+        on_collection_not_found=_noop,
+        on_collection_refresh_success=_noop,
+        on_collection_failed=_noop,
+        on_bulk_download_needed=needed.append,
+        on_bulk_download_complete=completed.append,
+        on_bulk_download_failed=failed.append,
+    )
+
+
+def _make_helper(image_service: FakeImageService) -> BulkDataHelpers:
+    return BulkDataHelpers(
+        image_service=image_service,
+        worker=ImmediateWorker(),
+        frame_provider=lambda: None,
+        call_after=lambda callback, *args: callback(*args),
+    )
+
+
+def test_check_and_download_bulk_data_loads_existing_index() -> None:
+    image_service = FakeImageService(check_result=(True, "current"))
+    helper = _make_helper(image_service)
+    statuses: list[str] = []
+
+    helper.check_and_download_bulk_data(_make_callbacks(statuses=statuses))
+
+    assert statuses == [
+        "bulk.status.checking",
+        "bulk.status.preparing_cache",
+        "bulk.status.ready",
+    ]
+    assert image_service.load_calls == [False]
+    assert image_service.download_calls == []
+    assert image_service.bulk_data == image_service.load_data
+
+
+def test_check_and_download_bulk_data_downloads_missing_index() -> None:
+    image_service = FakeImageService(check_result=(False, "missing cache"))
+    helper = _make_helper(image_service)
+    statuses: list[str] = []
+    needed: list[str] = []
+    completed: list[str] = []
+
+    helper.check_and_download_bulk_data(
+        _make_callbacks(statuses=statuses, needed=needed, completed=completed)
+    )
+
+    assert statuses == [
+        "bulk.status.checking",
+        "bulk.status.downloading",
+        "bulk.status.preparing_cache",
+    ]
+    assert needed == ["missing cache"]
+    assert completed == ["downloaded"]
+    assert image_service.download_calls == [False]
+    assert image_service.load_calls == [True]
+    assert image_service.bulk_data == image_service.load_data
+
+
+def test_load_bulk_data_into_memory_reports_ready_when_index_worker_not_started() -> None:
+    image_service = FakeImageService()
+    image_service.load_started = False
+    helper = _make_helper(image_service)
+    statuses: list[str] = []
+
+    helper.load_bulk_data_into_memory(statuses.append, force=True)
+
+    assert statuses == ["bulk.status.preparing_cache", "app.status.ready"]
+    assert image_service.load_calls == [True]
+    assert image_service.bulk_data is None
+
+
+def test_force_bulk_data_update_reports_ready_after_download_failure() -> None:
+    image_service = FakeImageService()
+    image_service.download_error = "network failed"
+    helper = _make_helper(image_service)
+    statuses: list[str] = []
+    failed: list[str] = []
+
+    helper.force_bulk_data_update(_make_callbacks(statuses=statuses, failed=failed))
+
+    assert statuses == ["bulk.status.downloading", "app.status.ready"]
+    assert failed == ["network failed"]
+    assert image_service.download_calls == [True]
+    assert image_service.load_calls == []

--- a/widgets/app_frame.py
+++ b/widgets/app_frame.py
@@ -5,8 +5,6 @@ import wx
 from loguru import logger
 from wx.lib.agw import flatnotebook as fnb
 
-from controllers.app_controller import get_deck_selector_controller
-
 if TYPE_CHECKING:
     from controllers.app_controller import AppController
 
@@ -782,7 +780,9 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
 
 def launch_app() -> None:
     app = wx.App(False)
-    controller = get_deck_selector_controller()
+    from controllers.app_bootstrap import create_deck_selector_controller
+
+    controller = create_deck_selector_controller()
     controller.frame.Show()
     app.MainLoop()
 


### PR DESCRIPTION
Closes #396

Summary:
- Add an app bootstrap boundary that builds controller dependencies, attaches AppFrame, schedules initial loads, and registers the legacy singleton shim.
- Refactor AppController to receive collaborators explicitly and delegate legacy frame creation to the bootstrap boundary.
- Fix BulkDataHelpers to emit status keys directly, inject UI call_after behavior, and cover check/download/load-index paths with focused tests.

Tests:
- python3 -m compileall controllers main.py widgets/app_frame.py tests/test_bulk_data_helpers.py
- python3 -m ruff check controllers/__init__.py controllers/app_bootstrap.py controllers/app_controller.py controllers/bulk_data_helpers.py main.py widgets/app_frame.py tests/test_bulk_data_helpers.py
- python3 -m black --check --target-version py310 controllers/__init__.py controllers/app_bootstrap.py controllers/app_controller.py controllers/bulk_data_helpers.py main.py widgets/app_frame.py tests/test_bulk_data_helpers.py
- python3 -m pytest tests/test_bulk_data_helpers.py tests/test_background_worker.py tests/test_image_service.py tests/test_session_manager.py
- python3 -m pytest tests --ignore=tests/ui --ignore=tests/test_card_box_panel_logic.py --ignore=tests/test_mana_icon_factory.py --ignore=tests/test_timer_alert_async.py --ignore=tests/test_identify_opponent_radar.py

Notes:
- Full non-UI collection on this Linux environment is blocked by modules that import wx at collection time; the last pytest command excludes those wx blockers and passed.