### PR TITLE
fix: share cache across WSL-made worktrees instead of redownloading

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 import utils.constants.paths as paths
 
 
@@ -56,3 +58,74 @@ def test_default_base_dir_uses_primary_repo_root_for_relative_worktree_gitdir(
     monkeypatch.chdir(worktree_root)
 
     assert paths._default_base_dir() == repo_root.resolve()
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("/mnt/c/Claude/MTGO_Tools/.git/worktrees/x", "C:\\Claude\\MTGO_Tools\\.git\\worktrees\\x"),
+        ("/mnt/d/repo", "D:\\repo"),
+        ("/mnt/c", "C:\\"),
+        ("C:\\Claude\\repo", "C:\\Claude\\repo"),  # already Windows, unchanged
+        ("/home/user/repo", "/home/user/repo"),  # non-mount, unchanged
+    ],
+)
+def test_translate_worktree_path_on_windows(raw, expected, monkeypatch):
+    monkeypatch.setattr(paths.os, "name", "nt")
+    assert paths._translate_worktree_path(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("C:\\Claude\\MTGO_Tools\\.git\\worktrees\\x", "/mnt/c/Claude/MTGO_Tools/.git/worktrees/x"),
+        ("D:/repo", "/mnt/d/repo"),
+        ("/mnt/c/repo", "/mnt/c/repo"),  # already WSL-form, unchanged
+        ("/home/user/repo", "/home/user/repo"),  # non-drive, unchanged
+    ],
+)
+def test_translate_worktree_path_on_wsl(raw, expected, monkeypatch):
+    monkeypatch.setattr(paths.os, "name", "posix")
+    monkeypatch.setattr(paths, "_running_under_wsl", lambda: True)
+    assert paths._translate_worktree_path(raw) == expected
+
+
+def test_translate_worktree_path_on_native_linux_is_noop(monkeypatch):
+    monkeypatch.setattr(paths.os, "name", "posix")
+    monkeypatch.setattr(paths, "_running_under_wsl", lambda: False)
+    # Windows-style input must not be translated on a real Linux host.
+    assert paths._translate_worktree_path("C:\\foo") == "C:\\foo"
+
+
+def test_default_base_dir_resolves_wsl_gitdir_on_windows(tmp_path, monkeypatch):
+    """Worktrees created by WSL git leave WSL-form pointers; Windows Python must translate."""
+    repo_root = tmp_path / "repo"
+    worktree_root = tmp_path / "repo-issue-123"
+    worktree_subdir = worktree_root / "scripts"
+    gitdir = repo_root / ".git" / "worktrees" / "repo-issue-123"
+    gitdir.mkdir(parents=True)
+    worktree_subdir.mkdir(parents=True)
+
+    # Simulate the pointer that WSL git would write: a /mnt/<drive>/... path.
+    # Build it from the real tmp_path by rewriting its drive prefix.
+    drive = tmp_path.drive  # e.g. "C:" on Windows, "" on Linux
+    if drive:
+        wsl_prefix = f"/mnt/{drive[0].lower()}"
+        wsl_gitdir = wsl_prefix + str(gitdir)[len(drive):].replace("\\", "/")
+    else:
+        # On non-Windows test hosts, fabricate a WSL path that maps back to tmp_path's posix form.
+        wsl_gitdir = "/mnt/c" + str(gitdir)
+    (worktree_root / ".git").write_text(f"gitdir: {wsl_gitdir}\n", encoding="utf-8")
+
+    monkeypatch.delenv(paths.BASE_DATA_DIR_ENV_VAR, raising=False)
+    monkeypatch.chdir(worktree_subdir)
+    monkeypatch.setattr(paths.os, "name", "nt")
+
+    # With translation, the resolver must walk up to repo_root.
+    # (On a Linux test host the translated C:\ path won't point at a real dir,
+    # so we only assert the non-regressing behavior under the "nt" branch by
+    # checking the translator in isolation — the full-path integration case is
+    # already covered by test_default_base_dir_uses_primary_repo_root_for_sibling_worktree.)
+    translated = paths._translate_worktree_path(wsl_gitdir)
+    assert translated != wsl_gitdir  # translation kicked in
+    assert not translated.startswith("/mnt/")  # no longer WSL-form

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -111,7 +111,7 @@ def test_default_base_dir_resolves_wsl_gitdir_on_windows(tmp_path, monkeypatch):
     drive = tmp_path.drive  # e.g. "C:" on Windows, "" on Linux
     if drive:
         wsl_prefix = f"/mnt/{drive[0].lower()}"
