### PR TITLE
refactor(repositories): lazy __getattr__ for package exports

### DIFF
--- a/repositories/__init__.py
+++ b/repositories/__init__.py
@@ -3,29 +3,46 @@ Repositories package - Data access layer.
 
 This package contains repository classes that handle all data persistence
 and retrieval operations, isolating the UI and business logic from data access details.
+
+Repository classes are imported lazily via :func:`__getattr__` so that importing
+the package (or any single submodule, e.g. ``repositories.deck_text_cache``)
+does not eagerly pull in every sibling repository. Eager imports here turned
+``import repositories.deck_text_cache`` into a load of every repository's
+dependency graph, which made the ``navigators <-> repositories`` cycle from
+the section-2 refactor bite (importing ``repositories.deck_text_cache`` from
+``services.scrapers.mtggoldfish`` triggered ``metagame_repository`` to load,
+which tried to re-enter the partially-loaded scraper). Lazy loading keeps the
+package import cheap and cycle-free. Mirrors ``services/__init__.py``.
 """
 
-from repositories.card_repository import CardRepository, get_card_repository
-from repositories.deck_repository import DeckRepository, get_deck_repository
-from repositories.deck_text_cache import DeckTextCache, get_deck_cache
-from repositories.format_card_pool_repository import (
-    FormatCardPoolRepository,
-    get_format_card_pool_repository,
-)
-from repositories.metagame_repository import MetagameRepository, get_metagame_repository
-from repositories.radar_repository import RadarRepository, get_radar_repository
+from __future__ import annotations
 
-__all__ = [
-    "CardRepository",
-    "DeckRepository",
-    "DeckTextCache",
-    "FormatCardPoolRepository",
-    "MetagameRepository",
-    "RadarRepository",
-    "get_card_repository",
-    "get_deck_cache",
-    "get_deck_repository",
-    "get_format_card_pool_repository",
-    "get_metagame_repository",
-    "get_radar_repository",
-]
+from importlib import import_module
+from typing import Any
+
+# Public attribute -> submodule providing it.
+_EXPORTS = {
+    "CardRepository": "repositories.card_repository",
+    "get_card_repository": "repositories.card_repository",
+    "DeckRepository": "repositories.deck_repository",
+    "get_deck_repository": "repositories.deck_repository",
+    "DeckTextCache": "repositories.deck_text_cache",
+    "get_deck_cache": "repositories.deck_text_cache",
+    "FormatCardPoolRepository": "repositories.format_card_pool_repository",
+    "get_format_card_pool_repository": "repositories.format_card_pool_repository",
+    "MetagameRepository": "repositories.metagame_repository",
+    "get_metagame_repository": "repositories.metagame_repository",
+    "RadarRepository": "repositories.radar_repository",
+    "get_radar_repository": "repositories.radar_repository",
+}
+
+__all__ = sorted(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value  # cache so subsequent access skips __getattr__
+    return value


### PR DESCRIPTION
## Summary
- Convert `repositories/__init__.py` from eager top-level imports of every repository subpackage to a lazy `_EXPORTS` + `__getattr__` pattern, mirroring `services/__init__.py`.
- Importing any `repositories.X` no longer transitively loads every sibling repository's dependency graph, defanging the kind of eager-edge cycle (navigators <-> repositories) that bit during the section-2 refactor.

Closes #449

## Test plan
- [x] Full pytest suite via Windows interop: `636 passed, 5 skipped` in ~35s
- [x] `repositories.card_repository`, `repositories.deck_text_cache`, etc. still importable both directly and via `from repositories import X`

Related: #446

Generated with [Claude Code](https://claude.com/claude-code)