### PR TITLE
Remove MongoDB; back saved decks with SQLite (#473)

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -100,7 +100,6 @@ The Tracker application provided excellent examples of how to structure an MTGOS
 
 - **BeautifulSoup4** - HTML parsing for MTGGoldfish scraping
 - **requests** - HTTP client for web scraping
-- **pymongo** - MongoDB driver
 - **pytesseract** - OCR for opponent name detection
 - **Pillow (PIL)** - Image processing for OCR
 - **pyautogui** - Screen capture (read-only)
@@ -165,7 +164,6 @@ While we did not use code from these projects, they demonstrated what features a
 - **Stack Overflow** - Various programming solutions
 - **Python documentation** - Language reference
 - **.NET documentation** - C# and framework references
-- **MongoDB documentation** - Database usage
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A desktop application for Magic: The Gathering Online (MTGO) players providing m
 
 ## Installation
 
-**Prerequisites**: Windows 10+, Python 3.11+, MongoDB (optional, for deck persistence), .NET 9.0 SDK (for MTGO Bridge).
+**Prerequisites**: Windows 10+, Python 3.11+, .NET 9.0 SDK (for MTGO Bridge).
 
 ```bash
 git clone https://github.com/Pedrogush/MTGO_Tools.git

--- a/docs/database_usage_report.md
+++ b/docs/database_usage_report.md
@@ -4,6 +4,15 @@ Report for issue #473. Inventories every place SQL (SQLite) and MongoDB are
 used in the codebase so we can decide whether to consolidate on a single
 persistence layer and how to make MongoDB fail fast when it is absent.
 
+> **Resolution (2026-05-29):** Per the repo owner's decision in #473, MongoDB
+> has been removed and the project now uses SQLite exclusively. The
+> `DatabaseMixin` saved-deck CRUD (`save_to_db`, `get_decks`, `load_from_db`,
+> `update_in_db`, `delete_from_db`) was migrated to a SQLite database at
+> `cache/saved_decks.db` with the same public method signatures (deck ids are
+> now integer rowids instead of Mongo `ObjectId`s). The `pymongo` dependency
+> and the MongoDB prerequisite/attributions were dropped. The inventory below
+> documents the pre-removal state.
+
 ## Summary
 
 - **SQLite** is the dominant local-persistence layer. It is used for four

--- a/docs/license_audit.md
+++ b/docs/license_audit.md
@@ -70,7 +70,6 @@ compatible with MIT redistribution:
 | wxPython | wxWindows Library License (LGPL-derived, permits closed-source linking) |
 | beautifulsoup4 | MIT |
 | curl-cffi | MIT |
-| pymongo | Apache-2.0 |
 | pygetwindow | BSD-3-Clause |
 | defusedxml | PSF |
 | pyautogui | BSD-3-Clause |

--- a/repositories/deck_repository/__init__.py
+++ b/repositories/deck_repository/__init__.py
@@ -2,7 +2,7 @@
 
 Split by responsibility into internal modules:
 
-- ``database``: MongoDB CRUD (``save_to_db``, ``get_decks``, ``update_in_db`` …)
+- ``database``: SQLite CRUD (``save_to_db``, ``get_decks``, ``update_in_db`` …)
 - ``filesystem``: deck-text file I/O and legacy-path migration
 - ``metadata_store``: per-deck notes, outboard, and sideboard-guide JSON stores
 - ``ui_state``: in-memory deck/current-deck/averaging buffer kept for the UI layer

--- a/repositories/deck_repository/database.py
+++ b/repositories/deck_repository/database.py
@@ -140,7 +140,9 @@ class DatabaseMixin(_Base):
 
         with self._connect() as conn:
             rows = conn.execute(
-                f"SELECT * FROM decks{where} ORDER BY {sort_column} DESC",
+                # sort_column is whitelisted (allowed_sort) and the WHERE
+                # clauses bind every user value via ? placeholders in `params`.
+                f"SELECT * FROM decks{where} ORDER BY {sort_column} DESC",  # nosec B608
                 params,
             ).fetchall()
 
@@ -212,7 +214,9 @@ class DatabaseMixin(_Base):
 
             params.append(deck_id)
             cursor = conn.execute(
-                f"UPDATE decks SET {', '.join(assignments)} WHERE id = ?",
+                # assignments are fixed "col = ?" fragments and every value
+                # (including deck_id) is bound via ? placeholders in `params`.
+                f"UPDATE decks SET {', '.join(assignments)} WHERE id = ?",  # nosec B608
                 params,
             )
             conn.commit()

--- a/repositories/deck_repository/database.py
+++ b/repositories/deck_repository/database.py
@@ -1,12 +1,26 @@
-"""MongoDB CRUD operations for saved decks."""
+"""SQLite CRUD operations for saved decks.
+
+Saved decks live in a single local SQLite database under ``cache/`` alongside
+the other SQLite-backed caches (deck text, format card pool, radar, images).
+This replaces the previous MongoDB backend so optional deck persistence never
+blocks on an external server's connection timeout.
+"""
 
 from __future__ import annotations
 
+import json
+import sqlite3
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pymongo
 from loguru import logger
+
+from utils.constants import (
+    SAVED_DECKS_DB_FILE,
+    SQLITE_BUSY_TIMEOUT_MS,
+    SQLITE_CONNECTION_TIMEOUT_SECONDS,
+)
 
 if TYPE_CHECKING:
     from repositories.deck_repository.protocol import DeckRepositoryProto
@@ -17,14 +31,50 @@ else:
 
 
 class DatabaseMixin(_Base):
-    """MongoDB persistence for user-saved decks."""
+    """SQLite persistence for user-saved decks."""
 
-    def _get_db(self):
-        if self._db is None:
-            if self._client is None:
-                self._client = pymongo.MongoClient("mongodb://localhost:27017/")
-            self._db = self._client.get_database("lm_scraper")
-        return self._db
+    def _get_db_path(self) -> Path:
+        if self._db_path is None:
+            self._db_path = SAVED_DECKS_DB_FILE
+        return self._db_path
+
+    def _connect(self) -> sqlite3.Connection:
+        db_path = self._get_db_path()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path, timeout=SQLITE_CONNECTION_TIMEOUT_SECONDS)
+        conn.row_factory = sqlite3.Row
+        conn.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+        self._ensure_schema(conn)
+        return conn
+
+    def _ensure_schema(self, conn: sqlite3.Connection) -> None:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS decks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                content TEXT NOT NULL,
+                format TEXT,
+                archetype TEXT,
+                player TEXT,
+                source TEXT NOT NULL DEFAULT 'manual',
+                date_saved TEXT NOT NULL,
+                date_modified TEXT,
+                metadata TEXT NOT NULL DEFAULT '{}'
+            )
+            """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_decks_format ON decks(format)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_decks_archetype ON decks(archetype)")
+        conn.commit()
+
+    @staticmethod
+    def _row_to_deck(row: sqlite3.Row) -> dict:
+        deck = dict(row)
+        try:
+            deck["metadata"] = json.loads(deck.get("metadata") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            deck["metadata"] = {}
+        deck["_id"] = deck["id"]
+        return deck
 
     def save_to_db(
         self,
@@ -36,22 +86,29 @@ class DatabaseMixin(_Base):
         source: str = "manual",
         metadata: dict | None = None,
     ):
-        db = self._get_db()
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO decks
+                    (name, content, format, archetype, player, source, date_saved, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    deck_name,
+                    deck_content,
+                    format_type,
+                    archetype,
+                    player,
+                    source,
+                    datetime.now().isoformat(),
+                    json.dumps(metadata or {}),
+                ),
+            )
+            conn.commit()
+            deck_id = cursor.lastrowid
 
-        deck_doc = {
-            "name": deck_name,
-            "content": deck_content,
-            "format": format_type,
-            "archetype": archetype,
-            "player": player,
-            "source": source,
-            "date_saved": datetime.now(),
-            "metadata": metadata or {},
-        }
-
-        result = db.decks.insert_one(deck_doc)
-        logger.info(f"Saved deck '{deck_name}' to database with ID: {result.inserted_id}")
-        return result.inserted_id
+        logger.info(f"Saved deck '{deck_name}' to database with ID: {deck_id}")
+        return deck_id
 
     def get_decks(
         self,
@@ -59,50 +116,65 @@ class DatabaseMixin(_Base):
         archetype: str | None = None,
         sort_by: str = "date_saved",
     ) -> list[dict]:
-        db = self._get_db()
+        allowed_sort = {
+            "date_saved",
+            "date_modified",
+            "name",
+            "format",
+            "archetype",
+            "player",
+            "source",
+            "id",
+        }
+        sort_column = sort_by if sort_by in allowed_sort else "date_saved"
 
-        query = {}
+        clauses = []
+        params: list = []
         if format_type:
-            query["format"] = format_type
+            clauses.append("format = ?")
+            params.append(format_type)
         if archetype:
-            query["archetype"] = archetype
+            clauses.append("archetype = ?")
+            params.append(archetype)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
 
-        decks = list(db.decks.find(query).sort(sort_by, pymongo.DESCENDING))
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"SELECT * FROM decks{where} ORDER BY {sort_column} DESC",
+                params,
+            ).fetchall()
+
+        decks = [self._row_to_deck(row) for row in rows]
         logger.debug(f"Retrieved {len(decks)} decks from database")
         return decks
 
     def load_from_db(self, deck_id):
-        db = self._get_db()
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM decks WHERE id = ?",
+                (int(deck_id),),
+            ).fetchone()
 
-        if isinstance(deck_id, str):
-            from bson import ObjectId
-
-            deck_id = ObjectId(deck_id)
-
-        deck = db.decks.find_one({"_id": deck_id})
-        if deck:
+        if row:
+            deck = self._row_to_deck(row)
             logger.debug(f"Loaded deck: {deck['name']}")
-        else:
-            logger.warning(f"Deck with ID {deck_id} not found")
+            return deck
 
-        return deck
+        logger.warning(f"Deck with ID {deck_id} not found")
+        return None
 
     def delete_from_db(self, deck_id) -> bool:
-        db = self._get_db()
+        with self._connect() as conn:
+            cursor = conn.execute("DELETE FROM decks WHERE id = ?", (int(deck_id),))
+            conn.commit()
+            deleted = cursor.rowcount
 
-        if isinstance(deck_id, str):
-            from bson import ObjectId
-
-            deck_id = ObjectId(deck_id)
-
-        result = db.decks.delete_one({"_id": deck_id})
-
-        if result.deleted_count > 0:
+        if deleted > 0:
             logger.info(f"Deleted deck with ID: {deck_id}")
             return True
-        else:
-            logger.warning(f"Deck with ID {deck_id} not found for deletion")
-            return False
+
+        logger.warning(f"Deck with ID {deck_id} not found for deletion")
+        return False
 
     def update_in_db(
         self,
@@ -111,31 +183,44 @@ class DatabaseMixin(_Base):
         deck_name: str | None = None,
         metadata: dict | None = None,
     ) -> bool:
-        db = self._get_db()
+        deck_id = int(deck_id)
 
-        if isinstance(deck_id, str):
-            from bson import ObjectId
-
-            deck_id = ObjectId(deck_id)
-
-        update_fields = {"date_modified": datetime.now()}
+        assignments = ["date_modified = ?"]
+        params: list = [datetime.now().isoformat()]
 
         if deck_content is not None:
-            update_fields["content"] = deck_content
+            assignments.append("content = ?")
+            params.append(deck_content)
         if deck_name is not None:
-            update_fields["name"] = deck_name
-        if metadata is not None:
-            existing_deck = db.decks.find_one({"_id": deck_id})
-            if existing_deck:
-                merged_metadata = existing_deck.get("metadata", {})
-                merged_metadata.update(metadata)
-                update_fields["metadata"] = merged_metadata
+            assignments.append("name = ?")
+            params.append(deck_name)
 
-        result = db.decks.update_one({"_id": deck_id}, {"$set": update_fields})
+        with self._connect() as conn:
+            if metadata is not None:
+                existing = conn.execute(
+                    "SELECT metadata FROM decks WHERE id = ?",
+                    (deck_id,),
+                ).fetchone()
+                if existing:
+                    try:
+                        merged = json.loads(existing["metadata"] or "{}")
+                    except (json.JSONDecodeError, TypeError):
+                        merged = {}
+                    merged.update(metadata)
+                    assignments.append("metadata = ?")
+                    params.append(json.dumps(merged))
 
-        if result.modified_count > 0:
+            params.append(deck_id)
+            cursor = conn.execute(
+                f"UPDATE decks SET {', '.join(assignments)} WHERE id = ?",
+                params,
+            )
+            conn.commit()
+            modified = cursor.rowcount
+
+        if modified > 0:
             logger.info(f"Updated deck with ID: {deck_id}")
             return True
-        else:
-            logger.warning(f"Deck with ID {deck_id} not found or no changes made")
-            return False
+
+        logger.warning(f"Deck with ID {deck_id} not found or no changes made")
+        return False

--- a/repositories/deck_repository/protocol.py
+++ b/repositories/deck_repository/protocol.py
@@ -7,16 +7,14 @@ that are initialized on ``DeckRepository`` itself.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Protocol
-
-import pymongo
 
 
 class DeckRepositoryProto(Protocol):
     """Cross-mixin ``self`` surface for ``DeckRepository``."""
 
-    _client: pymongo.MongoClient | None
-    _db: Any
+    _db_path: Path | None
     _decks: list[dict[str, Any]]
     _current_deck: dict[str, Any] | None
     _current_deck_text: str

--- a/repositories/deck_repository/repository.py
+++ b/repositories/deck_repository/repository.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
-
-import pymongo
 
 from repositories.deck_repository.database import DatabaseMixin
 from repositories.deck_repository.filesystem import FilesystemMixin
@@ -20,9 +19,8 @@ class DeckRepository(
 ):
     """Repository for deck data access operations and deck state management."""
 
-    def __init__(self, mongo_client: pymongo.MongoClient | None = None):
-        self._client = mongo_client
-        self._db = None
+    def __init__(self, db_path: Path | None = None):
+        self._db_path = db_path
 
         self._decks: list[dict[str, Any]] = []
         self._current_deck: dict[str, Any] | None = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ loguru==0.7.3
 wxPython==4.2.4; platform_system == "Windows"
 beautifulsoup4==4.14.3
 curl-cffi==0.14.0
-pymongo==4.16.0
 pygetwindow==0.0.9
 defusedxml==0.7.1
 pyautogui==0.9.54

--- a/tests/test_deck_repository.py
+++ b/tests/test_deck_repository.py
@@ -28,6 +28,70 @@ def deck_repo():
     return DeckRepository()
 
 
+@pytest.fixture
+def db_repo(tmp_path):
+    """DeckRepository whose SQLite saved-deck DB lives in a temp directory."""
+    return DeckRepository(db_path=tmp_path / "saved_decks.db")
+
+
+def test_save_to_db_returns_integer_id_and_loads_back(db_repo):
+    deck_id = db_repo.save_to_db(
+        deck_name="Dimir Control",
+        deck_content=SAMPLE_DECK,
+        format_type="Legacy",
+        archetype="Control",
+        player="Tester",
+        source="manual",
+        metadata={"foo": "bar"},
+    )
+
+    assert isinstance(deck_id, int)
+
+    loaded = db_repo.load_from_db(deck_id)
+    assert loaded is not None
+    assert loaded["name"] == "Dimir Control"
+    assert loaded["content"] == SAMPLE_DECK
+    assert loaded["format"] == "Legacy"
+    assert loaded["metadata"] == {"foo": "bar"}
+
+
+def test_get_decks_filters_by_format_and_archetype(db_repo):
+    db_repo.save_to_db("A", SAMPLE_DECK, format_type="Legacy", archetype="Control")
+    db_repo.save_to_db("B", SAMPLE_DECK, format_type="Modern", archetype="Aggro")
+
+    legacy = db_repo.get_decks(format_type="Legacy")
+    assert [d["name"] for d in legacy] == ["A"]
+
+    aggro = db_repo.get_decks(archetype="Aggro")
+    assert [d["name"] for d in aggro] == ["B"]
+
+    assert len(db_repo.get_decks()) == 2
+
+
+def test_update_in_db_merges_metadata(db_repo):
+    deck_id = db_repo.save_to_db("A", SAMPLE_DECK, metadata={"keep": 1})
+
+    assert db_repo.update_in_db(deck_id, deck_name="A2", metadata={"added": 2}) is True
+
+    loaded = db_repo.load_from_db(deck_id)
+    assert loaded["name"] == "A2"
+    assert loaded["metadata"] == {"keep": 1, "added": 2}
+
+
+def test_delete_from_db(db_repo):
+    deck_id = db_repo.save_to_db("A", SAMPLE_DECK)
+
+    assert db_repo.delete_from_db(deck_id) is True
+    assert db_repo.load_from_db(deck_id) is None
+    assert db_repo.delete_from_db(deck_id) is False
+
+
+def test_save_to_db_does_not_require_external_server(db_repo):
+    """SQLite persistence must work with no running database server (issue #473)."""
+    deck_id = db_repo.save_to_db("Offline", SAMPLE_DECK)
+    assert isinstance(deck_id, int)
+
+
 def test_save_deck_with_blank_name_uses_fallback(deck_repo, temp_dir):
     """Verify that blank deck names use the fallback 'saved_deck'."""
     result_path = deck_repo.save_deck_to_file("", SAMPLE_DECK, directory=temp_dir)

--- a/utils/constants/__init__.py
+++ b/utils/constants/__init__.py
@@ -82,6 +82,7 @@ from utils.constants.paths import (
     REMOTE_SNAPSHOT_BUNDLE_STAMP_FILE,
     REMOTE_SNAPSHOT_CACHE_DIR,
     REMOTE_SNAPSHOT_MANIFEST_FILE,
+    SAVED_DECKS_DB_FILE,
     ensure_base_dirs,
 )
 from utils.constants.radar import (
@@ -333,6 +334,7 @@ __all__ = [
     "LOGS_DIR",
     "MTGO_ARTICLES_CACHE_FILE",
     "RADAR_CACHE_DB_FILE",
+    "SAVED_DECKS_DB_FILE",
     "ARCHETYPE_CACHE_FILE",
     "ARCHETYPE_LIST_CACHE_FILE",
     "ARCHETYPE_DECKS_CACHE_FILE",

--- a/utils/constants/paths.py
+++ b/utils/constants/paths.py
@@ -179,6 +179,7 @@ DECK_TEXT_CACHE_FILE = CACHE_DIR / "deck_text_cache.json"  # Individual deck con
 ARCHETYPE_DECKS_CACHE_FILE = CACHE_DIR / "archetype_decks_cache.json"  # Deck lists per archetype
 FORMAT_CARD_POOL_DB_FILE = CACHE_DIR / "format_card_pool.db"
 RADAR_CACHE_DB_FILE = CACHE_DIR / "radar_cache.db"
+SAVED_DECKS_DB_FILE = CACHE_DIR / "saved_decks.db"
 DECK_CACHE_FILE = DECK_TEXT_CACHE_FILE
 CURR_DECK_FILE = DECKS_DIR / "curr_deck.txt"
 


### PR DESCRIPTION
## Summary

Optional deck persistence previously created a default `MongoClient("mongodb://localhost:27017/")` whose ~30s server-selection timeout caused a multi-second hang on save when MongoDB was not running. Per the repo owner's decision on #473, this PR removes MongoDB entirely and standardizes on SQLite (already the sole local-persistence layer for deck text, format card pool, radar, and card images). `DeckRepository.DatabaseMixin` now persists saved decks in `cache/saved_decks.db` via `sqlite3`, keeping the same public method signatures (`save_to_db`/`get_decks`/`load_from_db`/`update_in_db`/`delete_from_db`); deck ids are now integer rowids instead of Mongo `ObjectId`s and `metadata` is stored as JSON. `pymongo` is dropped from `requirements.txt`, the MongoDB prerequisite/attributions are removed from `README.md`, `ATTRIBUTIONS.md`, and `docs/license_audit.md`, and the removal is documented at the top of the pre-existing `docs/database_usage_report.md`. No remaining code path can block on a MongoDB connection timeout.

## Verification

Run from WSL against the Windows Python (which has `wx`), per the project's WSL/Windows interop workflow:

- `python -m ruff check` and `python -m black --check` on all changed files — clean (ran `ruff --fix` / `black` to auto-format `utils/constants/__init__.py` import order and `database.py`).
- `python -m pytest tests/test_deck_repository.py tests/test_deck_workflow_service.py -q` — 21 passed. Added 5 new non-wx unit tests covering the SQLite saved-deck CRUD (insert returns an int id and round-trips, format/archetype filtering, metadata merge on update, delete, and persistence with no external server).
- Full suite `python -m pytest -q` — 671 passed, 5 skipped.

Not verified in WSL: actual wx/UI behavior on Windows (the "Save deck" UI flow that calls `DeckWorkflowService.save_deck`). The save path is covered by `test_deck_workflow_service.py` against a fake repo, but the live GUI was not launched.

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)