### PR TITLE
perf(QW-2): batch the 916-row deck-list render into one SetItemCount/Refresh

### DIFF
--- a/tests/test_deck_results_list.py
+++ b/tests/test_deck_results_list.py
@@ -1,0 +1,136 @@
+"""Tests for the wx-independent bulk-populate logic of the deck results list.
+
+These cover :meth:`DeckResultsListHandlersMixin.set_decks`, the batched
+populate that replaces the per-row ``SetItemCount``/``Refresh`` calls so the
+916-row deck list triggers exactly one layout/scrollbar recomputation. ``wx`` is
+not importable in the WSL dev environment, so a minimal stub module is injected
+before importing the handler module by file path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+
+class _WxStub(types.ModuleType):
+    """A permissive ``wx`` stand-in fabricating attributes on demand.
+
+    The handlers module only references ``wx`` for type annotations at import
+    time, so any attribute access can return a harmless placeholder.
+    """
+
+    def __getattr__(self, name: str) -> Any:  # noqa: D401 - simple stub
+        value: Any = type(name, (), {})
+        setattr(self, name, value)
+        return value
+
+
+def _install_wx_stub() -> types.ModuleType:
+    """Install a ``wx`` stub only when the real module is unavailable."""
+    try:
+        import wx as real_wx  # noqa: F401
+
+        return sys.modules["wx"]
+    except Exception:
+        pass
+    stub = _WxStub("wx")
+    sys.modules["wx"] = stub
+    return stub
+
+
+def _load_handlers_module() -> types.ModuleType:
+    """Import the deck results list ``handlers.py`` directly by file path."""
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "widgets"
+        / "lists"
+        / "deck_results_list"
+        / "handlers.py"
+    )
+    spec = importlib.util.spec_from_file_location("_drl_handlers_under_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_wx_stub()
+DeckResultsListHandlersMixin = _load_handlers_module().DeckResultsListHandlersMixin
+
+
+class _FakeList(DeckResultsListHandlersMixin):
+    """Concrete mixin host recording the wx base-class calls under test."""
+
+    def __init__(self) -> None:
+        self._items: list[tuple[bool, tuple]] = []
+        self.set_item_count_calls: list[int] = []
+        self.refresh_calls = 0
+        self.freeze_calls = 0
+        self.thaw_calls = 0
+
+    def SetItemCount(self, count: int) -> None:
+        self.set_item_count_calls.append(count)
+
+    def Refresh(self) -> None:
+        self.refresh_calls += 1
+
+    def Freeze(self) -> None:
+        self.freeze_calls += 1
+
+    def Thaw(self) -> None:
+        self.thaw_calls += 1
+
+
+def _make_rows(n: int) -> list[tuple[str, str, str, str, str, str]]:
+    return [("", f"player{i}", f"arch{i}", f"event{i}", f"result{i}", f"date{i}") for i in range(n)]
+
+
+def test_set_decks_single_layout_pass() -> None:
+    lst = _FakeList()
+    rows = _make_rows(916)
+
+    lst.set_decks(rows)
+
+    # Exactly one SetItemCount + Refresh regardless of row count.
+    assert lst.set_item_count_calls == [916]
+    assert lst.refresh_calls == 1
+    # Wrapped in a single Freeze/Thaw pair.
+    assert lst.freeze_calls == 1
+    assert lst.thaw_calls == 1
+
+
+def test_set_decks_appends_structured_rows() -> None:
+    lst = _FakeList()
+    rows = _make_rows(3)
+
+    lst.set_decks(rows)
+
+    assert len(lst._items) == 3
+    for (is_structured, data), row in zip(lst._items, rows):
+        assert is_structured is True
+        assert data == row
+
+
+def test_set_decks_appends_after_existing_items() -> None:
+    lst = _FakeList()
+    lst._items.append((False, ("", "preexisting", "")))
+
+    lst.set_decks(_make_rows(2))
+
+    assert len(lst._items) == 3
+    assert lst.set_item_count_calls == [3]
+
+
+def test_set_decks_empty_still_single_pass() -> None:
+    lst = _FakeList()
+
+    lst.set_decks([])
+
+    assert lst.set_item_count_calls == [0]
+    assert lst.refresh_calls == 1
+    assert lst.freeze_calls == 1
+    assert lst.thaw_calls == 1

--- a/widgets/frames/app_frame/handlers/app_events.py
+++ b/widgets/frames/app_frame/handlers/app_events.py
@@ -243,20 +243,22 @@ class AppEventHandlers(_Base):
             return
         slug_to_name = {a.get("href", ""): a.get("name", "") for a in self.archetypes}
         show_source = self.controller.get_deck_data_source() == "both"
-        for deck in filtered:
-            slug = deck.get("name", "")
-            self.deck_list.AppendDeck(
-                player=deck.get("player", "Unknown"),
-                archetype=slug_to_name.get(slug, slug),
-                event=AppEventHandlers._strip_extra_dates(deck.get("event", "")),
-                result=deck.get("result", ""),
-                date=AppEventHandlers._normalize_date(deck.get("date", "")),
-                emoji=(
+        rows = [
+            (
+                (
                     ("🐠" if deck.get("source") == "mtggoldfish" else "🧙🏾‍♂️")
                     if show_source
                     else ""
                 ),
+                deck.get("player", "Unknown"),
+                slug_to_name.get(deck.get("name", ""), deck.get("name", "")),
+                AppEventHandlers._strip_extra_dates(deck.get("event", "")),
+                deck.get("result", ""),
+                AppEventHandlers._normalize_date(deck.get("date", "")),
             )
+            for deck in filtered
+        ]
+        self.deck_list.set_decks(rows)
         self.deck_list.Enable()
 
     def on_deck_selected(self: AppFrame, _event: wx.CommandEvent | None = None) -> None:

--- a/widgets/lists/deck_results_list/handlers.py
+++ b/widgets/lists/deck_results_list/handlers.py
@@ -45,6 +45,22 @@ class DeckResultsListHandlersMixin:
         self.SetItemCount(len(self._items))
         self.Refresh()
 
+    def set_decks(self, rows: list[tuple[str, str, str, str, str, str]]) -> None:
+        """Bulk-populate structured deck rows with a single layout pass.
+
+        Each row is ``(emoji, player, archetype, event, result, date)``. Appending
+        every row before a single :meth:`SetItemCount`/:meth:`Refresh` avoids the
+        per-row scrollbar/layout recomputation that defeats VListBox virtualization.
+        """
+        self.Freeze()
+        try:
+            for emoji, player, archetype, event, result, date in rows:
+                self._items.append((True, (emoji, player, archetype, event, result, date)))
+            self.SetItemCount(len(self._items))
+            self.Refresh()
+        finally:
+            self.Thaw()
+
     def Clear(self) -> None:
         self._items = []
         self.SetItemCount(0)


### PR DESCRIPTION
## Summary
Populating the deck-results list called `SetItemCount(len)` + `Refresh()` once per row inside the `_apply_deck_filters` loop, so loading 916 decks triggered 916 layout/scrollbar recomputations and defeated the `VListBox` virtualization (QW-2). This adds a bulk `DeckResultsList.set_decks(rows)` setter that appends all rows to `self._items` then calls `SetItemCount`/`Refresh` exactly once, wrapped in `Freeze()`/`Thaw()`. `_apply_deck_filters` now builds the row tuples and calls `set_decks` a single time instead of calling `AppendDeck` per deck.

## Verification
- `python -m ruff check` and `python -m black --check` on `widgets/lists/deck_results_list/handlers.py`, `widgets/frames/app_frame/handlers/app_events.py`, and `tests/test_deck_results_list.py` — all pass.
- Added `tests/test_deck_results_list.py` (wx-independent, follows the existing wx-stub pattern from `test_deck_builder_hotkeys.py`): asserts `set_decks` calls `SetItemCount`/`Refresh` exactly once and `Freeze`/`Thaw` exactly once regardless of row count (incl. 916 and empty), appends structured rows correctly, and appends after pre-existing items. `python -m pytest tests/test_deck_results_list.py -q` -> 4 passed.
- NOT verified in WSL: actual wx rendering and the cold-start wall-time measurement between the "Loading decks for Any…" and "Loaded 916 decks" log lines (the ~2.03s window) — `wx` is not importable here and the app runs on Windows. The measure step (`python -m automation.cli open-app --wait`) needs the Windows host.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)
