### PR TITLE
refactor(repositories): lazy __getattr__ to defang eager cycles

### DIFF
--- a/repositories/__init__.py
+++ b/repositories/__init__.py
@@ -2,30 +2,46 @@
 Repositories package - Data access layer.
 
 This package contains repository classes that handle all data persistence
-and retrieval operations, isolating the UI and business logic from data access details.
+and retrieval operations, isolating the UI and business logic from data
+access details.
+
+Repository classes are imported lazily via :func:`__getattr__` so that
+importing the package (or any single submodule, e.g.
+``repositories.deck_text_cache``) does not eagerly pull in every sibling
+repository. Eager aggregation here was responsible for the
+``navigators -> repositories -> services.scrapers -> repositories`` cycle
+risk flagged in #449; lazy loading keeps the package import cheap and
+cycle-free. Mirrors ``services/__init__.py``.
 """
 
-from repositories.card_repository import CardRepository, get_card_repository
-from repositories.deck_repository import DeckRepository, get_deck_repository
-from repositories.deck_text_cache import DeckTextCache, get_deck_cache
-from repositories.format_card_pool_repository import (
-    FormatCardPoolRepository,
-    get_format_card_pool_repository,
-)
-from repositories.metagame_repository import MetagameRepository, get_metagame_repository
-from repositories.radar_repository import RadarRepository, get_radar_repository
+from __future__ import annotations
 
-__all__ = [
-    "CardRepository",
-    "DeckRepository",
-    "DeckTextCache",
-    "FormatCardPoolRepository",
-    "MetagameRepository",
-    "RadarRepository",
-    "get_card_repository",
-    "get_deck_cache",
-    "get_deck_repository",
-    "get_format_card_pool_repository",
-    "get_metagame_repository",
-    "get_radar_repository",
-]
+from importlib import import_module
+from typing import Any
+
+# Public attribute -> submodule providing it.
+_EXPORTS = {
+    "CardRepository": "repositories.card_repository",
+    "get_card_repository": "repositories.card_repository",
+    "DeckRepository": "repositories.deck_repository",
+    "get_deck_repository": "repositories.deck_repository",
+    "DeckTextCache": "repositories.deck_text_cache",
+    "get_deck_cache": "repositories.deck_text_cache",
+    "FormatCardPoolRepository": "repositories.format_card_pool_repository",
+    "get_format_card_pool_repository": "repositories.format_card_pool_repository",
+    "MetagameRepository": "repositories.metagame_repository",
+    "get_metagame_repository": "repositories.metagame_repository",
+    "RadarRepository": "repositories.radar_repository",
+    "get_radar_repository": "repositories.radar_repository",
+}
+
+__all__ = sorted(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value  # cache so subsequent access skips __getattr__
+    return value

--- a/services/bundle_snapshot_client/__init__.py
+++ b/services/bundle_snapshot_client/__init__.py
@@ -6,6 +6,18 @@ package downloads that archive in-memory, extracts it, and writes the data into
 the local caches used by ``MetagameRepository`` so that archetype fetching, deck
 loading, radar analysis, and metagame analysis all start with warm caches.
 
+Why this service intentionally fans out to three repositories
+-------------------------------------------------------------
+
+The bundle is a single artifact (one URL, one download, one freshness stamp) that
+packs multiple cache shapes together.  Hydrating ``deck_text_cache``,
+``format_card_pool_repository`` and ``radar_repository`` from one parse pass is
+the entire purpose of the service — splitting it would either require multiple
+downloads (defeating the bundle) or a coordinator that still talks to all three.
+The MTGO-decklist merge also needs archetype href lookups to write into
+``deck_text_cache``, so even "just the deck-text slice" is not independent of the
+archetype slice.  See issue #450 for the investigation that confirmed this.
+
 Split by responsibility into internal modules:
 
 - ``stamp``: stamp file freshness tracking


### PR DESCRIPTION
## Summary

Mirrors `services/__init__.py`: replace eager top-level imports of all six repository subpackages in `repositories/__init__.py` with an `_EXPORTS` mapping plus module-level `__getattr__`.

Importing `repositories.X` previously ran the whole `__init__.py`, which transitively pulled every repository's dependencies. That eager aggregation is exactly what made the `navigators <-> repositories` cycle bite during the section-2 refactor (importing `repositories.deck_text_cache` from `services.scrapers.mtggoldfish` triggered `metagame_repository` to load, which re-entered the partially-loaded scraper).

With the lazy `__getattr__` pattern, attribute access on the package only imports the specific submodule that owns it, and the resolved attribute is cached in `globals()` so subsequent access skips `__getattr__`. Public surface (`__all__`) is unchanged.

Refs #449.

## Test plan
- [x] Full suite green via Windows Python: `636 passed, 5 skipped`
- [x] `black --check` and `ruff check` clean on the modified file
- [ ] Reviewer sanity-checks no consumer imports a private/non-exported name from `repositories`

Stacked on top of #451 (`loc-report`); base is set accordingly so it doesn't pick up unrelated diff.

Generated with [Claude Code](https://claude.com/claude-code)