### PR TITLE
fix: show oracle text when selecting card from deckbuilder search (#387)

### DIFF
--- a/widgets/handlers/app_event_handlers.py
+++ b/widgets/handlers/app_event_handlers.py
@@ -577,6 +577,7 @@ class AppEventHandlers:
         if idx is None:
             if self.card_inspector_panel.active_zone is None:
                 self.card_inspector_panel.reset()
+                self.oracle_text_ctrl.ChangeValue("")
             return
         meta = self.builder_panel.get_result_at_index(idx)
         if not meta:
@@ -584,6 +585,8 @@ class AppEventHandlers:
         self._clear_zone_selections()
         faux_card = {"name": meta.get("name", "Unknown"), "qty": 1}
         self.card_inspector_panel.update_card(faux_card, zone=None, meta=meta)
+        oracle_text = meta.get("oracle_text") if meta is not None else None
+        self.oracle_text_ctrl.ChangeValue(oracle_text or "")
 
     def _on_daily_average_success(self, deck_text: str) -> None:
         self.daily_average_button.Enable()


### PR DESCRIPTION
## Summary
- When a card was selected from a deckbuilder search result, the right-panel Oracle text control wasn't updated — so stale text (from a prior mainboard/deckboard selection) stayed on screen, or nothing appeared at all.
- `_on_builder_result_selected` now mirrors `_handle_card_focus`: it writes `meta.oracle_text` into `oracle_text_ctrl` on selection, and clears it on deselection (when the inspector is currently showing a builder result).

Fixes #387

## Test plan
- [ ] Launch app; in the deckbuilder panel, run a search and click a result → Oracle text panel shows that card's oracle text.
- [ ] With a builder result selected, click a card in mainboard/deckboard → Oracle text switches to the zone card (existing behavior preserved).
- [ ] With a builder result selected, deselect it (e.g., click empty area in results) → Oracle text panel clears.
- [ ] Select a mainboard card; Oracle text shows correctly (regression check — unchanged path).