### PR TITLE
feat(card_table): view controls (+/-/remove) across grid, table, pile

### DIFF
--- a/tests/test_card_table_panel_sorting.py
+++ b/tests/test_card_table_panel_sorting.py
@@ -15,6 +15,10 @@ from widgets.panels.card_table_panel.sorting import (
     PILE_SORT_COLOR,
     PILE_SORT_MV,
     PILE_SORT_TYPE,
+    TABLE_ACTION_ADD,
+    TABLE_ACTION_REMOVE,
+    TABLE_ACTION_SUB,
+    action_slot_at,
     color_sort_key,
     group_into_piles,
     is_land,
@@ -212,3 +216,21 @@ def test_pile_key_for_handles_missing_metadata():
     # A card whose name doesn't exist in metadata should still bucket safely.
     key = pile_key_for({"name": "Unknown", "qty": 1}, {}, PILE_SORT_MV)
     assert key == (0, "0")  # no metadata → mv 0, label "0"
+
+
+def test_action_slot_at_maps_thirds_to_add_sub_remove():
+    width = 60  # three 20px slots
+    # First third -> add, middle -> subtract, last -> remove.
+    assert action_slot_at(0, width) == TABLE_ACTION_ADD
+    assert action_slot_at(19, width) == TABLE_ACTION_ADD
+    assert action_slot_at(20, width) == TABLE_ACTION_SUB
+    assert action_slot_at(39, width) == TABLE_ACTION_SUB
+    assert action_slot_at(40, width) == TABLE_ACTION_REMOVE
+    assert action_slot_at(59, width) == TABLE_ACTION_REMOVE
+
+
+def test_action_slot_at_clamps_out_of_range_and_zero_width():
+    # Past the right edge clamps to the last slot; a degenerate width is safe.
+    assert action_slot_at(1000, 60) == TABLE_ACTION_REMOVE
+    assert action_slot_at(-5, 60) == TABLE_ACTION_ADD
+    assert action_slot_at(10, 0) == TABLE_ACTION_ADD

--- a/widgets/frames/app_frame/handlers/card_tables.py
+++ b/widgets/frames/app_frame/handlers/card_tables.py
@@ -120,6 +120,19 @@ class CardTablesHandler(_Base):
             return
 
         if not event.ControlDown():
+            # Plain +/-/Delete edit the quantity of the currently selected deck
+            # card in whatever view (grid/table/pile) is showing. Skipped while a
+            # text field has focus so they don't clobber normal typing.
+            if not self._typing_in_text_field():
+                if key_code in (ord("+"), wx.WXK_NUMPAD_ADD, ord("=")):
+                    if self._handle_increment_shortcut():
+                        return
+                elif key_code in (ord("-"), wx.WXK_NUMPAD_SUBTRACT):
+                    if self._handle_decrement_shortcut():
+                        return
+                elif key_code in (wx.WXK_DELETE, wx.WXK_NUMPAD_DELETE):
+                    if self._handle_remove_shortcut():
+                        return
             event.Skip()
             return
         handled = False
@@ -138,6 +151,16 @@ class CardTablesHandler(_Base):
         if handled:
             return
         event.Skip()
+
+    @staticmethod
+    def _typing_in_text_field() -> bool:
+        """True when keyboard focus is on an editable text control.
+
+        Used to suppress the bare +/-/Delete deck-edit shortcuts while the user
+        is typing in a search box, deck-name field, notes area, etc.
+        """
+        focused = wx.Window.FindFocus()
+        return isinstance(focused, (wx.TextCtrl, wx.SearchCtrl, wx.ComboBox))
 
     def _handle_increment_shortcut(self: AppFrame) -> bool:
         selection = self._get_selected_zone_card()
@@ -166,6 +189,15 @@ class CardTablesHandler(_Base):
             return False
         self._handle_zone_delta(zone, card["name"], -1)
         self._focus_card_in_zone(zone, card["name"])
+        return True
+
+    def _handle_remove_shortcut(self: AppFrame) -> bool:
+        """Remove the selected card from its zone entirely (the [Del] shortcut)."""
+        selection = self._get_selected_zone_card()
+        if selection is None:
+            return False
+        zone, card = selection
+        self._handle_zone_remove(zone, card["name"])
         return True
 
     def _get_selected_zone_card(self: AppFrame) -> tuple[str, dict[str, Any]] | None:

--- a/widgets/panels/card_table_panel/frame.py
+++ b/widgets/panels/card_table_panel/frame.py
@@ -167,6 +167,8 @@ class CardTablePanel(CardTablePanelHandlersMixin, CardTablePanelPropertiesMixin,
             on_hover=self._handle_view_hover,
             icon_factory=icon_factory,
             label_for_column=self._column_label,
+            on_delta=lambda name, delta: self._on_delta(self.zone, name, delta),
+            on_remove=self._handle_view_remove,
         )
         self._content_book.AddPage(self.table_view, "table")
 
@@ -179,6 +181,7 @@ class CardTablePanel(CardTablePanelHandlersMixin, CardTablePanelPropertiesMixin,
             on_select=self._handle_view_select,
             on_hover=self._handle_view_hover,
             get_sort_mode=lambda: self.pile_sort,
+            on_remove=self._handle_view_remove,
         )
         self._content_book.AddPage(self.pile_view, "pile")
 
@@ -284,6 +287,11 @@ class CardTablePanel(CardTablePanelHandlersMixin, CardTablePanelPropertiesMixin,
         if self._on_hover is None:
             return
         self._on_hover(self.zone, card)
+
+    def _handle_view_remove(self, name: str) -> None:
+        """Remove ``name`` from this panel's zone (pile-view right-click)."""
+        if self._on_remove:
+            self._on_remove(self.zone, name)
 
     def _sync_grid_selection(self) -> None:
         if self.active_panel:

--- a/widgets/panels/card_table_panel/pile_view.py
+++ b/widgets/panels/card_table_panel/pile_view.py
@@ -91,6 +91,7 @@ class DeckPileView(wx.ScrolledWindow):
         on_select: Callable[[dict[str, Any] | None], None],
         on_hover: Callable[[dict[str, Any]], None] | None,
         get_sort_mode: Callable[[], str] | None = None,
+        on_remove: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__(parent, style=wx.HSCROLL | wx.VSCROLL)
         self.zone = zone
@@ -99,6 +100,7 @@ class DeckPileView(wx.ScrolledWindow):
         self._on_select = on_select
         self._on_hover = on_hover
         self._get_sort_mode = get_sort_mode or (lambda: PILE_SORT_MV)
+        self._on_remove = on_remove
 
         self._cards: list[dict[str, Any]] = []
         # piles is a list of (label, [card_entries...]) — card_entries are
@@ -133,6 +135,7 @@ class DeckPileView(wx.ScrolledWindow):
         self.Bind(wx.EVT_PAINT, self._on_paint)
         self.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
         self.Bind(wx.EVT_LEFT_UP, self._on_left_up)
+        self.Bind(wx.EVT_RIGHT_DOWN, self._on_right_down)
         self.Bind(wx.EVT_MOTION, self._on_motion)
         self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
         self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self._on_capture_lost)
@@ -433,6 +436,24 @@ class DeckPileView(wx.ScrolledWindow):
         if not self.HasCapture():
             self.CaptureMouse()
         self.Refresh()
+
+    def _on_right_down(self, event: wx.MouseEvent) -> None:
+        """Right-click removes the card under the cursor from the deck zone.
+
+        Removal is delegated to the panel's ``on_remove`` callback, which drops
+        every copy of that card from the zone (mirroring the grid view's ``×``
+        button); the pile view is then rebuilt by the resulting ``set_cards``.
+        """
+        if self._on_remove is None:
+            event.Skip()
+            return
+        point = self._to_logical(event.GetPosition())
+        hit = self._hit_test(point)
+        if hit is None:
+            event.Skip()
+            return
+        _pile_idx, _member_idx, entry = hit
+        self._on_remove(entry["name"])
 
     def _on_motion(self, event: wx.MouseEvent) -> None:
         point = self._to_logical(event.GetPosition())

--- a/widgets/panels/card_table_panel/sorting.py
+++ b/widgets/panels/card_table_panel/sorting.py
@@ -32,6 +32,23 @@ PILE_SORT_MV = "mv"
 PILE_SORT_COLOR = "color"
 PILE_SORT_TYPE = "type"
 
+# Table-view row controls. The trailing actions cell is split into this many
+# equal-width slots, one glyph each (add / subtract / remove).
+TABLE_ACTION_COUNT = 3
+TABLE_ACTION_ADD, TABLE_ACTION_SUB, TABLE_ACTION_REMOVE = range(TABLE_ACTION_COUNT)
+
+
+def action_slot_at(x_in_cell: int, cell_width: int) -> int:
+    """Map an x offset inside the actions cell to an action slot index.
+
+    The cell is split into ``TABLE_ACTION_COUNT`` equal slots. Out-of-range x
+    is clamped so an edge click still resolves to the nearest slot.
+    """
+    if cell_width <= 0:
+        return TABLE_ACTION_ADD
+    slot = int(x_in_cell // (cell_width / TABLE_ACTION_COUNT))
+    return max(0, min(TABLE_ACTION_COUNT - 1, slot))
+
 
 def _meta(get_metadata: Callable[[str], Any], name: str) -> dict[str, Any]:
     """Return metadata for ``name`` as a dict-like object, never None."""

--- a/widgets/panels/card_table_panel/table_view.py
+++ b/widgets/panels/card_table_panel/table_view.py
@@ -34,7 +34,11 @@ from widgets.panels.card_table_panel.sorting import (
     COL_NAME,
     COL_TEXT,
     COL_TYPE,
+    TABLE_ACTION_ADD,
+    TABLE_ACTION_REMOVE,
+    TABLE_ACTION_SUB,
     TABLE_COLUMNS,
+    action_slot_at,
     card_colors,
     card_mana_value,
     card_type_line,
@@ -76,6 +80,14 @@ _COLUMN_LABELS: dict[str, str] = {
     COL_TEXT: "Text",
     COL_COLOR: "Color",
 }
+
+# Trailing, non-data "actions" column rendered with the same +/-/x controls the
+# grid view shows on a selected card. It is not part of TABLE_COLUMNS so it
+# never participates in sorting or fit-to-width; it is appended after the data
+# columns and clicks on it are routed by x-position to add/remove/delete.
+_ACTIONS_COL = len(TABLE_COLUMNS)
+_ACTION_GLYPHS = ("+", "−", "×")
+_ACTIONS_COL_WIDTH = 66
 
 # Cache of (token, target-size) → wx.Bitmap shared across all renderer
 # instances. Bitmap creation + scaling is expensive; oracle text repeats
@@ -358,6 +370,44 @@ class _InlineSymbolStringRenderer(gridlib.GridCellRenderer):
         return _InlineSymbolStringRenderer(self._factory, self._icon_size)
 
 
+class _ActionCellRenderer(gridlib.GridCellRenderer):
+    """Draws the ``+ − ×`` row controls, each glyph centered in an equal slot."""
+
+    def Draw(
+        self,
+        grid: gridlib.Grid,
+        attr: gridlib.GridCellAttr,
+        dc: wx.DC,
+        rect: wx.Rect,
+        row: int,
+        col: int,
+        isSelected: bool,
+    ) -> None:
+        _paint_row_background(grid, dc, rect, col, isSelected)
+        dc.SetFont(grid.GetDefaultCellFont().Bold())
+        dc.SetTextForeground(grid.GetDefaultCellTextColour())
+        slot_w = rect.width / len(_ACTION_GLYPHS)
+        char_h = dc.GetCharHeight()
+        y = rect.y + max(0, (rect.height - char_h) // 2)
+        for idx, glyph in enumerate(_ACTION_GLYPHS):
+            tw = dc.GetTextExtent(glyph)[0]
+            x = rect.x + int(slot_w * idx + (slot_w - tw) / 2)
+            dc.DrawText(glyph, x, y)
+
+    def GetBestSize(
+        self,
+        grid: gridlib.Grid,
+        attr: gridlib.GridCellAttr,
+        dc: wx.DC,
+        row: int,
+        col: int,
+    ) -> wx.Size:
+        return wx.Size(_ACTIONS_COL_WIDTH, grid.GetDefaultRowSize())
+
+    def Clone(self) -> _ActionCellRenderer:
+        return _ActionCellRenderer()
+
+
 class DeckTableView(wx.Panel):
     """A wx.grid-backed sortable/reorderable table of deck cards."""
 
@@ -370,6 +420,8 @@ class DeckTableView(wx.Panel):
         on_hover: Callable[[dict[str, Any]], None] | None,
         icon_factory: ManaIconFactory,
         label_for_column: Callable[[str], str] | None = None,
+        on_delta: Callable[[str, int], None] | None = None,
+        on_remove: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__(parent)
         self.zone = zone
@@ -378,6 +430,8 @@ class DeckTableView(wx.Panel):
         self._on_hover = on_hover
         self._icon_factory = icon_factory
         self._labels = label_for_column or _COLUMN_LABELS.get
+        self._on_delta = on_delta
+        self._on_remove = on_remove
 
         self._cards: list[dict[str, Any]] = []
         self._rows: list[dict[str, Any]] = []  # cards in current display order
@@ -395,7 +449,8 @@ class DeckTableView(wx.Panel):
         self.SetSizer(sizer)
 
         self.grid = gridlib.Grid(self)
-        self.grid.CreateGrid(0, len(TABLE_COLUMNS))
+        # One extra trailing column hosts the +/-/x row controls.
+        self.grid.CreateGrid(0, len(TABLE_COLUMNS) + 1)
         self.grid.EnableEditing(False)
         self.grid.EnableDragColMove(True)
         self.grid.EnableDragColSize(True)
@@ -439,6 +494,14 @@ class DeckTableView(wx.Panel):
             attr = gridlib.GridCellAttr()
             attr.SetRenderer(renderer)
             self.grid.SetColAttr(idx, attr)
+
+        # Actions column: fixed width, non-sortable, non-resizable.
+        self.grid.SetColLabelValue(_ACTIONS_COL, "")
+        actions_attr = gridlib.GridCellAttr()
+        actions_attr.SetRenderer(_ActionCellRenderer())
+        self.grid.SetColAttr(_ACTIONS_COL, actions_attr)
+        self.grid.SetColSize(_ACTIONS_COL, _ACTIONS_COL_WIDTH)
+        self.grid.DisableColResize(_ACTIONS_COL)
 
         sizer.Add(self.grid, 1, wx.EXPAND)
 
@@ -558,7 +621,9 @@ class DeckTableView(wx.Panel):
         for idx, w in self._natural_widths.items():
             if self.grid.GetColSize(idx) != w:
                 self.grid.SetColSize(idx, w)
-        available = self.grid.GetClientSize().GetWidth()
+        # Reserve room for the fixed actions column so the data columns shrink
+        # to fit beside it rather than pushing it off-screen.
+        available = self.grid.GetClientSize().GetWidth() - _ACTIONS_COL_WIDTH
         if available <= 0:
             return
         total = sum(self._natural_widths.values())
@@ -608,7 +673,7 @@ class DeckTableView(wx.Panel):
     # ----- event handlers -----
     def _on_header_click(self, event: gridlib.GridEvent) -> None:
         col = event.GetCol()
-        if col < 0:
+        if col < 0 or col == _ACTIONS_COL:
             event.Skip()
             return
         col_id = self._column_id_at(col)
@@ -625,6 +690,9 @@ class DeckTableView(wx.Panel):
             event.Skip()
             return
         card = self._rows[row]
+        if event.GetCol() == _ACTIONS_COL:
+            self._handle_action_click(row, card["name"], event.GetPosition())
+            return
         if self._selected_name and card["name"].lower() == self._selected_name.lower():
             self._selected_name = None
             self._apply_selection_highlight()
@@ -633,6 +701,23 @@ class DeckTableView(wx.Panel):
         self._selected_name = card["name"]
         self._apply_selection_highlight()
         self._on_select(card)
+
+    def _handle_action_click(self, row: int, name: str, pos: wx.Point) -> None:
+        # Convert the event position (device coords on the grid window) into an
+        # offset within the actions cell, then route to the matching callback.
+        # CellToRect returns logical (scroll-aware, col-move-aware) coords, so
+        # compare against the unscrolled click position.
+        col = _ACTIONS_COL
+        rect = self.grid.CellToRect(row, col)
+        x_logical, _ = self.grid.CalcUnscrolledPosition(pos)
+        x_in_cell = x_logical - rect.x
+        action = action_slot_at(x_in_cell, rect.width)
+        if action == TABLE_ACTION_ADD and self._on_delta:
+            self._on_delta(name, 1)
+        elif action == TABLE_ACTION_SUB and self._on_delta:
+            self._on_delta(name, -1)
+        elif action == TABLE_ACTION_REMOVE and self._on_remove:
+            self._on_remove(name)
 
     def _on_cell_select(self, event: gridlib.GridEvent) -> None:
         # Suppress the native single-cell highlight; we manage row selection.


### PR DESCRIPTION
## Summary

Adds the deck-editing view controls requested in #498. The table view now has a trailing actions column rendering `+ − ×` row controls (click position routes to increment / decrement / remove). Bare `+`, `-`, and `Delete` keys edit the quantity of the currently selected deck card in whichever view is showing (grid / table / pile), suppressed while a text field has focus so they don't interfere with typing. Right-clicking a card in the pile view removes it from the zone. All mutations reuse the existing `on_delta` / `on_remove` zone-edit callbacks, so deck text, stats, and persistence update through the established path.

## Verification

Run from WSL (wx is not importable here; the full UI suite requires Windows):
- `python -m ruff check` on all changed files — passed.
- `python -m black --check` on all changed files — passed.
- The pure slot-mapping helper `action_slot_at` was extracted into the wx-free `sorting.py` module and exercised standalone (importing the module file directly to bypass the wx-importing package `__init__`): all assertions pass. Unit tests for it were added to `tests/test_card_table_panel_sorting.py` (that test module imports through the package `__init__`, so it executes on Windows per the project's WSL↔Windows test convention).

Not verified in WSL (requires Windows + wx):
- Actual rendering and hit-testing of the table actions column (`CellToRect` / `CalcUnscrolledPosition` coordinate mapping, behavior under column reorder/scroll).
- `EVT_CHAR_HOOK` delivery of bare `+/-/Delete` and the `FindFocus`-based text-field guard against real focused controls.
- Pile-view `EVT_RIGHT_DOWN` removal.

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)