### PR TITLE
feat(deckbuilder): 1-4 / Shift+1-4 copy hotkeys in result list

### DIFF
--- a/help/deck_builder.html
+++ b/help/deck_builder.html
@@ -29,14 +29,32 @@ left panel header when a deck is loaded.</p>
   <tr><td><strong>Result list</strong></td>
       <td>Click a result to preview it in the <a href="card_inspector.html">Card Inspector</a>.</td></tr>
   <tr><td><strong>Add to Main</strong></td>
-      <td>Adds one copy of the selected card to the Mainboard.</td></tr>
+      <td>Adds one copy of the selected card to the Mainboard. With a result selected in the
+          list, you can also press <strong>1</strong>, <strong>2</strong>, <strong>3</strong> or
+          <strong>4</strong> to add that many copies to the Mainboard.</td></tr>
   <tr><td><strong>Add to Side</strong></td>
-      <td>Adds one copy of the selected card to the Sideboard.</td></tr>
+      <td>Adds one copy of the selected card to the Sideboard. With a result selected in the
+          list, you can also press <strong>Shift+1</strong>, <strong>Shift+2</strong>,
+          <strong>Shift+3</strong> or <strong>Shift+4</strong> to add that many copies to the
+          Sideboard.</td></tr>
   <tr><td><strong>Mana Keyboard</strong></td>
       <td>Opens the floating mana-symbol keyboard. Click a symbol to insert it into the search
           field, which allows searching by mana cost.</td></tr>
   <tr><td><strong>Back to Research</strong></td>
       <td>Returns the left panel to Metagame Research mode.</td></tr>
+</table>
+
+<h2>Result list shortcuts</h2>
+<p>When a card is selected in the result list, these keys add copies without leaving the
+keyboard:</p>
+<table>
+  <tr><th>Key</th><th>Action</th></tr>
+  <tr><td><strong>+</strong></td><td>Add one copy to the active zone.</td></tr>
+  <tr><td><strong>1</strong> / <strong>2</strong> / <strong>3</strong> / <strong>4</strong></td>
+      <td>Add 1, 2, 3 or 4 copies to the Mainboard.</td></tr>
+  <tr><td><strong>Shift+1</strong> / <strong>Shift+2</strong> / <strong>Shift+3</strong> /
+          <strong>Shift+4</strong></td>
+      <td>Add 1, 2, 3 or 4 copies to the Sideboard.</td></tr>
 </table>
 
 <h2>Editing counts</h2>

