### PR TITLE
perf(QW-1): skip redundant deck reload when bundle archetypes are unchanged

### DIFF
--- a/controllers/app_controller/lifecycle.py
+++ b/controllers/app_controller/lifecycle.py
@@ -46,7 +46,20 @@ class LifecycleMixin(_Base):
             if updated and archetypes_by_format:
                 fmt_archetypes = archetypes_by_format.get(self.current_format.lower())
                 if fmt_archetypes is not None:
-                    # Archetypes already in memory from bundle — skip the disk read.
+                    # If the bundle's archetypes match what the optimistic
+                    # startup load already put on screen, the combo and deck
+                    # list are already correct — firing on_archetypes_success
+                    # here would repopulate the combo and redundantly reload the
+                    # full deck list (a ~1.9s no-op with visible UI churn).
+                    # Skip it; the on-screen state is unchanged.
+                    if fmt_archetypes == self.archetypes:
+                        logger.debug(
+                            "Bundle archetypes unchanged for "
+                            f"{self.current_format} — skipping redundant reload"
+                        )
+                        return
+                    # Archetypes changed — use the in-memory copy from the bundle
+                    # (skip the disk read) and refresh the UI.
                     self.archetypes = fmt_archetypes
                     self.filtered_archetypes = fmt_archetypes
                     if callbacks:


### PR DESCRIPTION
## Summary
On cold start the 916-deck list was loaded twice: once by the optimistic startup archetype fetch (~+12.3s) and again after the remote client-bundle apply (~+20.9s→+22.7s). The bundle-apply branch in `_on_bundle_done` (`controllers/app_controller/lifecycle.py`) always called `callbacks.on_archetypes_success(...)`, which routes to `AppFrame._on_archetypes_loaded` and unconditionally ends with `self._load_decks(scope="all")` — a ~1.9s no-op with visible UI churn whenever the bundle brought the same archetypes that the optimistic load already put on screen. This change guards that branch: when the bundle's archetypes for the active format equal the already-loaded in-memory `self.archetypes`, it skips the success callback so the combo and deck list are left as-is. The changed-archetypes path (and the no-bundle fallback `fetch_archetypes`) is unchanged.

## Verification
- `python -m ruff check controllers/app_controller/lifecycle.py` — passed.
- `python -m black --check controllers/app_controller/lifecycle.py` — passed (no reformatting needed).
- `python -m py_compile controllers/app_controller/lifecycle.py` — passed.
- `python -m pytest tests/test_bundle_snapshot_client.py -q` — could NOT run in WSL: the test module transitively imports `utils.constants` → `utils.constants.keyboard` → `wx`, and `wx` is not importable off-Windows. No non-wx test covers the `_on_bundle_done` closure in isolation; it is a local closure inside `run_initial_loads`, so no focused unit test was added without refactoring (out of scope for this issue).
- NOT verified in WSL: the cold-start log behavior ("Loaded 916 decks for Any" appearing once vs. twice, "fully settled" dropping from ~22.7s toward ~12-13s). This requires running the app and the `python -m automation.cli open-app --wait` trace on Windows, which cannot be done here. The change is a pure equality guard with `logger.debug` on the skip path for trace confirmation.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)