### PR TITLE
fix: headless screenshot when window is hidden (#415)

### DIFF
--- a/automation/server.py
+++ b/automation/server.py
@@ -194,8 +194,12 @@ class AutomationServer:
         """Take a screenshot of the application window.
 
         When *headless* is True the frame is temporarily restored if it is
-        iconized (minimized) so the capture works even when the window is not
-        visible on screen, then returned to its previous state afterward.
+        iconized (minimized) or hidden so the capture works even when the
+        window is not visible on screen, then returned to its previous state
+        afterward. Hidden windows are first minimized before the restore so
+        they take the same code path as minimized windows — Show() alone does
+        not paint the window reliably before capture, causing the screen DC
+        to grab whatever is in the foreground at the window's coordinates.
         """
         import os
         import tempfile
@@ -215,10 +219,13 @@ class AutomationServer:
         was_hidden = not self.frame.IsShown()
 
         if headless and (was_iconized or was_hidden):
-            if was_iconized:
-                self.frame.Iconize(False)
             if was_hidden:
+                # Convert hidden into minimized so we can use the known-working
+                # restore-from-minimized path below.
                 self.frame.Show()
+                self.frame.Iconize(True)
+                wx.SafeYield()
+            self.frame.Iconize(False)
             self.frame.Raise()
             wx.SafeYield()
 
@@ -235,7 +242,7 @@ class AutomationServer:
             mem_dc.SelectObject(wx.NullBitmap)
         finally:
             if headless:
-                if was_iconized:
+                if was_iconized or was_hidden:
                     self.frame.Iconize(True)
                 if was_hidden:
                     self.frame.Hide()


### PR DESCRIPTION
## Summary
- `screenshot --headless` was capturing the wrong content whenever the main window was hidden (not just minimized): the screen DC was grabbing whatever app was currently in the foreground at the window's coordinates.
- Root cause: `Show()` + `Raise()` + `SafeYield()` does not reliably paint a hidden window at its screen coordinates before the capture runs.
- Fix: for hidden windows, first `Show()` + `Iconize(True)` to convert into the minimized state, then reuse the existing restore-from-minimized path that already works. Previous hidden/minimized state is still restored afterward.

Fixes #415.

## Test plan
- [ ] Launch the app with `--automation`, hide the main frame, run `python -m automation.cli screenshot --headless --path out.png`, and verify the PNG shows the app's own window rather than the foreground app.
- [ ] Repeat with the app minimized — should continue to work as before.
- [ ] Repeat with the app in its normal visible state — should be unaffected.
- [ ] Confirm the window returns to its prior state (hidden / minimized / visible) after each capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)