--- a/tests/test_deck_builder_hotkeys.py
+++ b/tests/test_deck_builder_hotkeys.py
@@ -1,0 +1,231 @@
+"""Tests for the deck builder result-list copy hotkeys (1-4 main, Shift+1-4 side).
+
+These cover the wx-independent dispatch logic in
+:class:`DeckBuilderPanelHandlersMixin`. ``wx`` is not importable in the
+WSL dev environment, so a minimal stub module is injected before importing
+the handlers mixin. The stub provides only the attributes the module touches
+at import time and during the exercised code paths.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+class _WxStub(types.ModuleType):
+    """A ``wx`` stand-in that fabricates unique int constants on demand.
+
+    Importing the deck builder package transitively touches many ``wx`` names
+    (``WXK_TAB``, ``LIST_FORMAT_LEFT``, widget classes used as bases, ...).
+    Rather than enumerate them, unknown attribute reads return a fresh unique
+    integer so any constant comparison is well-defined. The numpad digit codes
+    are pinned to values distinct from the top-row ``ord("1")..ord("4")`` keys
+    so the digit map under test behaves like the real wx.
+    """
+
+    _PINNED = {
+        "NOT_FOUND": -1,
+        "WXK_NUMPAD1": 324,
+        "WXK_NUMPAD2": 325,
+        "WXK_NUMPAD3": 326,
+        "WXK_NUMPAD4": 327,
+    }
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self._counter = 1000
+
+    def __getattr__(self, item: str) -> Any:
+        if item in self._PINNED:
+            value = self._PINNED[item]
+        else:
+            # Unique int per name; widget base classes resolve to ``object``.
+            self._counter += 1
+            value = self._counter
+        setattr(self, item, value)
+        return value
+
+
+def _install_wx_stub() -> types.ModuleType:
+    """Install a permissive ``wx`` stub only when real ``wx`` is unavailable.
+
+    On the Windows host where real ``wx`` imports fine, the stub is never
+    installed (so it cannot poison other tests). In the WSL dev environment
+    ``import wx`` fails, so the stub stands in for the constants this test
+    needs.
+    """
+    try:
+        import wx as real_wx  # noqa: F401
+
+        return sys.modules["wx"]
+    except Exception:
+        pass
+    existing = sys.modules.get("wx")
+    if isinstance(existing, _WxStub):
+        return existing
+    wx = _WxStub("wx")
+    sys.modules["wx"] = wx
+    return wx
+
+
+def _load_handlers_module() -> types.ModuleType:
+    """Import ``handlers.py`` directly, bypassing the package ``__init__``.
+
+    The deck builder package ``__init__`` transitively imports ``wx.svg`` and
+    real widget classes, which the stub cannot satisfy. ``handlers.py`` itself
+    only needs ``wx`` plus ``utils.constants``, so load it by file path.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "widgets"
+        / "panels"
+        / "deck_builder_panel"
+        / "handlers.py"
+    )
+    spec = importlib.util.spec_from_file_location("_db_handlers_under_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_wx_stub()
+DeckBuilderPanelHandlersMixin = _load_handlers_module().DeckBuilderPanelHandlersMixin
+
+
+class _KeyEvent:
+    """Stand-in for ``wx.KeyEvent`` exposing the methods the handler calls."""
+
+    def __init__(
+        self,
+        key_code: int,
+        *,
+        shift: bool = False,
+        ctrl: bool = False,
+        alt: bool = False,
+    ) -> None:
+        self._key_code = key_code
+        self._shift = shift
+        self._ctrl = ctrl
+        self._alt = alt
+        self.skipped = False
+
+    def GetKeyCode(self) -> int:
+        return self._key_code
+
+    def ShiftDown(self) -> bool:
+        return self._shift
+
+    def ControlDown(self) -> bool:
+        return self._ctrl
+
+    def AltDown(self) -> bool:
+        return self._alt
+
+    def Skip(self) -> None:
+        self.skipped = True
+
+
+class _ResultsCtrl:
+    def __init__(self, first_selected: int = 0) -> None:
+        self._first_selected = first_selected
+
+    def GetFirstSelected(self) -> int:
+        return self._first_selected
+
+
+class _Panel(DeckBuilderPanelHandlersMixin):
+    """Concrete subclass wiring just enough state for the hotkey paths."""
+
+    def __init__(self, selected: dict[str, Any] | None) -> None:
+        self._selected = selected
+        self.results_ctrl = _ResultsCtrl()
+        self.main_calls: list[tuple[str, int]] = []
+        self.side_calls: list[tuple[str, int]] = []
+        self.active_zone_calls: list[str] = []
+        self._on_add_to_main = lambda name, count=1: self.main_calls.append((name, count))
+        self._on_add_to_side = lambda name, count=1: self.side_calls.append((name, count))
+        self._on_add_to_active_zone = self.active_zone_calls.append
+
+    def get_selected_result(self) -> dict[str, Any] | None:
+        return self._selected
+
+    def get_result_at_index(self, idx: int) -> dict[str, Any] | None:
+        return self._selected
+
+
+@pytest.mark.parametrize(
+    "key_code, expected",
+    [
+        (ord("1"), 1),
+        (ord("2"), 2),
+        (ord("3"), 3),
+        (ord("4"), 4),
+        (324, 1),  # WXK_NUMPAD1
+        (327, 4),  # WXK_NUMPAD4
+        (ord("0"), None),
+        (ord("5"), None),
+        (ord("a"), None),
+    ],
+)
+def test_digit_to_count(key_code: int, expected: int | None) -> None:
+    assert DeckBuilderPanelHandlersMixin._digit_to_count(key_code) == expected
+
+
+@pytest.mark.parametrize("count_key, count", [(ord("1"), 1), (ord("4"), 4)])
+def test_digit_adds_copies_to_main(count_key: int, count: int) -> None:
+    panel = _Panel({"name": "Llanowar Elves"})
+    event = _KeyEvent(count_key)
+    panel._on_result_key_down(event)
+    assert panel.main_calls == [("Llanowar Elves", count)]
+    assert panel.side_calls == []
+    assert event.skipped is False
+
+
+@pytest.mark.parametrize("count_key, count", [(ord("2"), 2), (ord("3"), 3)])
+def test_shift_digit_adds_copies_to_side(count_key: int, count: int) -> None:
+    panel = _Panel({"name": "Pyroblast"})
+    event = _KeyEvent(count_key, shift=True)
+    panel._on_result_key_down(event)
+    assert panel.side_calls == [("Pyroblast", count)]
+    assert panel.main_calls == []
+
+
+def test_plus_adds_one_to_active_zone() -> None:
+    panel = _Panel({"name": "Island"})
+    event = _KeyEvent(ord("+"))
+    panel._on_result_key_down(event)
+    assert panel.active_zone_calls == ["Island"]
+    assert panel.main_calls == []
+    assert panel.side_calls == []
+
+
+def test_no_selection_does_nothing() -> None:
+    panel = _Panel(None)
+    event = _KeyEvent(ord("3"))
+    panel._on_result_key_down(event)
+    assert panel.main_calls == []
+    assert panel.side_calls == []
+
+
+def test_ctrl_digit_is_skipped() -> None:
+    """Ctrl-modified digits are left for the global app hotkey handler."""
+    panel = _Panel({"name": "Island"})
+    event = _KeyEvent(ord("1"), ctrl=True)
+    panel._on_result_key_down(event)
+    assert panel.main_calls == []
+    assert event.skipped is True
+
+
+def test_unmapped_key_is_skipped() -> None:
+    panel = _Panel({"name": "Island"})
+    event = _KeyEvent(ord("z"))
+    panel._on_result_key_down(event)
+    assert event.skipped is True

--- a/tests/test_deck_builder_hotkeys.py
+++ b/tests/test_deck_builder_hotkeys.py
@@ -27,12 +27,14 @@ class _WxStub(types.ModuleType):
     so the digit map under test behaves like the real wx.
     """
 
+    # Mirror the real wx values so the stub matches the constants the handler
+    # reads on the Windows host (wx.WXK_NUMPAD0 == 324, NUMPAD1..9 == 325..333).
     _PINNED = {
         "NOT_FOUND": -1,
-        "WXK_NUMPAD1": 324,
-        "WXK_NUMPAD2": 325,
-        "WXK_NUMPAD3": 326,
-        "WXK_NUMPAD4": 327,
+        "WXK_NUMPAD1": 325,
+        "WXK_NUMPAD2": 326,
+        "WXK_NUMPAD3": 327,
+        "WXK_NUMPAD4": 328,
     }
 
     def __init__(self, name: str) -> None:
@@ -96,7 +98,7 @@ def _load_handlers_module() -> types.ModuleType:
     return module
 
 
-_install_wx_stub()
+_WX = _install_wx_stub()
 DeckBuilderPanelHandlersMixin = _load_handlers_module().DeckBuilderPanelHandlersMixin
 
 
@@ -168,8 +170,11 @@ class _Panel(DeckBuilderPanelHandlersMixin):
         (ord("2"), 2),
         (ord("3"), 3),
         (ord("4"), 4),
-        (324, 1),  # WXK_NUMPAD1
-        (327, 4),  # WXK_NUMPAD4
+        # Reference the same wx constants the handler reads, so the codes stay
+        # correct under both real wx (Windows) and the stub (WSL) rather than
+        # hard-coding numbers that drift from wx's actual numpad values.
+        (_WX.WXK_NUMPAD1, 1),
+        (_WX.WXK_NUMPAD4, 4),
         (ord("0"), None),
         (ord("5"), None),
         (ord("a"), None),

--- a/widgets/frames/app_frame/frame/left_panel.py
+++ b/widgets/frames/app_frame/frame/left_panel.py
@@ -92,8 +92,8 @@ class LeftPanelBuilderMixin(_Base):
             on_search=self._on_builder_search,
             on_clear=self._on_builder_clear,
             on_result_selected=self._on_builder_result_selected,
-            on_add_to_main=lambda name: self._handle_zone_delta("main", name, 1),
-            on_add_to_side=lambda name: self._handle_zone_delta("side", name, 1),
+            on_add_to_main=lambda name, count=1: self._handle_zone_delta("main", name, count),
+            on_add_to_side=lambda name, count=1: self._handle_zone_delta("side", name, count),
             on_add_to_active_zone=self._add_search_card_to_active_zone,
             locale=self.locale,
         )

--- a/widgets/panels/deck_builder_panel/frame/__init__.py
+++ b/widgets/panels/deck_builder_panel/frame/__init__.py
@@ -47,8 +47,8 @@ class DeckBuilderPanel(
         on_search: Callable[[], None],
         on_clear: Callable[[], None],
         on_result_selected: Callable[[int | None], None],
-        on_add_to_main: Callable[[str], None] | None = None,
-        on_add_to_side: Callable[[str], None] | None = None,
+        on_add_to_main: Callable[..., None] | None = None,
+        on_add_to_side: Callable[..., None] | None = None,
         on_add_to_active_zone: Callable[[str], None] | None = None,
         locale: str | None = None,
     ) -> None:

--- a/widgets/panels/deck_builder_panel/frame/results_pane.py
+++ b/widgets/panels/deck_builder_panel/frame/results_pane.py
@@ -106,7 +106,10 @@ class ResultsPaneBuilderMixin(_Base):
         add_btns_row = wx.BoxSizer(wx.HORIZONTAL)
         add_main_btn = wx.Button(self, label=self._t("builder.add_to_main"))
         stylize_button(add_main_btn)
-        add_main_btn.SetToolTip("Add the selected card to the mainboard")
+        add_main_btn.SetToolTip(
+            "Add the selected card to the mainboard "
+            "(shortcut: press 1-4 in the results list to add that many copies)"
+        )
         add_main_btn.Enable(False)
         add_main_btn.Bind(wx.EVT_BUTTON, lambda _evt: self._on_add_to_zone("main"))
         add_btns_row.Add(add_main_btn, 1, wx.RIGHT, PADDING_SM)
@@ -114,7 +117,10 @@ class ResultsPaneBuilderMixin(_Base):
 
         add_side_btn = wx.Button(self, label=self._t("builder.add_to_side"))
         stylize_button(add_side_btn)
-        add_side_btn.SetToolTip("Add the selected card to the sideboard")
+        add_side_btn.SetToolTip(
+            "Add the selected card to the sideboard "
+            "(shortcut: press Shift+1-4 in the results list to add that many copies)"
+        )
         add_side_btn.Enable(False)
         add_side_btn.Bind(wx.EVT_BUTTON, lambda _evt: self._on_add_to_zone("side"))
         add_btns_row.Add(add_side_btn, 1)

--- a/widgets/panels/deck_builder_panel/handlers.py
+++ b/widgets/panels/deck_builder_panel/handlers.py
@@ -61,13 +61,45 @@ class DeckBuilderPanelHandlersMixin(_Base):
         self._add_result_by_index(idx)
 
     def _on_result_key_down(self, event: wx.KeyEvent) -> None:
-        if event.GetKeyCode() == ord("+") and not event.ControlDown():
+        if event.ControlDown() or event.AltDown():
+            event.Skip()
+            return
+
+        key_code = event.GetKeyCode()
+
+        # "+" adds one copy to the active zone (legacy shortcut).
+        if key_code == ord("+"):
             if self.results_ctrl:
                 selected = self.results_ctrl.GetFirstSelected()
                 if selected != wx.NOT_FOUND:
                     self._add_result_by_index(selected)
                     return
+            event.Skip()
+            return
+
+        # 1-4 add 1-4 copies to the mainboard; Shift+1-4 add to the sideboard.
+        count = self._digit_to_count(key_code)
+        if count is not None:
+            zone = "side" if event.ShiftDown() else "main"
+            self._on_add_to_zone(zone, count)
+            return
+
         event.Skip()
+
+    @staticmethod
+    def _digit_to_count(key_code: int) -> int | None:
+        """Map a 1-4 key code (top row or numpad) to a copy count, else ``None``."""
+        digit_keys = {
+            ord("1"): 1,
+            ord("2"): 2,
+            ord("3"): 3,
+            ord("4"): 4,
+            wx.WXK_NUMPAD1: 1,
+            wx.WXK_NUMPAD2: 2,
+            wx.WXK_NUMPAD3: 3,
+            wx.WXK_NUMPAD4: 4,
+        }
+        return digit_keys.get(key_code)
 
     def _add_result_by_index(self, idx: int) -> None:
         card = self.get_result_at_index(idx)
@@ -76,7 +108,7 @@ class DeckBuilderPanelHandlersMixin(_Base):
             if name:
                 self._on_add_to_active_zone(name)
 
-    def _on_add_to_zone(self, zone: str) -> None:
+    def _on_add_to_zone(self, zone: str, count: int = 1) -> None:
         card = self.get_selected_result()
         if not card:
             return
@@ -84,9 +116,9 @@ class DeckBuilderPanelHandlersMixin(_Base):
         if not name:
             return
         if zone == "main" and self._on_add_to_main:
-            self._on_add_to_main(name)
+            self._on_add_to_main(name, count)
         elif zone == "side" and self._on_add_to_side:
-            self._on_add_to_side(name)
+            self._on_add_to_side(name, count)
 
     def _update_add_buttons(self) -> None:
         has_selection = self.get_selected_result() is not None

--- a/widgets/panels/deck_builder_panel/protocol.py
+++ b/widgets/panels/deck_builder_panel/protocol.py
@@ -26,8 +26,8 @@ class DeckBuilderPanelProto(Protocol):
     _on_search_callback: Callable[[], None]
     _on_clear_callback: Callable[[], None]
     _on_result_selected_callback: Callable[[int | None], None]
-    _on_add_to_main: Callable[[str], None] | None
-    _on_add_to_side: Callable[[str], None] | None
+    _on_add_to_main: Callable[..., None] | None
+    _on_add_to_side: Callable[..., None] | None
     _on_add_to_active_zone: Callable[[str], None] | None
 
     inputs: dict[str, wx.TextCtrl]


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts to the Deck Builder result list: with a card selected, pressing `1`, `2`, `3` or `4` (top row or numpad) adds that many copies to the Mainboard, and `Shift+1`-`Shift+4` adds copies to the Sideboard. The existing `+` shortcut (add one to the active zone) is preserved, and `Ctrl`/`Alt`-modified digits are skipped so they reach the global app hotkey handler. The panel's add-to-zone callbacks now accept an optional copy count so a multi-copy add is a single deck mutation. Button tooltips and the Deck Builder help page were updated to document the shortcuts.

The "set up custom hotkey dialog" item from the issue is intentionally deferred as a follow-up: it is a separate, substantially larger configuration feature (persisted user-configurable keybindings with a UI), and bundling it would make this change non-minimal and harder to review.

## Verification

Run from WSL (the app/UI runs on Windows; `wx` is not importable here):
- `python -m ruff check` and `python -m black --check` on all changed files and the new test: pass.
- Added `tests/test_deck_builder_hotkeys.py` (loads `handlers.py` directly with a permissive `wx` stub, only when real `wx` is unavailable, so it does not poison wx-importing tests on the Windows host). `python -m pytest tests/test_deck_builder_hotkeys.py -q` -> 17 passed. Covers `_digit_to_count`, `1`/`4` -> main, `Shift`+digit -> side, `+` -> active zone, no-selection no-op, and Ctrl/unmapped pass-through.
- Ran `tests/test_deck_builder_hotkeys.py` together with `tests/test_results_filter.py` (82 passed) to confirm no stub leakage between tests.
- Help HTML re-validated with `html.parser`.

NOT verified in WSL: actual wx key-event delivery and focus behavior in the running app (EVT_KEY_DOWN reporting raw digit key codes under Shift, button tooltip rendering, numpad codes). These need the Windows GUI. The full wx UI test suite was not run here.

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
