### PR TITLE
perf(#480): lazy-load matplotlib/MetagameAnalysisFrame off the cold-start path

### DIFF
--- a/widgets/frames/app_frame/frame/__init__.py
+++ b/widgets/frames/app_frame/frame/__init__.py
@@ -34,7 +34,6 @@ from widgets.frames.app_frame.properties import AppFramePropertiesMixin
 from widgets.frames.identify_opponent import MTGOpponentDeckSpy
 from widgets.frames.mana_keyboard import ManaKeyboardFrame
 from widgets.frames.match_history import MatchHistoryFrame
-from widgets.frames.metagame_analysis import MetagameAnalysisFrame
 from widgets.frames.radar import RadarFrame
 from widgets.frames.timer_alert import TimerAlertFrame
 from widgets.frames.top_cards import TopCardsFrame
@@ -45,6 +44,7 @@ from widgets.panels.deck_research_panel import DeckResearchPanel
 
 if TYPE_CHECKING:
     from controllers.app_controller import AppController
+    from widgets.frames.metagame_analysis import MetagameAnalysisFrame
 
 
 class AppFrame(

--- a/widgets/frames/app_frame/handlers/app_events.py
+++ b/widgets/frames/app_frame/handlers/app_events.py
@@ -15,7 +15,6 @@ from widgets.dialogs.feedback_dialog import show_feedback_dialog
 from widgets.frames.app_frame.handlers.ui_helpers import open_child_window, widget_exists
 from widgets.frames.identify_opponent import MTGOpponentDeckSpy
 from widgets.frames.match_history import MatchHistoryFrame
-from widgets.frames.metagame_analysis import MetagameAnalysisFrame
 from widgets.frames.radar import RadarFrame
 from widgets.frames.timer_alert import TimerAlertFrame
 from widgets.frames.top_cards import TopCardsFrame
@@ -712,6 +711,11 @@ class AppEventHandlers(_Base):
         )
 
     def open_metagame_analysis(self) -> None:
+        # Imported lazily: pulling in MetagameAnalysisFrame eagerly drags
+        # matplotlib (a heavy cold-import) onto the startup path. It is only
+        # needed when the user deliberately opens this chart.
+        from widgets.frames.metagame_analysis import MetagameAnalysisFrame
+
         open_child_window(
             self,
             "metagame_window",


### PR DESCRIPTION
## Summary

`MetagameAnalysisFrame` transitively imports `matplotlib`, a heavy cold-import (hundreds of ms to seconds) that previously ran on the main thread at module load — before the splash even painted — because two startup-path modules imported it eagerly. matplotlib is only required when the user deliberately opens the Metagame Analysis chart from the toolbar, so this PR defers the import to that point. In `handlers/app_events.py` the import now lives inside `open_metagame_analysis()`; in `frame/__init__.py` the module-level import is demoted to a `TYPE_CHECKING`-only import (it was used solely for the `metagame_window` type annotation, and `from __future__ import annotations` is already present). numpy stays on the startup path via `card_image_display/properties.py`, so only matplotlib leaves.

## Verification

Run from WSL (this repo is developed in WSL; `wx` is not importable here and the full UI suite needs Windows):
- `python -m ruff check` on both changed files — all checks passed.
- `python -m black --check` on both changed files — both unchanged (already formatted).
- `python -m py_compile` on both changed files — compiles cleanly.

Not verified in WSL: actual app launch, splash timing/stopwatch measurement, and the runtime behavior of opening the Metagame Analysis window — all require `wx`/matplotlib on Windows. The lazy import path should be exercised manually on Windows to confirm the chart still opens and the startup interval drops.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)