### PR TITLE
perf(#484): persist card index as msgpack instead of JSON

### DIFF
--- a/repositories/card_repository/card_data_manager.py
+++ b/repositories/card_repository/card_data_manager.py
@@ -20,6 +20,7 @@ from repositories.card_repository import remote, storage
 from repositories.card_repository.builder import build_index
 from repositories.card_repository.schemas import CardEntry
 from utils.constants import CARD_DATA_DIR
+from utils.perf import timed
 
 
 def load_card_manager(data_dir: Path | str = CARD_DATA_DIR, force: bool = False) -> CardDataManager:
@@ -36,6 +37,9 @@ class CardDataManager:
         self._cards_by_name: dict[str, CardEntry] | None = None
 
     def ensure_latest(self, force: bool = False) -> None:
+        # One-time conversion of a pre-msgpack JSON index so existing installs
+        # avoid a needless re-download on first launch after the format change.
+        storage.migrate_legacy_index(self.index_path, storage.legacy_index_path(self.data_dir))
         remote_meta = remote.fetch_dataset_headers()
         local_meta = storage.load_meta(self.meta_path) or {}
         missing_index = not self.index_path.exists()
@@ -147,6 +151,7 @@ class CardDataManager:
         self._cards = index["cards"]
         self._cards_by_name = index["cards_by_name"]
 
+    @timed
     def _load_index(self) -> None:
         card_index = storage.load_index(self.index_path)
         self._cards = card_index.cards

--- a/repositories/card_repository/storage.py
+++ b/repositories/card_repository/storage.py
@@ -1,7 +1,13 @@
 """On-disk format for the atomic-cards index and its metadata sidecar.
 
 Owns path resolution, the module-level msgspec decoder (reused across loads),
-atomic JSON writes, and the meta-JSON read helper.
+atomic index writes, and the meta-JSON read helper.
+
+The index is persisted as ``msgspec.msgpack`` (binary): it decodes
+substantially faster and is smaller on disk than the equivalent JSON, which
+matters because the index is ~34k card records read on every startup. A
+one-time migration converts a pre-existing JSON index to msgpack in place
+(see :func:`migrate_legacy_index`).
 """
 
 from __future__ import annotations
@@ -12,27 +18,60 @@ from typing import Any
 
 import msgspec
 import msgspec.json
+import msgspec.msgpack
 from loguru import logger
 
 from repositories.card_repository.schemas import CardIndex
-from utils.atomic_io import atomic_write_json
+from utils.atomic_io import atomic_write_bytes, atomic_write_json
 from utils.constants import CARD_DATA_DIR
+from utils.perf import timed
 
-# Reusing the decoder avoids re-building it on every call, which matters for
+# Reusing the codecs avoids re-building them on every call, which matters for
 # repeat loads (e.g. force-refresh).
-_card_index_decoder: msgspec.json.Decoder[CardIndex] = msgspec.json.Decoder(CardIndex)
+_card_index_decoder: msgspec.msgpack.Decoder[CardIndex] = msgspec.msgpack.Decoder(CardIndex)
+_card_index_encoder: msgspec.msgpack.Encoder = msgspec.msgpack.Encoder()
 
 
 def resolve_paths(data_dir: Path | str = CARD_DATA_DIR) -> tuple[Path, Path, Path]:
     """Return ``(data_dir, index_path, meta_path)`` after ensuring ``data_dir`` exists.
 
-    The ``_v2`` filename invalidates pre-double-faced-aware caches.
+    The ``_v2`` filename invalidates pre-double-faced-aware caches; the
+    ``.msgpack`` extension distinguishes the binary index from the legacy JSON.
     """
     base = Path(data_dir)
     base.mkdir(parents=True, exist_ok=True)
-    return base, base / "atomic_cards_index_v2.json", base / "atomic_cards_meta.json"
+    return base, base / "atomic_cards_index_v2.msgpack", base / "atomic_cards_meta.json"
 
 
+def legacy_index_path(data_dir: Path | str = CARD_DATA_DIR) -> Path:
+    """Return the path of the pre-msgpack JSON index (used for migration)."""
+    return Path(data_dir) / "atomic_cards_index_v2.json"
+
+
+def migrate_legacy_index(index_path: Path, legacy_path: Path) -> bool:
+    """Convert a legacy JSON index to msgpack in place, if applicable.
+
+    Returns ``True`` when a migration was performed. The legacy JSON file is
+    removed afterwards so the conversion runs at most once. A corrupt legacy
+    file is left untouched so the normal download/rebuild path can replace it.
+    """
+    if index_path.exists() or not legacy_path.exists():
+        return False
+    try:
+        index = msgspec.json.decode(legacy_path.read_bytes(), type=CardIndex)
+    except (msgspec.DecodeError, OSError) as exc:
+        logger.warning(f"Could not migrate legacy card index {legacy_path}: {exc}")
+        return False
+    atomic_write_bytes(index_path, _card_index_encoder.encode(index))
+    logger.info("Migrated card index from JSON to msgpack")
+    try:
+        legacy_path.unlink()
+    except OSError:
+        pass
+    return True
+
+
+@timed
 def load_index(index_path: Path) -> CardIndex:
     if not index_path.exists():
         raise RuntimeError("Card data index missing or invalid")
@@ -44,7 +83,7 @@ def load_index(index_path: Path) -> CardIndex:
 
 
 def write_index(index_path: Path, index: dict[str, Any]) -> None:
-    atomic_write_json(index_path, index, ensure_ascii=False)
+    atomic_write_bytes(index_path, _card_index_encoder.encode(index))
 
 
 def load_meta(meta_path: Path) -> dict[str, Any] | None:
@@ -62,8 +101,10 @@ def write_meta(meta_path: Path, meta: dict[str, Any]) -> None:
 
 
 __all__ = [
+    "legacy_index_path",
     "load_index",
     "load_meta",
+    "migrate_legacy_index",
     "resolve_paths",
     "write_index",
     "write_meta",

--- a/tests/test_card_index_storage.py
+++ b/tests/test_card_index_storage.py
@@ -1,0 +1,87 @@
+"""Tests for the msgpack-backed atomic-cards index storage layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import msgspec.json
+
+from repositories.card_repository import storage
+from repositories.card_repository.schemas import CardEntry
+
+
+def _sample_index() -> dict:
+    entry = CardEntry(
+        name="Opt",
+        name_lower="opt",
+        aliases=[],
+        colors=["U"],
+        color_identity=["U"],
+        legalities={"modern": "Legal"},
+        mana_cost="{U}",
+    )
+    return {"cards": [entry], "cards_by_name": {"opt": entry}}
+
+
+def test_resolve_paths_uses_msgpack_extension(tmp_path: Path) -> None:
+    _, index_path, meta_path = storage.resolve_paths(tmp_path)
+    assert index_path.name == "atomic_cards_index_v2.msgpack"
+    assert meta_path.name == "atomic_cards_meta.json"
+
+
+def test_write_then_load_index_round_trip(tmp_path: Path) -> None:
+    _, index_path, _ = storage.resolve_paths(tmp_path)
+    storage.write_index(index_path, _sample_index())
+
+    loaded = storage.load_index(index_path)
+    assert loaded.cards[0].name == "Opt"
+    assert loaded.cards_by_name["opt"].mana_cost == "{U}"
+
+
+def test_load_index_missing_raises(tmp_path: Path) -> None:
+    _, index_path, _ = storage.resolve_paths(tmp_path)
+    try:
+        storage.load_index(index_path)
+    except RuntimeError as exc:
+        assert "missing or invalid" in str(exc)
+    else:  # pragma: no cover - failure path
+        raise AssertionError("expected RuntimeError for missing index")
+
+
+def test_migrate_legacy_index_converts_json_to_msgpack(tmp_path: Path) -> None:
+    _, index_path, _ = storage.resolve_paths(tmp_path)
+    legacy_path = storage.legacy_index_path(tmp_path)
+    legacy_path.write_bytes(msgspec.json.encode(_sample_index()))
+
+    assert storage.migrate_legacy_index(index_path, legacy_path) is True
+    # Legacy JSON removed, msgpack written, and decodable.
+    assert index_path.exists()
+    assert not legacy_path.exists()
+    assert storage.load_index(index_path).cards[0].name == "Opt"
+
+
+def test_migrate_legacy_index_noop_when_index_present(tmp_path: Path) -> None:
+    _, index_path, _ = storage.resolve_paths(tmp_path)
+    storage.write_index(index_path, _sample_index())
+    legacy_path = storage.legacy_index_path(tmp_path)
+    legacy_path.write_bytes(msgspec.json.encode(_sample_index()))
+
+    # An existing msgpack index wins; the legacy file is left untouched.
+    assert storage.migrate_legacy_index(index_path, legacy_path) is False
+    assert legacy_path.exists()
+
+
+def test_migrate_legacy_index_noop_when_no_legacy(tmp_path: Path) -> None:
+    _, index_path, _ = storage.resolve_paths(tmp_path)
+    legacy_path = storage.legacy_index_path(tmp_path)
+    assert storage.migrate_legacy_index(index_path, legacy_path) is False
+
+
+def test_migrate_legacy_index_leaves_corrupt_legacy(tmp_path: Path) -> None:
+    _, index_path, _ = storage.resolve_paths(tmp_path)
+    legacy_path = storage.legacy_index_path(tmp_path)
+    legacy_path.write_bytes(b"not valid json")
+
+    assert storage.migrate_legacy_index(index_path, legacy_path) is False
+    assert not index_path.exists()
+    assert legacy_path.exists()


### PR DESCRIPTION
## Summary

Switches the persisted atomic-cards index (`data/atomic_cards_index_v2.*`) from JSON to `msgspec.msgpack` (binary), the single largest card-data startup cost identified in `docs/perf/PERF_OPTIMIZATION_REPORT.md` (HP1). The ~63.8 MB JSON took ~2s to decode warm and 5-6s cold; msgpack decodes faster and is smaller on disk. Only the encoder/decoder format changes — `build_index` still produces the same dict, so the schema is unchanged. `storage.write_index`/`load_index` now use a reused module-level msgpack `Encoder`/`Decoder`, and `resolve_paths` returns the `.msgpack` path. A one-time `migrate_legacy_index` converts a pre-existing JSON index to msgpack in place on first launch (no re-download), then removes the old JSON; a corrupt legacy file is left for the normal download/rebuild path. Per the issue's measure step, `@timed` is added to `load_index` and `_load_index`.

## Verification

- `python -m ruff check` and `python -m black --check` on `repositories/card_repository/storage.py`, `repositories/card_repository/card_data_manager.py`, and the new `tests/test_card_index_storage.py` — all clean.
- Added `tests/test_card_index_storage.py` (7 tests): msgpack round-trip, missing-index error, legacy JSON→msgpack migration, and the three migration no-op/corruption cases. All 7 pass.
- Could NOT run the project pytest suite via the normal command in WSL: `repositories.card_repository` transitively imports `wx` through `utils.constants`, and `wx` is not importable here. The usual Windows-interop workaround (`/init … cmd.exe /c "pytest …"`) was also unavailable this session — the WSL↔Windows interop layer returned `UtilAcceptVsock` errors even for a trivial `echo`. To verify behavior I instead exercised `storage.py` and the new test functions directly in pure Python with `utils.constants` stubbed (no wx): the round-trip, migration (incl. corrupt-file and no-op cases), and `@timed` instrumentation all behave as expected, and msgpack output was smaller than JSON on the sample data.
- Not verified from WSL: the full wx/UI test suite on Windows Python, and real-world cold/warm decode timing against the production 63.8 MB index. These should be checked on Windows during review.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)
