### PR TITLE
feat(card_panel): make stats tab scrollable

### DIFF
--- a/widgets/panels/card_panel/frame.py
+++ b/widgets/panels/card_panel/frame.py
@@ -82,10 +82,12 @@ class CardPanel(
         self.notebook.AddPage(oracle_panel, self._t("card_panel.tab.oracle_text"))
 
     def _build_stats_tab(self) -> None:
-        stats_panel = wx.Panel(self.notebook)
+        stats_panel = wx.ScrolledWindow(self.notebook, style=wx.VSCROLL)
         stats_panel.SetBackgroundColour(DARK_PANEL)
+        stats_panel.SetScrollRate(0, 10)
         sizer = wx.BoxSizer(wx.VERTICAL)
         stats_panel.SetSizer(sizer)
+        self.stats_panel = stats_panel
 
         self.stats_card_label = wx.StaticText(stats_panel, label="")
         font = self.stats_card_label.GetFont()

--- a/widgets/panels/card_panel/handlers.py
+++ b/widgets/panels/card_panel/handlers.py
@@ -98,12 +98,13 @@ class CardPanelHandlersMixin(_Base):
             self.stats_card_label.SetLabel(self._t("card_panel.stats.no_card"))
             self._set_format_stats(None, None)
             self._set_archetype_stats(None)
-            return
-
-        card_name = str(meta.get("name") or "")
-        self.stats_card_label.SetLabel(card_name)
-        self._set_format_stats(self._current_format, card_name)
-        self._set_archetype_stats(card_name)
+        else:
+            card_name = str(meta.get("name") or "")
+            self.stats_card_label.SetLabel(card_name)
+            self._set_format_stats(self._current_format, card_name)
+            self._set_archetype_stats(card_name)
+        self.stats_panel.Layout()
+        self.stats_panel.FitInside()
 
     def _set_format_stats(self, format_name: str | None, card_name: str | None) -> None:
         if not format_name:

--- a/widgets/panels/card_panel/protocol.py
+++ b/widgets/panels/card_panel/protocol.py
@@ -31,6 +31,7 @@ class CardPanelProto(Protocol):
     # UI widgets
     notebook: wx.Notebook
     oracle_html: wx.html.HtmlWindow
+    stats_panel: wx.ScrolledWindow
     stats_card_label: wx.StaticText
     stats_format_header: wx.StaticText
     stats_format_total: wx.StaticText


### PR DESCRIPTION
## Summary
- Follow-up to #432 (issue #413) — leftover changes that didn't make it into the original PR.
- Swap the stats tab's `wx.Panel` for a `wx.ScrolledWindow` (vertical scroll, rate 10) so per-card stats stop getting clipped when content overflows.
- Call `Layout()` + `FitInside()` after each `_update_stats_card` refresh so the virtual size tracks the new content (including the no-card placeholder path).

## Test plan
- [ ] Open the Card panel, switch to the Stats tab, and confirm a vertical scrollbar appears when content overflows the panel height.
- [ ] Resize the window vertically and confirm the scrollable region updates correctly.
- [ ] Switch between cards (including the "no card selected" state) and verify layout/scroll updates without leaving stale scroll position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)