### PR TITLE
docs(bundle_snapshot_client): document intentional 3-repo fan-out

### DIFF
--- a/services/bundle_snapshot_client/__init__.py
+++ b/services/bundle_snapshot_client/__init__.py
@@ -6,6 +6,18 @@ package downloads that archive in-memory, extracts it, and writes the data into
 the local caches used by ``MetagameRepository`` so that archetype fetching, deck
 loading, radar analysis, and metagame analysis all start with warm caches.
 
+Why this service intentionally fans out to three repositories
+-------------------------------------------------------------
+
+The bundle is a single artifact (one URL, one download, one freshness stamp) that
+packs multiple cache shapes together.  Hydrating ``deck_text_cache``,
+``format_card_pool_repository`` and ``radar_repository`` from one parse pass is
+the entire purpose of the service — splitting it would either require multiple
+downloads (defeating the bundle) or a coordinator that still talks to all three.
+The MTGO-decklist merge also needs archetype href lookups to write into
+``deck_text_cache``, so even "just the deck-text slice" is not independent of the
+archetype slice.  See issue #450 for the investigation that confirmed this.
+
 Split by responsibility into internal modules:
 
 - ``stamp``: stamp file freshness tracking


### PR DESCRIPTION
## Summary

Investigation of issue #450 (Refs #450). The dependency graph from #446 flagged `services.bundle_snapshot_client` as the only service with eager edges to three different repositories (`deck_text_cache`, `format_card_pool_repository`, `radar_repository`) and asked whether this was a legitimate cross-cutting cache loader or three concerns sharing a module.

**Conclusion: case (1) — legitimate cross-cutting bundle loader.** Added a short docstring section to the package `__init__.py` explaining why the fan-out is intentional, so future graph audits don't re-raise the same question.

## Evidence

- The remote publishes a **single** artifact (`client-bundle.tar.gz`) at one URL. There is one download, one parse pass, one freshness stamp. Hydrating the three caches atomically from that one parse is the entire job.
- The bundle archive itself bundles archetypes, deck lists, deck texts, MTGO decklists, card pools and radars together — this is a publisher-side decision, not something this module made up.
- The MTGO-decklist merge in `archetype_cache._hydrate_mtgo_decklists` needs archetype href lookups to write into `deck_text_cache`, so the "deck-text slice" and the "archetype slice" are not independent of each other; splitting them would require either re-introducing the join or re-downloading the same bundle twice.
- The module is already cleanly split internally by *responsibility* (`stamp` / `http` / `parser` / `archetype_cache` / `snapshot_cache` / `service`) via mixins sharing one `Protocol`. The structural problem the issue worried about isn't there.
- Only 2 of the 3 repository edges are eager (`snapshot_cache.py` imports `FormatCardPoolRepository` and `RadarRepository` at module top); the `deck_text_cache` edge is already lazy inside functions. Making the other two lazy too is possible but wouldn't change the architectural answer — the service still legitimately needs to write to all three.

## Stacking

This PR stacks on #453 (lazy repositories init). Base must remain `lazy-repositories-init`; do not retarget to `main` until #453 lands.

## Test plan

- [x] `black --check services/bundle_snapshot_client/__init__.py` — pass
- [x] `ruff check services/bundle_snapshot_client/__init__.py` — pass
- [x] Full pytest via WSL→Windows interop (`/mnt/c/Windows/System32/cmd.exe /c "python -m pytest -x -q"`): 636 passed, 5 skipped

Refs #450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)