-        wsl_gitdir = wsl_prefix + str(gitdir)[len(drive):].replace("\\", "/")
+        wsl_gitdir = wsl_prefix + str(gitdir)[len(drive) :].replace("\\", "/")
     else:
         # On non-Windows test hosts, fabricate a WSL path that maps back to tmp_path's posix form.
         wsl_gitdir = "/mnt/c" + str(gitdir)

--- a/utils/constants/paths.py
+++ b/utils/constants/paths.py
@@ -3,10 +3,54 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
 
 BASE_DATA_DIR_ENV_VAR = "MTGO_TOOLS_BASE_DATA_DIR"
+
+# Matches a WSL mount path like "/mnt/c" or "/mnt/c/foo/bar".
+_WSL_MOUNT_RE = re.compile(r"^/mnt/([a-zA-Z])(?:/(.*))?$")
+# Matches a Windows drive path like "C:\foo\bar" or "C:/foo/bar".
+_WINDOWS_DRIVE_RE = re.compile(r"^([a-zA-Z]):[\\/](.*)$")
+
+
+def _running_under_wsl() -> bool:
+    if sys.platform != "linux":
+        return False
+    if os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"):
+        return True
+    try:
+        with open("/proc/version", encoding="utf-8") as f:
+            return "microsoft" in f.read().lower()
+    except OSError:
+        return False
+
+
+def _translate_worktree_path(raw: str) -> str:
+    """Bridge path styles between WSL and Windows in .git worktree pointers.
+
+    Git worktree markers are plain text pointing at the primary repo's
+    ``.git/worktrees/<name>``. A worktree created by WSL git encodes the path
+    as ``/mnt/<drive>/…``; Windows git encodes it as ``<drive>:\\…``. When the
+    process reading the pointer runs on the other OS, the raw string can't be
+    interpreted as an absolute path and silently resolves to the wrong place
+    (e.g. ``C:\\mnt\\c\\…`` on Windows), so the caller has to translate.
+    """
+    if os.name == "nt":
+        match = _WSL_MOUNT_RE.match(raw)
+        if match:
+            drive = match.group(1).upper()
+            rest = match.group(2) or ""
+            rest = rest.replace("/", "\\")
+            return f"{drive}:\\{rest}" if rest else f"{drive}:\\"
+    elif _running_under_wsl():
+        match = _WINDOWS_DRIVE_RE.match(raw)
+        if match:
+            drive = match.group(1).lower()
+            rest = match.group(2).replace("\\", "/")
+            return f"/mnt/{drive}/{rest}" if rest else f"/mnt/{drive}"
+    return raw
 
 
 def _resolved_env_base_dir() -> Path | None:
@@ -45,7 +89,9 @@ def _resolve_gitdir(worktree_git_marker: Path) -> Path | None:
     prefix = "gitdir:"
     if not content.startswith(prefix):
         return None
-    gitdir = Path(content[len(prefix) :].strip()).expanduser()
+    raw = content[len(prefix) :].strip()
+    raw = _translate_worktree_path(raw)
+    gitdir = Path(raw).expanduser()
     if not gitdir.is_absolute():
         gitdir = worktree_git_marker.parent / gitdir
     return gitdir.resolve()


### PR DESCRIPTION
## Summary
- Fix `BASE_DATA_DIR` resolution so running `python main.py` from a sibling/.worktrees checkout uses the primary repo's data instead of triggering a full redownload.
- Root cause: `git worktree add` from WSL writes `gitdir: /mnt/<drive>/…` in each worktree's `.git` file. Windows Python interprets that leading `/` as *current-drive relative*, so it resolves to `C:\mnt\c\…` — a directory that doesn't exist, so `ensure_base_dirs()` happily creates an empty tree there and re-fetches every cache.
- Add `_translate_worktree_path()` in `utils/constants/paths.py` to normalize the pointer before `Path()` sees it: WSL-mount → Windows drive under `os.name == "nt"`, and Windows drive → WSL-mount when running inside WSL. Native Linux is a no-op, so non-WSL hosts are unaffected.

## Test plan
- [x] `pytest tests/test_paths.py -v` — 15/15 passing (4 pre-existing + 11 new, including 9 parametrized translator cases covering both directions and a native-Linux no-op).
- [x] Real-world probe: `cd C:\Claude\MTGO_Tools-issue-415 && env\Scripts\python.exe -c "from utils.constants.paths import BASE_DATA_DIR; print(BASE_DATA_DIR)"` now prints `C:\Claude\MTGO_Tools` (was `C:\mnt\c\Claude\MTGO_Tools`).
- [x] `ruff check utils/constants/paths.py tests/test_paths.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)