### PR TITLE
fix(#478): repair installer build — Inno Setup section-tag parse error

### DIFF
--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -148,10 +148,12 @@ begin
 
   // Get-FileHash exits 0 regardless; we let PowerShell perform the comparison
   // and translate the result into the process exit code.
+  // Keep the args array on the same line as the format string: Inno Setup reads
+  // any line beginning with '[' (even inside [Code]) as a section header, so a
+  // line that starts with '[FilePath, ExpectedHash]' aborts compilation.
   Script := Format(
     '$h = (Get-FileHash -Algorithm SHA256 -Path ''%s'').Hash; '
-    + 'if ($h -ieq ''%s'') { exit 0 } else { Write-Error "SHA256 mismatch: $h"; exit 1 }',
-    [FilePath, ExpectedHash]);
+    + 'if ($h -ieq ''%s'') { exit 0 } else { Write-Error "SHA256 mismatch: $h"; exit 1 }', [FilePath, ExpectedHash]);
   Result := Exec('powershell.exe',
     '-NoProfile -NonInteractive -Command "' + Script + '"',
     '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);


### PR DESCRIPTION
## Summary
Fixes #478 — the **Build Windows Installer** CI job was failing.

The PyInstaller and .NET bridge steps succeeded; the build aborted at the Inno Setup compile step:

```
Error on line 154 in packaging\installer.iss: Invalid section tag.
Compile aborted.
[ERROR] Inno Setup compilation failed!
```

## Root cause
Inno Setup treats any line beginning with `[` (after leading whitespace) as a **section header**, even inside the `[Code]` block. The SHA-256 verification helper added in #462 (`VerifySha256PS`) split its `Format(...)` call across multiple lines so that the args array began its own line:

```pascal
Script := Format(
  '$h = (Get-FileHash ...).Hash; '
  + 'if ($h -ieq ''%s'') ...',
  [FilePath, ExpectedHash]);   // <- line starts with '[' => parsed as a section tag
```

The compiler read `[FilePath, ExpectedHash]` as an invalid section tag and aborted. The two sibling helpers (`DownloadFilePS`, `ExtractZipPS`) keep their args array on the same line as the format string, which is why they compile fine.

## Fix
Move the args array back onto the format-string line (matching the sibling helpers) and add a comment documenting the gotcha so it doesn't regress. No behavior change — purely a parse fix.

## Verification
- Confirmed via the CI job log (`actions/jobs/78288961386`) that line 154 was the sole failure point.
- Verified the only lines now beginning with `[` are legitimate section tags (`[Setup]`, `[Files]`, `[Code]`, …).
- Inno Setup is not installed locally, so a full compile wasn't run here — CI's `Build Windows Installer` job will exercise the full installer compile on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)