### PR TITLE
Skip tutorial on app start when --automation flag is set

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from loguru import logger
 from controllers.app_controller import get_deck_selector_controller
 from utils.constants import BASE_DATA_DIR, LOGS_DIR, ensure_base_dirs
 from utils.logging_config import configure_logging
+from utils.runtime_flags import set_automation_enabled
 from widgets.splash_frame import LoadingFrame
 
 # Global flag for automation mode
@@ -115,6 +116,7 @@ def main() -> None:
     args = parse_args()
     _automation_enabled = args.automation
     _automation_port = args.automation_port
+    set_automation_enabled(_automation_enabled)
 
     ensure_base_dirs()
     log_file = configure_logging(LOGS_DIR)

--- a/tests/test_runtime_flags.py
+++ b/tests/test_runtime_flags.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def runtime_flags():
+    module = importlib.import_module("utils.runtime_flags")
+    original = module.is_automation_enabled()
+    yield module
+    module.set_automation_enabled(original)
+
+
+def test_is_automation_enabled_defaults_to_false(runtime_flags):
+    runtime_flags.set_automation_enabled(False)
+    assert runtime_flags.is_automation_enabled() is False
+
+
+def test_set_automation_enabled_round_trips(runtime_flags):
+    runtime_flags.set_automation_enabled(True)
+    assert runtime_flags.is_automation_enabled() is True
+    runtime_flags.set_automation_enabled(False)
+    assert runtime_flags.is_automation_enabled() is False
+
+
+def test_set_automation_enabled_coerces_truthy_values(runtime_flags):
+    runtime_flags.set_automation_enabled(1)  # type: ignore[arg-type]
+    assert runtime_flags.is_automation_enabled() is True
+    runtime_flags.set_automation_enabled(0)  # type: ignore[arg-type]
+    assert runtime_flags.is_automation_enabled() is False
+
+
+_WX_AVAILABLE = importlib.util.find_spec("wx") is not None
+_requires_wx = pytest.mark.skipif(
+    not _WX_AVAILABLE or sys.platform != "win32",
+    reason="AppFrame tutorial-skip checks require wxPython (Windows-only)",
+)
+
+
+def _call_restore_session_state(is_automation: bool, tutorial_shown: bool):
+    """Invoke AppFrame._restore_session_state unbound with mocked collaborators."""
+    from widgets import app_frame as app_frame_module
+
+    frame = MagicMock()
+    frame.controller.zone_cards = {"main": [], "side": [], "out": []}
+    frame.controller.session_manager.restore_session_state.return_value = {
+        "left_mode": "research",
+    }
+    frame.controller.session_manager.is_tutorial_shown.return_value = tutorial_shown
+    frame.controller.card_repo.is_card_data_ready.return_value = True
+
+    with (
+        patch.object(app_frame_module, "is_automation_enabled", return_value=is_automation),
+        patch.object(app_frame_module, "wx") as wx_mock,
+    ):
+        app_frame_module.AppFrame._restore_session_state(frame)
+        return wx_mock, frame
+
+
+@_requires_wx
+def test_restore_session_state_schedules_tutorial_when_not_shown_and_not_automation():
+    wx_mock, frame = _call_restore_session_state(is_automation=False, tutorial_shown=False)
+    wx_mock.CallAfter.assert_called_once_with(frame._open_tutorial)
+
+
+@_requires_wx
+def test_restore_session_state_skips_tutorial_under_automation():
+    wx_mock, _frame = _call_restore_session_state(is_automation=True, tutorial_shown=False)
+    wx_mock.CallAfter.assert_not_called()
+
+
+@_requires_wx
+def test_restore_session_state_skips_tutorial_when_already_shown():
+    wx_mock, _frame = _call_restore_session_state(is_automation=False, tutorial_shown=True)
+    wx_mock.CallAfter.assert_not_called()

--- a/utils/runtime_flags.py
+++ b/utils/runtime_flags.py
@@ -1,0 +1,14 @@
+"""Process-wide runtime flags set during application startup."""
+
+from __future__ import annotations
+
+_automation_enabled: bool = False
+
+
+def set_automation_enabled(enabled: bool) -> None:
+    global _automation_enabled
+    _automation_enabled = bool(enabled)
+
+
+def is_automation_enabled() -> bool:
+    return _automation_enabled

--- a/widgets/app_frame.py
+++ b/widgets/app_frame.py
@@ -26,6 +26,7 @@ from utils.constants import (
 )
 from utils.i18n import LOCALE_LABELS, SUPPORTED_LOCALES, translate
 from utils.mana_icon_factory import ManaIconFactory
+from utils.runtime_flags import is_automation_enabled
 from widgets.buttons.toolbar_buttons import ToolbarButtons
 from widgets.dialogs.help_dialog import show_help
 from widgets.dialogs.image_download_dialog import show_image_download_dialog
@@ -622,7 +623,7 @@ class AppFrame(AppEventHandlers, SideboardGuideHandlers, CardTablePanelHandler, 
 
     def _restore_session_state(self) -> None:
         state = self.controller.session_manager.restore_session_state(self.controller.zone_cards)
-        if not self.controller.session_manager.is_tutorial_shown():
+        if not self.controller.session_manager.is_tutorial_shown() and not is_automation_enabled():
             wx.CallAfter(self._open_tutorial)
 
         # Restore left panel mode


### PR DESCRIPTION
## Summary
- Add `utils/runtime_flags.py` exposing `is_automation_enabled()` / `set_automation_enabled()` so non-entrypoint modules can query the automation mode chosen at launch time.
- Set the flag from `main()` right after argument parsing.
- Short-circuit the first-run tutorial in `AppFrame._restore_session_state` when automation is active — the modal `show_tutorial` dialog was blocking the wx main loop on headless/CLI-launched runs.
- Add unit tests covering the new helper and the three branches of the tutorial-scheduling logic.

Closes #409

## Test plan
- [ ] `python -m pytest tests/test_runtime_flags.py -v` (runtime-flag unit tests always run; AppFrame branch tests auto-skip without wxPython).
- [ ] Full remote pytest via `./run_pytest_on_host.sh -v`.
- [ ] Manual: launch via `python main.py --automation` with a fresh settings dir and confirm the tutorial dialog no longer appears; launch without `--automation` and confirm the tutorial still shows on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)