### PR TITLE
Standardize UI background task lifecycle

### DIFF
--- a/services/image_service.py
+++ b/services/image_service.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from loguru import logger
 
+from utils.background_worker import BackgroundWorker
 from utils.card_images import (
     BULK_DATA_CACHE,
     PRINTING_INDEX_CACHE,
@@ -67,18 +68,17 @@ class CardImageDownloadQueue:
         self._lock = threading.Lock()
         self._condition = threading.Condition(self._lock)
         self._executor = ThreadPoolExecutor(max_workers=self._MAX_CONCURRENT_DOWNLOADS)
-        self._thread = threading.Thread(
-            target=self._run,
+        self._worker = BackgroundWorker(thread_name_prefix="card-image-download-queue")
+        self._thread = self._worker.submit(
+            self._run,
             name="card-image-download-queue",
-            daemon=True,
         )
-        self._thread.start()
 
     def stop(self, timeout: float = IMAGE_DOWNLOAD_QUEUE_STOP_TIMEOUT_SECONDS) -> None:
         self._stop_event.set()
         with self._condition:
             self._condition.notify_all()
-        self._thread.join(timeout=timeout)
+        self._worker.shutdown(timeout=timeout)
         self._executor.shutdown(wait=True, cancel_futures=True)
 
     def set_selected_request(self, request: CardImageRequest | None) -> None:
@@ -300,11 +300,13 @@ class ImageService:
         self._printings_inflight: set[str] = set()
         self._on_printings_loaded: Callable[[str, list[dict[str, Any]]], None] | None = None
         self._process_worker = ProcessWorker()
+        self._worker = BackgroundWorker(thread_name_prefix="image-service")
         self._bulk_download_handle: ProcessHandle | None = None
         self._printings_handle: ProcessHandle | None = None
 
     def shutdown(self) -> None:
         self._download_queue.stop()
+        self._worker.shutdown(timeout=IMAGE_DOWNLOAD_QUEUE_STOP_TIMEOUT_SECONDS)
         if self._bulk_download_handle:
             self._process_worker.terminate(self._bulk_download_handle)
             self._bulk_download_handle = None
@@ -393,7 +395,7 @@ class ImageService:
         def run_task() -> None:
             self._run_printings_task(worker, success_handler, error_handler)
 
-        threading.Thread(target=run_task, daemon=True).start()
+        self._worker.submit(run_task, name="image-service-printings")
 
     @staticmethod
     def _run_printings_task(
@@ -408,14 +410,8 @@ class ImageService:
             return
         on_success(result)
 
-    @staticmethod
-    def _call_after(callback: Callable[..., Any], *args: Any) -> None:
-        try:
-            import wx
-
-            wx.CallAfter(callback, *args)
-        except ImportError:
-            callback(*args)
+    def _call_after(self, callback: Callable[..., Any], *args: Any) -> None:
+        self._worker.call_after(callback, *args)
 
     # ============= Bulk Data Management =============
 

--- a/tests/test_background_worker.py
+++ b/tests/test_background_worker.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import sys
 import threading
 import time
+from types import SimpleNamespace
 
 from utils.background_worker import BackgroundWorker
 
@@ -116,3 +118,53 @@ def test_background_worker_shutdown_timeout():
     worker.shutdown(timeout=0.2)
 
     assert worker.is_stopped()
+
+
+def test_background_worker_call_after_uses_wx_when_app_available(monkeypatch):
+    worker = BackgroundWorker()
+    calls = []
+
+    fake_wx = SimpleNamespace(
+        GetApp=lambda: object(),
+        CallAfter=lambda callback, *args, **kwargs: calls.append((callback, args, kwargs)),
+    )
+    monkeypatch.setitem(sys.modules, "wx", fake_wx)
+
+    callback = lambda value: value  # noqa: E731
+
+    assert worker.call_after(callback, "ok") is True
+    assert calls == [(callback, ("ok",), {})]
+
+    worker.shutdown()
+
+
+def test_background_worker_call_after_skips_when_wx_app_missing(monkeypatch):
+    worker = BackgroundWorker()
+    calls = []
+
+    def fail_call_after(*_args, **_kwargs):
+        raise AssertionError("wx.CallAfter should not be called without a wx app")
+
+    fake_wx = SimpleNamespace(GetApp=lambda: None, CallAfter=fail_call_after)
+    monkeypatch.setitem(sys.modules, "wx", fake_wx)
+
+    assert worker.call_after(lambda: calls.append("called")) is False
+    assert calls == []
+
+    worker.shutdown()
+
+
+def test_background_worker_call_after_skips_after_wx_teardown(monkeypatch):
+    worker = BackgroundWorker()
+    calls = []
+
+    def raising_call_after(*_args, **_kwargs):
+        raise RuntimeError("wrapped C/C++ object of type App has been deleted")
+
+    fake_wx = SimpleNamespace(GetApp=lambda: object(), CallAfter=raising_call_after)
+    monkeypatch.setitem(sys.modules, "wx", fake_wx)
+
+    assert worker.call_after(lambda: calls.append("called")) is False
+    assert calls == []
+
+    worker.shutdown()

--- a/tests/test_card_box_panel_logic.py
+++ b/tests/test_card_box_panel_logic.py
@@ -8,6 +8,10 @@ from typing import Any
 
 import pytest
 
+from utils.background_worker import BackgroundWorker
+
+pytest.importorskip("wx")
+
 
 def _load_card_box_panel_module():
     """Load widgets/panels/card_box_panel.py directly, bypassing the package __init__."""
@@ -103,3 +107,42 @@ def test_build_image_name_candidates(card: dict[str, Any], meta: Any, expected: 
     """_build_image_name_candidates must return the correct candidate list for each input."""
     result = CardBoxPanel._build_image_name_candidates(None, card, meta)
     assert result == expected
+
+
+def test_image_load_worker_skips_ui_callback_after_worker_shutdown(monkeypatch) -> None:
+    """Late image lookups must not queue wx callbacks after panel teardown."""
+    panel = CardBoxPanel.__new__(CardBoxPanel)
+    panel._image_worker = BackgroundWorker()
+    panel._image_worker.shutdown(timeout=0.1)
+    callbacks: list[tuple[int, object]] = []
+    panel._on_image_load_done = lambda gen, image: callbacks.append((gen, image))
+
+    monkeypatch.setattr(_cbp_mod, "get_card_image", lambda *_args, **_kwargs: None)
+
+    CardBoxPanel._image_load_worker(panel, 7, ["Island"])
+
+    assert callbacks == []
+
+
+def test_on_destroy_stops_image_worker_without_waiting() -> None:
+    panel = CardBoxPanel.__new__(CardBoxPanel)
+    shutdown_calls: list[float] = []
+    panel._image_worker = type(
+        "Worker",
+        (),
+        {"shutdown": lambda self, timeout=10.0: shutdown_calls.append(timeout)},
+    )()
+    skipped = []
+    event = type(
+        "Event",
+        (),
+        {
+            "GetEventObject": lambda self: panel,
+            "Skip": lambda self: skipped.append(True),
+        },
+    )()
+
+    CardBoxPanel._on_destroy(panel, event)
+
+    assert shutdown_calls == [0.0]
+    assert skipped == [True]

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -59,6 +59,68 @@ def test_is_loading_when_loading():
     assert service.is_loading() is True
 
 
+class _InlineWorker:
+    def __init__(self):
+        self.submit_names: list[str | None] = []
+        self.call_after_calls: list[tuple[object, tuple[object, ...]]] = []
+
+    def submit(self, target, *args, name=None, **kwargs):  # noqa: ANN001
+        self.submit_names.append(name)
+        target(*args, **kwargs)
+        return None
+
+    def call_after(self, callback, *args, **_kwargs) -> bool:  # noqa: ANN001
+        self.call_after_calls.append((callback, args))
+        callback(*args)
+        return True
+
+    def shutdown(self, timeout: float = 10.0) -> None:
+        pass
+
+
+class _FakePrintingsDownloader:
+    def fetch_printings_by_name(self, card_name: str):
+        return [
+            {
+                "id": f"{card_name}-id",
+                "set": "abc",
+                "set_name": "Alpha Beta",
+                "collector_number": "42",
+                "released_at": "2024-01-01",
+            }
+        ]
+
+
+def test_fetch_printings_by_name_async_uses_background_worker() -> None:
+    service = ImageService()
+    worker = _InlineWorker()
+    service._worker = worker
+    service.image_downloader = _FakePrintingsDownloader()
+    loaded = []
+    service.set_printings_loaded_callback(lambda name, printings: loaded.append((name, printings)))
+
+    try:
+        service.fetch_printings_by_name_async("Island")
+    finally:
+        service.shutdown()
+
+    assert worker.submit_names == ["image-service-printings"]
+    assert loaded == [
+        (
+            "Island",
+            [
+                {
+                    "id": "Island-id",
+                    "set": "ABC",
+                    "set_name": "Alpha Beta",
+                    "collector_number": "42",
+                    "released_at": "2024-01-01",
+                }
+            ],
+        )
+    ]
+
+
 class _FakeCache:
     def get_image_path_for_printing(self, card_name, set_code, size):
         return None

--- a/tests/test_radar_dialog_lifecycle.py
+++ b/tests/test_radar_dialog_lifecycle.py
@@ -1,0 +1,75 @@
+"""Headless lifecycle tests for radar dialog background work."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("wx")
+
+import widgets.panels.radar_panel as radar_panel
+
+RadarDialog = radar_panel.RadarDialog
+
+
+class _AliveThread:
+    def is_alive(self) -> bool:
+        return True
+
+
+class _StoppedThread:
+    def is_alive(self) -> bool:
+        return False
+
+
+class _FakeWorker:
+    def __init__(self) -> None:
+        self.shutdown_calls: list[float] = []
+
+    def shutdown(self, timeout: float = 10.0) -> None:
+        self.shutdown_calls.append(timeout)
+
+
+def _make_dialog(worker_thread) -> RadarDialog:  # noqa: ANN001
+    dialog = RadarDialog.__new__(RadarDialog)
+    dialog.worker_thread = worker_thread
+    dialog._worker = _FakeWorker()
+    dialog.cancel_requested = False
+    dialog.IsModal = MagicMock(return_value=False)
+    dialog.EndModal = MagicMock()
+    dialog.Close = MagicMock()
+    return dialog
+
+
+def test_close_button_cancels_pending_radar_worker(monkeypatch) -> None:
+    dialog = _make_dialog(_AliveThread())
+    event = MagicMock()
+
+    monkeypatch.setattr(radar_panel.wx, "MessageBox", lambda *_args, **_kwargs: radar_panel.wx.YES)
+
+    RadarDialog._on_close(dialog, event)
+
+    assert dialog.cancel_requested is True
+    assert dialog.worker_thread is None
+    assert dialog._worker.shutdown_calls == [2.0]
+    dialog.Close.assert_called_once_with()
+    event.Skip.assert_not_called()
+
+
+def test_close_event_skips_instead_of_reclosing(monkeypatch) -> None:
+    dialog = _make_dialog(_StoppedThread())
+    skipped = []
+
+    class CloseEvent:
+        def Skip(self) -> None:
+            skipped.append(True)
+
+    monkeypatch.setattr(radar_panel.wx, "CloseEvent", CloseEvent)
+    event = CloseEvent()
+
+    RadarDialog._on_close(dialog, event)
+
+    assert dialog._worker.shutdown_calls == [0.2]
+    assert skipped == [True]
+    dialog.Close.assert_not_called()

--- a/tests/test_timer_alert_async.py
+++ b/tests/test_timer_alert_async.py
@@ -4,9 +4,44 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
+pytest.importorskip("wx")
+
 import widgets.timer_alert as timer_alert
 
 TimerAlertFrame = timer_alert.TimerAlertFrame
+
+
+class _FakeThread:
+    def __init__(self, target, args: tuple[object, ...]) -> None:
+        self.target = target
+        self.args = args
+        self.daemon = True
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+
+class _FakeWorker:
+    def __init__(self) -> None:
+        self.threads: list[_FakeThread] = []
+        self.call_after_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+        self.shutdown_calls: list[float] = []
+
+    def submit(self, target, *args, name: str | None = None):  # noqa: ARG002, ANN001
+        thread = _FakeThread(target, args)
+        self.threads.append(thread)
+        thread.start()
+        return thread
+
+    def call_after(self, func, *args, **kwargs) -> bool:  # noqa: ANN001
+        self.call_after_calls.append((func, args, kwargs))
+        return True
+
+    def shutdown(self, timeout: float = 10.0) -> None:
+        self.shutdown_calls.append(timeout)
 
 
 def _make_frame() -> TimerAlertFrame:
@@ -16,6 +51,7 @@ def _make_frame() -> TimerAlertFrame:
     frame._watcher = None
     frame._watch_start_pending = False
     frame._closed = False
+    frame._worker = _FakeWorker()
     frame._watch_timer = MagicMock()
     frame._monitor_timer = MagicMock()
     frame._repeat_timer = MagicMock()
@@ -27,44 +63,25 @@ def test_start_watch_loop_runs_bridge_start_in_background(monkeypatch) -> None:
     frame = _make_frame()
     watcher = MagicMock()
     start_watch_calls: list[int] = []
-    call_after_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
-    threads: list[object] = []
 
     def fake_start_watch(*, interval_ms: int):
         start_watch_calls.append(interval_ms)
         return watcher
 
-    class FakeThread:
-        def __init__(self, *, target, daemon: bool, args: tuple[object, ...] = ()) -> None:
-            self.target = target
-            self.args = args
-            self.daemon = daemon
-            self.started = False
-            threads.append(self)
-
-        def start(self) -> None:
-            self.started = True
-
     monkeypatch.setattr(timer_alert.mtgo_bridge, "start_watch", fake_start_watch)
-    monkeypatch.setattr(
-        timer_alert.wx,
-        "CallAfter",
-        lambda func, *args, **kwargs: call_after_calls.append((func, args, kwargs)),
-    )
-    monkeypatch.setattr(timer_alert.threading, "Thread", FakeThread)
 
     TimerAlertFrame._start_watch_loop(frame)
 
     assert frame._watch_start_pending is True
     assert start_watch_calls == []
-    assert len(threads) == 1
-    assert threads[0].started is True
-    assert threads[0].daemon is True
+    assert len(frame._worker.threads) == 1
+    assert frame._worker.threads[0].started is True
+    assert frame._worker.threads[0].daemon is True
 
-    threads[0].target(*threads[0].args)
+    frame._worker.threads[0].target(*frame._worker.threads[0].args)
 
     assert start_watch_calls == [frame.WATCH_INTERVAL_MS]
-    assert call_after_calls == [(frame._complete_watch_start, (watcher,), {})]
+    assert frame._worker.call_after_calls == [(frame._complete_watch_start, (watcher,), {})]
 
 
 def test_on_close_stops_existing_watcher_in_background(monkeypatch) -> None:
@@ -74,20 +91,6 @@ def test_on_close_stops_existing_watcher_in_background(monkeypatch) -> None:
     frame._watch_timer.IsRunning.return_value = True
     frame._monitor_timer.IsRunning.return_value = True
     frame._repeat_timer.IsRunning.return_value = True
-    threads: list[object] = []
-
-    class FakeThread:
-        def __init__(self, *, target, daemon: bool, args: tuple[object, ...] = ()) -> None:
-            self.target = target
-            self.args = args
-            self.daemon = daemon
-            self.started = False
-            threads.append(self)
-
-        def start(self) -> None:
-            self.started = True
-
-    monkeypatch.setattr(timer_alert.threading, "Thread", FakeThread)
     event = MagicMock()
 
     TimerAlertFrame.on_close(frame, event)
@@ -98,11 +101,12 @@ def test_on_close_stops_existing_watcher_in_background(monkeypatch) -> None:
     frame._monitor_timer.Stop.assert_called_once_with()
     frame._repeat_timer.Stop.assert_called_once_with()
     watcher.stop.assert_not_called()
-    assert len(threads) == 1
-    assert threads[0].started is True
-    assert threads[0].daemon is True
+    assert len(frame._worker.threads) == 1
+    assert frame._worker.threads[0].started is True
+    assert frame._worker.threads[0].daemon is True
+    assert frame._worker.shutdown_calls == [2.0]
 
-    threads[0].target(*threads[0].args)
+    frame._worker.threads[0].target(*frame._worker.threads[0].args)
 
     watcher.stop.assert_called_once_with()
     event.Skip.assert_called_once_with()

--- a/utils/background_worker.py
+++ b/utils/background_worker.py
@@ -15,10 +15,12 @@ class BackgroundWorker:
     Run blocking work in threads and marshal callbacks onto the UI thread.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, thread_name_prefix: str = "background-worker") -> None:
         self._stop_event = threading.Event()
         self._threads: list[threading.Thread] = []
         self._lock = threading.Lock()
+        self._thread_name_prefix = thread_name_prefix
+        self._thread_counter = 0
 
     def submit(
         self,
@@ -26,38 +28,86 @@ class BackgroundWorker:
         *args: Any,
         on_success: Callable[[Any], None] | None = None,
         on_error: Callable[[Exception], None] | None = None,
+        name: str | None = None,
         **kwargs: Any,
-    ) -> None:
+    ) -> threading.Thread | None:
         """Submit a task to run in a background thread.
 
         For long-running tasks, the function should periodically check self.is_stopped() and exit when True.
         """
+        if self.is_stopped():
+            logger.debug(f"Background worker stopped; ignoring task: {func.__name__}")
+            return None
 
-        def wrapper():
+        def wrapper() -> None:
             try:
                 result = func(*args, **kwargs)
             except Exception as exc:
                 logger.exception(f"Background task failed: {exc}")
                 if on_error:
-                    self._call_after(on_error, exc)
-                return
+                    self.call_after(on_error, exc)
+            else:
+                if on_success:
+                    self.call_after(on_success, result)
+            finally:
+                self._remove_thread(threading.current_thread())
 
-            if on_success:
-                self._call_after(on_success, result)
-
-        thread = threading.Thread(target=wrapper, daemon=True)
+        thread = threading.Thread(target=wrapper, daemon=True, name=self._next_thread_name(name))
         with self._lock:
             self._threads.append(thread)
         thread.start()
-        logger.debug(f"Started background thread: {func.__name__}")
+        logger.debug(f"Started background thread: {thread.name}")
+        return thread
 
-    def _call_after(self, callback: Callable, *args: Any) -> None:
+    def call_after(self, callback: Callable[..., Any], *args: Any, **kwargs: Any) -> bool:
+        """Schedule a UI callback if the worker and wx app are still alive."""
+        if self.is_stopped():
+            return False
         try:
             import wx
-
-            wx.CallAfter(callback, *args)
         except ImportError:
-            callback(*args)
+            callback(*args, **kwargs)
+            return True
+
+        if not self._wx_app_available(wx):
+            logger.debug("Skipping wx.CallAfter because the wx app is not available")
+            return False
+
+        try:
+            wx.CallAfter(callback, *args, **kwargs)
+        except RuntimeError as exc:
+            logger.debug(f"Skipping wx.CallAfter after wx teardown: {exc}")
+            return False
+        return True
+
+    @staticmethod
+    def _wx_app_available(wx_module: Any) -> bool:
+        get_app = getattr(wx_module, "GetApp", None)
+        if get_app is None:
+            return True
+        try:
+            app = get_app()
+        except (RuntimeError, SystemError):
+            return False
+        if app is None:
+            return False
+        try:
+            return bool(app)
+        except (RuntimeError, SystemError):
+            return False
+
+    def _next_thread_name(self, name: str | None) -> str:
+        if name:
+            return name
+        with self._lock:
+            self._thread_counter += 1
+            counter = self._thread_counter
+        return f"{self._thread_name_prefix}-{counter}"
+
+    def _remove_thread(self, thread: threading.Thread) -> None:
+        with self._lock:
+            if thread in self._threads:
+                self._threads.remove(thread)
 
     def is_stopped(self) -> bool:
         return self._stop_event.is_set()
@@ -69,7 +119,10 @@ class BackgroundWorker:
         with self._lock:
             threads = list(self._threads)
 
+        current_thread = threading.current_thread()
         for thread in threads:
+            if thread is current_thread:
+                continue
             if thread.is_alive():
                 logger.debug(f"Waiting for thread {thread.name} to finish...")
                 thread.join(timeout=timeout)

--- a/widgets/dialogs/feedback_dialog.py
+++ b/widgets/dialogs/feedback_dialog.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import threading
 from collections.abc import Callable
 from pathlib import Path
 
 import wx
 from loguru import logger
 
+from utils.background_worker import BackgroundWorker
 from utils.constants import DARK_BG, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
 from utils.diagnostics import export_diagnostics_bundle
 
@@ -31,8 +31,10 @@ class FeedbackDialog(wx.Dialog):
 
         self._logs_dir = logs_dir
         self._event_logging_enabled = event_logging_enabled
+        self._worker = BackgroundWorker(thread_name_prefix="feedback-export")
 
         self._build_ui()
+        self.Bind(wx.EVT_CLOSE, self._on_close)
         self.Centre()
 
     # ------------------------------------------------------------------
@@ -145,24 +147,31 @@ class FeedbackDialog(wx.Dialog):
         self._export_btn.Disable()
         self._status_label.SetLabel("Exporting…")
 
-        def _worker() -> None:
-            try:
-                out = export_diagnostics_bundle(
-                    dest,
-                    logs_dir=self._logs_dir,
-                    notes=notes,
-                    include_events=include_events,
-                )
-                wx.CallAfter(self._on_export_done, out, None)
-            except Exception as exc:
-                logger.exception("Failed to export diagnostics bundle")
-                wx.CallAfter(self._on_export_done, None, exc)
+        def _worker() -> Path:
+            return export_diagnostics_bundle(
+                dest,
+                logs_dir=self._logs_dir,
+                notes=notes,
+                include_events=include_events,
+            )
 
-        threading.Thread(target=_worker, daemon=True).start()
+        def _on_error(exc: Exception) -> None:
+            logger.error(f"Failed to export diagnostics bundle: {exc}")
+            self._on_export_done(None, exc)
+
+        self._worker.submit(
+            _worker,
+            on_success=lambda out: self._on_export_done(out, None),
+            on_error=_on_error,
+            name="feedback-export",
+        )
 
     def _on_export_done(self, out: Path | None, exc: Exception | None) -> None:
-        self._status_label.SetLabel("")
-        self._export_btn.Enable()
+        try:
+            self._status_label.SetLabel("")
+            self._export_btn.Enable()
+        except RuntimeError:
+            return
         if exc is not None:
             wx.MessageBox(
                 f"Export failed: {exc}",
@@ -175,6 +184,10 @@ class FeedbackDialog(wx.Dialog):
                 "Export complete",
                 wx.OK | wx.ICON_INFORMATION,
             )
+
+    def _on_close(self, event: wx.CloseEvent) -> None:
+        self._worker.shutdown(timeout=0.2)
+        event.Skip()
 
 
 def _timestamp() -> str:

--- a/widgets/identify_opponent.py
+++ b/widgets/identify_opponent.py
@@ -642,23 +642,29 @@ class MTGOpponentDeckSpy(wx.Frame):
 
         if not archetype_dict:
             logger.warning(f"Could not resolve archetype: {archetype_name} in {format_name}")
-            wx.CallAfter(self.radar_panel.set_error, f"Archetype '{archetype_name}' not found")
+            self._bg_worker.call_after(
+                self.radar_panel.set_error,
+                f"Archetype '{archetype_name}' not found",
+            )
             return
 
         # Update tracking
         self._last_radar_archetype = archetype_name
 
         # Show loading state
-        wx.CallAfter(self.radar_panel.set_loading, f"Loading radar for {archetype_name}...")
-
-        # Start background thread to generate radar
-        self._radar_cancel_requested = False
-        self._radar_worker_thread = threading.Thread(
-            target=self._generate_radar_worker,
-            args=(archetype_dict, format_name),
-            daemon=True,
+        self._bg_worker.call_after(
+            self.radar_panel.set_loading,
+            f"Loading radar for {archetype_name}...",
         )
-        self._radar_worker_thread.start()
+
+        # Start background task to generate radar
+        self._radar_cancel_requested = False
+        self._radar_worker_thread = self._bg_worker.submit(
+            self._generate_radar_worker,
+            archetype_dict,
+            format_name,
+            name="opponent-radar-generate",
+        )
         logger.info(f"Started radar generation for {archetype_name} ({format_name})")
 
     def _generate_radar_worker(self, archetype_dict: dict[str, Any], format_name: str) -> None:
@@ -669,7 +675,7 @@ class MTGOpponentDeckSpy(wx.Frame):
                     raise InterruptedError("Radar generation cancelled")
 
                 # Update status label with progress
-                wx.CallAfter(
+                self._bg_worker.call_after(
                     self.radar_panel.set_loading,
                     f"Analyzing deck {current}/{total}...",
                 )
@@ -684,17 +690,17 @@ class MTGOpponentDeckSpy(wx.Frame):
 
             # Display results on UI thread
             if not self._radar_cancel_requested:
-                wx.CallAfter(self._display_radar, radar)
+                self._bg_worker.call_after(self._display_radar, radar)
 
         except InterruptedError:
             # User cancelled or switched opponents
             logger.info("Radar generation cancelled")
-            wx.CallAfter(self.radar_panel.clear)
+            self._bg_worker.call_after(self.radar_panel.clear)
 
         except Exception as exc:
             # Error occurred
             logger.exception(f"Failed to generate radar: {exc}")
-            wx.CallAfter(self.radar_panel.set_error, "Failed to load radar")
+            self._bg_worker.call_after(self.radar_panel.set_error, "Failed to load radar")
 
         finally:
             # Reset worker thread reference
@@ -1007,14 +1013,12 @@ class MTGOpponentDeckSpy(wx.Frame):
         # Cancel any running radar worker
         if self._radar_worker_thread and self._radar_worker_thread.is_alive():
             self._radar_cancel_requested = True
-            # Give it a moment to clean up
-            self._radar_worker_thread.join(
-                timeout=OPPONENT_TRACKER_RADAR_THREAD_JOIN_TIMEOUT_SECONDS
-            )
 
         if self._poll_timer.IsRunning():
             self._poll_timer.Stop()
-        self._bg_worker.shutdown(timeout=5.0)
+        self._bg_worker.shutdown(
+            timeout=max(5.0, OPPONENT_TRACKER_RADAR_THREAD_JOIN_TIMEOUT_SECONDS)
+        )
         event.Skip()
 
 

--- a/widgets/panels/card_box_panel.py
+++ b/widgets/panels/card_box_panel.py
@@ -1,10 +1,10 @@
 from collections.abc import Callable
-from threading import Thread
 from typing import Any
 
 import wx
 from PIL import Image as PilImage
 
+from utils.background_worker import BackgroundWorker
 from utils.card_images import get_card_image
 from utils.constants import (
     DARK_ACCENT,
@@ -64,12 +64,14 @@ class CardBoxPanel(wx.Panel):
         self._image_attempted = False
         self._image_generation: int = 0
         self._image_name_candidates: list[str] = []
+        self._image_worker = BackgroundWorker(thread_name_prefix="card-box-image")
 
         self.SetBackgroundColour(DARK_ALT)
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
         self.SetMinSize((DECK_CARD_WIDTH, DECK_CARD_HEIGHT))
         self.SetMaxSize((DECK_CARD_WIDTH, DECK_CARD_HEIGHT))
         self.Bind(wx.EVT_PAINT, self._on_paint)
+        self.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
 
         layout = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(layout)
@@ -157,13 +159,18 @@ class CardBoxPanel(wx.Panel):
 
         Safe to call simultaneously on many panels — all I/O happens in parallel
         daemon threads and results are posted back to the main thread via
-        wx.CallAfter, so the UI is never blocked.
+        BackgroundWorker.call_after, so the UI is never blocked after teardown.
         """
         self._image_generation += 1
         gen = self._image_generation
         self._image_attempted = True
         candidates = list(self._image_name_candidates)
-        Thread(target=self._image_load_worker, args=(gen, candidates), daemon=True).start()
+        self._image_worker.submit(
+            self._image_load_worker,
+            gen,
+            candidates,
+            name="card-box-image-load",
+        )
 
     def _image_load_worker(self, gen: int, candidates: list[str]) -> None:
         image_path = None
@@ -173,7 +180,7 @@ class CardBoxPanel(wx.Panel):
                 image_path = path
                 break
         if not image_path:
-            wx.CallAfter(self._on_image_load_done, gen, None)
+            self._image_worker.call_after(self._on_image_load_done, gen, None)
             return
         try:
             pil_img = PilImage.open(str(image_path)).convert("RGB")
@@ -182,9 +189,9 @@ class CardBoxPanel(wx.Panel):
             new_w = max(1, int(w * scale))
             new_h = max(1, int(h * scale))
             pil_img = pil_img.resize((new_w, new_h), PilImage.LANCZOS)
-            wx.CallAfter(self._on_image_load_done, gen, pil_img)
+            self._image_worker.call_after(self._on_image_load_done, gen, pil_img)
         except Exception:
-            wx.CallAfter(self._on_image_load_done, gen, None)
+            self._image_worker.call_after(self._on_image_load_done, gen, None)
 
     def _on_image_load_done(self, gen: int, pil_img: "PilImage.Image | None") -> None:
         try:
@@ -204,6 +211,11 @@ class CardBoxPanel(wx.Panel):
             self._card_bitmap = self._render_bitmap_with_image(wx_img)
             self._image_available = True
         self.Refresh()
+
+    def _on_destroy(self, event: wx.Event) -> None:
+        if event.GetEventObject() is self:
+            self._image_worker.shutdown(timeout=0.0)
+        event.Skip()
 
     def set_active(self, active: bool) -> None:
         if self._active == active:

--- a/widgets/panels/card_inspector_panel.py
+++ b/widgets/panels/card_inspector_panel.py
@@ -247,7 +247,7 @@ class CardInspectorPanel(wx.Panel):
         self.name_label.SetLabel(header)
 
         # Get or use metadata
-        if meta is None and self.card_manager:
+        if meta is None and self.card_manager and self.card_manager.is_loaded:
             meta = self.card_manager.get_card(card["name"]) or {}
         else:
             meta = meta or {}

--- a/widgets/panels/card_inspector_panel.py
+++ b/widgets/panels/card_inspector_panel.py
@@ -6,12 +6,12 @@ Shows card image, metadata, oracle text, and allows navigation through different
 
 from collections.abc import Callable
 from pathlib import Path
-from threading import Thread
 from typing import Any
 
 import wx
 from loguru import logger
 
+from utils.background_worker import BackgroundWorker
 from utils.card_data import CardDataManager
 from utils.card_images import BULK_DATA_CACHE, CardImageRequest, get_cache, get_card_image
 from utils.constants import (
@@ -68,8 +68,10 @@ class CardInspectorPanel(wx.Panel):
         self._failed_image_requests: set[tuple[str, str]] = set()
         self._image_request_name: str | None = None
         self._image_lookup_gen: int = 0
+        self._image_worker = BackgroundWorker(thread_name_prefix="card-inspector-image")
 
         self._build_ui()
+        self.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
         self.reset()
 
     def _build_ui(self) -> None:
@@ -402,7 +404,13 @@ class CardInspectorPanel(wx.Panel):
                 path = get_card_image(card_name, "normal") if card_name else None
                 if not path and image_request_name:
                     path = get_card_image(image_request_name, "normal")
-                wx.CallAfter(self._apply_no_printings_image, gen, card_name, active_request, path)
+                self._image_worker.call_after(
+                    self._apply_no_printings_image,
+                    gen,
+                    card_name,
+                    active_request,
+                    path,
+                )
             else:
                 uuid = active_request.uuid if active_request else None
                 image_paths = image_cache.get_image_paths_by_uuid(uuid, "normal") if uuid else []
@@ -416,7 +424,7 @@ class CardInspectorPanel(wx.Panel):
                     and image_request_name is not None
                     and "//" in image_request_name
                 )
-                wx.CallAfter(
+                self._image_worker.call_after(
                     self._apply_printings_image,
                     gen,
                     printings,
@@ -427,7 +435,12 @@ class CardInspectorPanel(wx.Panel):
                     need_double_face,
                 )
 
-        Thread(target=_lookup, daemon=True).start()
+        self._image_worker.submit(_lookup, name="card-inspector-image-lookup")
+
+    def _on_destroy(self, event: wx.Event) -> None:
+        if event.GetEventObject() is self:
+            self._image_worker.shutdown(timeout=0.0)
+        event.Skip()
 
     def _apply_no_printings_image(
         self,

--- a/widgets/panels/radar_panel.py
+++ b/widgets/panels/radar_panel.py
@@ -17,6 +17,7 @@ from loguru import logger
 
 from services.radar_service import CardFrequency, RadarData, RadarService, get_radar_service
 from utils.atomic_io import atomic_write_text
+from utils.background_worker import BackgroundWorker
 from utils.constants import DARK_ALT, DARK_PANEL, LIGHT_TEXT
 from utils.i18n import translate
 
@@ -267,8 +268,10 @@ class RadarDialog(wx.Dialog):
         self.archetypes: list[dict[str, Any]] = []
         self.current_radar: RadarData | None = None
         self.worker_thread: threading.Thread | None = None
+        self._worker = BackgroundWorker(thread_name_prefix="radar-dialog")
         self.cancel_requested = False
 
+        self.Bind(wx.EVT_CLOSE, self._on_close)
         self._build_ui()
         self._load_archetypes()
 
@@ -353,17 +356,16 @@ class RadarDialog(wx.Dialog):
         self.cancel_requested = False
 
         # Start worker thread
-        self.worker_thread = threading.Thread(
-            target=self._generate_radar_worker,
-            args=(archetype,),
-            daemon=True,
+        self.worker_thread = self._worker.submit(
+            self._generate_radar_worker,
+            archetype,
+            name="radar-dialog-generate",
         )
-        self.worker_thread.start()
 
     def _on_cancel_clicked(self, event: wx.Event) -> None:
         self.cancel_requested = True
-        wx.CallAfter(self.progress_label.SetLabel, "Cancelling...")
-        wx.CallAfter(self.cancel_btn.Enable, False)
+        self._worker.call_after(self.progress_label.SetLabel, "Cancelling...")
+        self._worker.call_after(self.cancel_btn.Enable, False)
 
     def _generate_radar_worker(self, archetype: dict[str, Any]) -> None:
         try:
@@ -373,8 +375,8 @@ class RadarDialog(wx.Dialog):
                     raise InterruptedError("Radar generation cancelled by user")
 
                 percent = int((current / total) * 100) if total > 0 else 0
-                wx.CallAfter(self.progress.SetValue, percent)
-                wx.CallAfter(
+                self._worker.call_after(self.progress.SetValue, percent)
+                self._worker.call_after(
                     self.progress_label.SetLabel,
                     f"Analyzing deck {current}/{total}: {deck_name}",
                 )
@@ -388,29 +390,35 @@ class RadarDialog(wx.Dialog):
 
             # Display results on UI thread
             if not self.cancel_requested:
-                wx.CallAfter(self.radar_panel.display_radar, radar)
-                wx.CallAfter(self.progress_label.SetLabel, "Radar generated successfully!")
-                self.current_radar = radar
+                self._worker.call_after(self._display_generated_radar, radar)
+                self._worker.call_after(
+                    self.progress_label.SetLabel,
+                    "Radar generated successfully!",
+                )
 
         except InterruptedError as exc:
             # User cancelled
-            wx.CallAfter(self.progress_label.SetLabel, f"Cancelled: {exc}")
-            wx.CallAfter(self.progress.SetValue, 0)
+            self._worker.call_after(self.progress_label.SetLabel, f"Cancelled: {exc}")
+            self._worker.call_after(self.progress.SetValue, 0)
 
         except Exception as exc:
             # Error occurred
             logger.exception(f"Failed to generate radar: {exc}")
-            wx.CallAfter(self.progress_label.SetLabel, "Failed to generate radar.")
-            wx.CallAfter(self.progress.SetValue, 0)
+            self._worker.call_after(self.progress_label.SetLabel, "Failed to generate radar.")
+            self._worker.call_after(self.progress.SetValue, 0)
 
         finally:
             # Re-enable UI controls
-            wx.CallAfter(self.generate_btn.Enable, True)
-            wx.CallAfter(self.cancel_btn.Enable, False)
-            wx.CallAfter(self.archetype_choice.Enable, True)
+            self._worker.call_after(self.generate_btn.Enable, True)
+            self._worker.call_after(self.cancel_btn.Enable, False)
+            self._worker.call_after(self.archetype_choice.Enable, True)
             if not self.cancel_requested:
-                wx.CallAfter(self.progress.SetValue, 0)
+                self._worker.call_after(self.progress.SetValue, 0)
             self.worker_thread = None
+
+    def _display_generated_radar(self, radar: RadarData) -> None:
+        self.current_radar = radar
+        self.radar_panel.display_radar(radar)
 
     def _export_radar(self, radar: RadarData) -> None:
         # Ask for minimum expected copies threshold
@@ -461,6 +469,7 @@ class RadarDialog(wx.Dialog):
         return self.current_radar
 
     def _on_close(self, event: wx.Event) -> None:
+        is_close_event = isinstance(event, wx.CloseEvent)
         # If worker is running, request cancellation
         if self.worker_thread and self.worker_thread.is_alive():
             response = wx.MessageBox(
@@ -473,11 +482,14 @@ class RadarDialog(wx.Dialog):
 
             # Cancel the worker
             self.cancel_requested = True
-            # Give it a moment to clean up
-            if self.worker_thread:
-                self.worker_thread.join(timeout=2.0)
+            self._worker.shutdown(timeout=2.0)
+            self.worker_thread = None
+        else:
+            self._worker.shutdown(timeout=0.2)
 
         if self.IsModal():
             self.EndModal(wx.ID_OK)
+        elif is_close_event:
+            event.Skip()
         else:
             self.Close()

--- a/widgets/timer_alert.py
+++ b/widgets/timer_alert.py
@@ -10,13 +10,13 @@ if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
 import re
-import threading
 from typing import Any
 
 import wx
 from loguru import logger
 
 from utils import mtgo_bridge
+from utils.background_worker import BackgroundWorker
 from utils.constants import (
     DARK_ACCENT,
     DARK_ALT,
@@ -137,6 +137,7 @@ class TimerAlertFrame(wx.Frame):
         self._watcher: BridgeWatcher | None = None
         self._watch_start_pending = False
         self._closed = False
+        self._worker = BackgroundWorker(thread_name_prefix="timer-alert")
         self._watch_timer = wx.Timer(self)
         self._monitor_timer = wx.Timer(self)
         self._repeat_timer = wx.Timer(self)
@@ -495,7 +496,7 @@ class TimerAlertFrame(wx.Frame):
         if self._closed or self._watcher or self._watch_start_pending:
             return
         self._watch_start_pending = True
-        threading.Thread(target=self._watch_start_worker, daemon=True).start()
+        self._worker.submit(self._watch_start_worker, name="timer-watch-start")
 
     def _watch_start_worker(self) -> None:
         try:
@@ -503,18 +504,26 @@ class TimerAlertFrame(wx.Frame):
         except FileNotFoundError as exc:
             logger.error("Bridge executable not found: {}", exc)
             if not self._closed:
-                wx.CallAfter(self._handle_watch_start_failure, "timer.status.bridge_missing", exc)
+                self._worker.call_after(
+                    self._handle_watch_start_failure,
+                    "timer.status.bridge_missing",
+                    exc,
+                )
             return
         except Exception as exc:  # noqa: BLE001
             logger.exception("Unable to start bridge watcher")
             if not self._closed:
-                wx.CallAfter(self._handle_watch_start_failure, "timer.status.bridge_error", exc)
+                self._worker.call_after(
+                    self._handle_watch_start_failure,
+                    "timer.status.bridge_error",
+                    exc,
+                )
             return
 
         if self._closed:
             self._stop_watcher_worker(watcher)
             return
-        wx.CallAfter(self._complete_watch_start, watcher)
+        self._worker.call_after(self._complete_watch_start, watcher)
 
     def _handle_watch_start_failure(self, status_key: str, error: Exception) -> None:
         self._watch_start_pending = False
@@ -543,11 +552,11 @@ class TimerAlertFrame(wx.Frame):
             self._watcher = None
         if watcher_to_stop is None:
             return
-        threading.Thread(
-            target=self._stop_watcher_worker,
-            args=(watcher_to_stop,),
-            daemon=True,
-        ).start()
+        self._worker.submit(
+            self._stop_watcher_worker,
+            watcher_to_stop,
+            name="timer-watch-stop",
+        )
 
     def _stop_watcher_worker(self, watcher: BridgeWatcher) -> None:
         try:
@@ -617,6 +626,7 @@ class TimerAlertFrame(wx.Frame):
         if self._repeat_timer.IsRunning():
             self._repeat_timer.Stop()
         self._stop_watcher_async()
+        self._worker.shutdown(timeout=2.0)
         event.Skip()
 
 


### PR DESCRIPTION
## Summary
- Extend BackgroundWorker with named submissions, tracked thread return values, and guarded call_after scheduling that skips callbacks after worker shutdown or wx.App teardown.
- Route timer, radar, image-service/card-image, and feedback export background flows through BackgroundWorker instead of ad hoc raw threads plus wx.CallAfter.
- Add lifecycle-focused coverage for guarded callbacks, image lookup shutdown, image-service printings fetch, timer watcher close, and radar dialog close behavior.

## Verification
- python3 -m ruff check utils/background_worker.py services/image_service.py widgets/timer_alert.py widgets/panels/radar_panel.py widgets/panels/card_box_panel.py widgets/panels/card_inspector_panel.py widgets/dialogs/feedback_dialog.py widgets/identify_opponent.py tests/test_background_worker.py tests/test_timer_alert_async.py tests/test_card_box_panel_logic.py tests/test_image_service.py tests/test_radar_dialog_lifecycle.py
- python3 -m py_compile utils/background_worker.py services/image_service.py widgets/timer_alert.py widgets/panels/radar_panel.py widgets/panels/card_box_panel.py widgets/panels/card_inspector_panel.py widgets/dialogs/feedback_dialog.py widgets/identify_opponent.py tests/test_background_worker.py tests/test_timer_alert_async.py tests/test_card_box_panel_logic.py tests/test_image_service.py tests/test_radar_dialog_lifecycle.py
- python3 -m pytest tests/test_background_worker.py tests/test_timer_alert_async.py tests/test_card_box_panel_logic.py tests/test_image_service.py tests/test_radar_dialog_lifecycle.py (20 passed, 3 skipped because wx is unavailable in this Linux shell)

Closes #400