### PR TITLE
perf(#483): skip rebuilding the inactive card view on +/- edits (QW4)

### DIFF
--- a/widgets/panels/card_table_panel/handlers.py
+++ b/widgets/panels/card_table_panel/handlers.py
@@ -90,11 +90,16 @@ class CardTablePanelHandlersMixin(_Base):
                     scrollToTop=not preserve_scroll,
                 )
 
-                # Populate the new views with the same data so a switch is
-                # instant. The pile view is expensive (kicks off image loads)
-                # so only update it when it is or will be the active page.
-                self.table_view.set_cards(cards)
-                if self.view_mode == "pile":
+                # Populate the table/pile views only when one of them is the
+                # active page. Both are fully rebuilt by set_cards (the table
+                # issues ~5 SetCellValue per card plus a column auto-size, the
+                # pile kicks off image loads), so rebuilding the hidden view on
+                # every +/- edit just delays the visible view's refresh.
+                # set_view_mode() re-populates whichever view becomes active on
+                # the next switch, so a stale hidden view is harmless.
+                if self.view_mode == "table":
+                    self.table_view.set_cards(cards)
+                elif self.view_mode == "pile":
                     self.pile_view.set_cards(cards)
 
                 self._switch_content_page()


### PR DESCRIPTION
## Summary

Every +/- quantity click ran `_update_panels`, which unconditionally called `self.table_view.set_cards(cards)` even when the table view was hidden (the default view is "grid"). Rebuilding the hidden table is expensive (~5 `SetCellValue` per card plus a column auto-size for a 75-card deck) and delays the visible view's refresh. This change guards `table_view.set_cards` behind `view_mode == "table"`, mirroring the existing `pile_view` guard. `set_view_mode()` already re-populates (and re-selects) whichever view becomes active on the next switch, so the now-stale hidden view is repopulated lazily and stays correct.

## Verification

- `python -m ruff check widgets/panels/card_table_panel/handlers.py` — passed.
- `python -m black --check widgets/panels/card_table_panel/handlers.py` — passed (unchanged).
- Could NOT run in WSL: the changed code lives in `widgets/panels/card_table_panel/handlers.py`, whose package `__init__` imports `wx` (not importable here), so the wx-dependent UI behavior and the existing `tests/test_card_table_panel_sorting.py` (which imports the package) cannot be exercised in WSL. The runtime `_update_panels took …s` before/after measurement and the visual +/- feedback need verification on Windows.
- No non-wx unit test added: the guarded logic is in a wx-dependent mixin and cannot be exercised without importing `wx`.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)