### PR TITLE
perf(#481): lower the splash minimum-on-screen floor (QW2)

### DIFF
--- a/widgets/frames/splash_frame/frame.py
+++ b/widgets/frames/splash_frame/frame.py
@@ -15,7 +15,7 @@ from widgets.frames.splash_frame.properties import LoadingFramePropertiesMixin
 class LoadingFrame(LoadingFrameHandlersMixin, LoadingFramePropertiesMixin, wx.Frame):
     """Lightweight splash that shows a loading message while the main UI initializes."""
 
-    def __init__(self, min_duration: float = 0.8, max_duration: float = 1.8) -> None:
+    def __init__(self, min_duration: float = 0.25, max_duration: float = 1.8) -> None:
         super().__init__(
             None,
             title="Loading MTGO Deck Builder",
@@ -33,7 +33,7 @@ class LoadingFrame(LoadingFrameHandlersMixin, LoadingFramePropertiesMixin, wx.Fr
 
         self._timer = wx.Timer(self)
         self.Bind(wx.EVT_TIMER, self._on_tick, self._timer)
-        self._timer.Start(40)
+        self._timer.Start(20)
 
         self.Centre(wx.BOTH)
 


### PR DESCRIPTION
## Summary

The loading splash had a hard-coded 0.8s minimum-on-screen floor (`min_duration=0.8`), which held a ready main window behind an artificial delay of up to ~0.3-0.6s on machines that build the UI quickly. This lowers `min_duration` to 0.25s in `widgets/frames/splash_frame/frame.py` — still large enough to avoid a visible flash but eliminating most of the forced wait — and tightens the poll timer from 40ms to 20ms so `_maybe_finish` (in `handlers.py`) fires the main-window reveal more promptly once `_ready` is set.

## Verification

- `python -m ruff check widgets/frames/splash_frame/frame.py` — passed.
- `python -m black --check widgets/frames/splash_frame/frame.py` — passed (no reformatting needed).
- No existing tests reference the splash frame / `min_duration`, and the affected module imports `wx`, which is not available in WSL, so the actual splash-to-main timing behavior could NOT be exercised here. The change is a pure constant adjustment to two literals; the surrounding ready/elapsed logic is unchanged.
- The wx/UI behavior (no perceptible flash, prompt reveal) must be confirmed on Windows.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)