### PR TITLE
perf(HI-2): conditional 304 + TTL for the client bundle snapshot

### DIFF
--- a/services/bundle_snapshot_client/http.py
+++ b/services/bundle_snapshot_client/http.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -18,23 +19,60 @@ class BundleSnapshotError(Exception):
     """Raised when the bundle cannot be downloaded or applied."""
 
 
+@dataclass(frozen=True)
+class BundleResponse:
+    """Outcome of a (conditional) bundle download.
+
+    ``not_modified`` is ``True`` when the server answered ``304 Not Modified``
+    to a conditional request, in which case ``content`` is ``None`` and the
+    expensive gunzip + tar-parse + SQLite merge can be skipped entirely.
+    """
+
+    content: bytes | None
+    not_modified: bool = False
+    etag: str | None = None
+    last_modified: str | None = None
+
+
 class DownloadMixin(_Base):
     """Download the compressed bundle archive over HTTP."""
 
-    def _download_bundle(self) -> bytes:
+    def _download_bundle(
+        self, etag: str | None = None, last_modified: str | None = None
+    ) -> BundleResponse:
         url = f"{self.base_url}/{self.bundle_path}"
-        data = self._http_get_bytes(url)
-        if data is None:
+        response = self._http_get_bytes(url, etag=etag, last_modified=last_modified)
+        if response is None or (response.content is None and not response.not_modified):
             raise BundleSnapshotError(f"Failed to download bundle from {url!r}")
-        return data
+        return response
 
-    def _http_get_bytes(self, url: str) -> bytes | None:
+    def _http_get_bytes(
+        self, url: str, etag: str | None = None, last_modified: str | None = None
+    ) -> BundleResponse | None:
+        headers: dict[str, str] = {}
+        if etag:
+            headers["If-None-Match"] = etag
+        if last_modified:
+            headers["If-Modified-Since"] = last_modified
+
         try:
             import curl_cffi.requests as requests  # type: ignore[import-untyped]
 
-            response = requests.get(url, impersonate="chrome", timeout=self.request_timeout)
+            response = requests.get(
+                url,
+                impersonate="chrome",
+                timeout=self.request_timeout,
+                headers=headers or None,
+            )
+            if response.status_code == 304:
+                logger.debug(f"Bundle unchanged (304) for {url!r}")
+                return BundleResponse(content=None, not_modified=True)
             response.raise_for_status()
-            return response.content
+            return BundleResponse(
+                content=response.content,
+                etag=response.headers.get("ETag"),
+                last_modified=response.headers.get("Last-Modified"),
+            )
         except ImportError:
             pass
         except Exception as exc:
@@ -42,14 +80,26 @@ class DownloadMixin(_Base):
             return None
 
         try:
+            from urllib.error import HTTPError
             from urllib.parse import urlparse
-            from urllib.request import urlopen
+            from urllib.request import Request, urlopen
 
             parsed = urlparse(url)
             if parsed.scheme not in ("https", "http"):
                 raise ValueError(f"Disallowed URL scheme: {parsed.scheme!r}")
-            with urlopen(url, timeout=self.request_timeout) as resp:  # nosec B310
-                return resp.read()
+            request = Request(url, headers=headers)  # nosec B310
+            try:
+                with urlopen(request, timeout=self.request_timeout) as resp:  # nosec B310
+                    return BundleResponse(
+                        content=resp.read(),
+                        etag=resp.headers.get("ETag"),
+                        last_modified=resp.headers.get("Last-Modified"),
+                    )
+            except HTTPError as http_exc:
+                if http_exc.code == 304:
+                    logger.debug(f"Bundle unchanged (304) for {url!r}")
+                    return BundleResponse(content=None, not_modified=True)
+                raise
         except Exception as exc:
             logger.debug(f"Bundle download (urllib) failed for {url!r}: {exc}")
             return None

--- a/services/bundle_snapshot_client/protocol.py
+++ b/services/bundle_snapshot_client/protocol.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from services.bundle_snapshot_client.http import BundleResponse
 
 
 class BundleSnapshotClientProto(Protocol):
@@ -19,6 +22,15 @@ class BundleSnapshotClientProto(Protocol):
     max_age: int
     request_timeout: int
 
-    def _http_get_bytes(self, url: str) -> bytes | None: ...
+    def _http_get_bytes(
+        self, url: str, etag: str | None = ..., last_modified: str | None = ...
+    ) -> BundleResponse | None: ...
+    def _read_stamp(self) -> dict[str, object]: ...
     def _is_stamp_fresh(self) -> bool: ...
-    def _write_stamp(self, generated_at: str, applied_at: float) -> None: ...
+    def _write_stamp(
+        self,
+        generated_at: str,
+        applied_at: float,
+        etag: str | None = ...,
+        last_modified: str | None = ...,
+    ) -> None: ...

--- a/services/bundle_snapshot_client/service.py
+++ b/services/bundle_snapshot_client/service.py
@@ -74,8 +74,35 @@ class BundleSnapshotClient(
             logger.debug("Bundle stamp is fresh — skipping download")
             return False, None
 
+        stamp = self._read_stamp()
+        stored_generated_at = str(stamp.get("generated_at", "")) if stamp else ""
+        stored_etag = stamp.get("etag") if stamp else None
+        stored_last_modified = stamp.get("last_modified") if stamp else None
+
+        logger.info("Revalidating remote client bundle…")
+        response = self._download_bundle(
+            etag=stored_etag if isinstance(stored_etag, str) else None,
+            last_modified=stored_last_modified if isinstance(stored_last_modified, str) else None,
+        )
+
+        now = time.time()
+
+        # 304 Not Modified — the multi-MB download + gunzip + tar-parse +
+        # SQLite merge are all skipped. Refresh applied_at so the cheap
+        # revalidation only recurs once per TTL.
+        if response.not_modified or response.content is None:
+            logger.debug("Bundle unchanged (304) — skipping download + merge")
+            self._write_stamp(
+                stored_generated_at,
+                now,
+                etag=stored_etag if isinstance(stored_etag, str) else None,
+                last_modified=(
+                    stored_last_modified if isinstance(stored_last_modified, str) else None
+                ),
+            )
+            return False, None
+
         logger.info("Downloading remote client bundle…")
-        bundle_bytes = self._download_bundle()
         (
             manifest,
             archetype_entries,
@@ -84,10 +111,22 @@ class BundleSnapshotClient(
             card_pool_entries,
             radar_entries,
             mtgo_decklist_entries,
-        ) = self._parse_bundle(bundle_bytes)
+        ) = self._parse_bundle(response.content)
 
         generated_at = manifest.get("generated_at", "")
-        now = time.time()
+
+        # Manifest short-circuit — the server did not honour the conditional
+        # request (no validators), but the downloaded bundle is identical to the
+        # one we already merged, so skip the expensive re-hydration.
+        if generated_at and generated_at == stored_generated_at:
+            logger.debug(f"Bundle generated_at unchanged ({generated_at!r}) — skipping merge")
+            self._write_stamp(
+                generated_at,
+                now,
+                etag=response.etag,
+                last_modified=response.last_modified,
+            )
+            return False, None
 
         self._hydrate_archetype_lists(archetype_entries, now)
         self._hydrate_archetype_decks(deck_entries, now)
@@ -95,7 +134,12 @@ class BundleSnapshotClient(
         card_pools = self._hydrate_format_card_pools(card_pool_entries)
         radars = self._hydrate_radars(radar_entries)
         inserted = self._hydrate_deck_texts(deck_texts)
-        self._write_stamp(generated_at, now)
+        self._write_stamp(
+            generated_at,
+            now,
+            etag=response.etag,
+            last_modified=response.last_modified,
+        )
 
         logger.info(
             f"Bundle applied: {len(archetype_entries)} archetype lists, "

--- a/services/bundle_snapshot_client/stamp.py
+++ b/services/bundle_snapshot_client/stamp.py
@@ -21,22 +21,46 @@ else:
 class StampMixin(_Base):
     """Stamp file read/write for bundle freshness tracking."""
 
-    def _is_stamp_fresh(self) -> bool:
+    def _read_stamp(self) -> dict[str, object]:
+        """Return the parsed stamp file, or ``{}`` when missing/unreadable."""
         if not self.stamp_file.exists():
-            return False
+            return {}
         try:
             data = json.loads(self.stamp_file.read_text(encoding="utf-8"))
-            applied_at = float(data.get("applied_at", 0))
-            return (time.time() - applied_at) < self.max_age
+            return data if isinstance(data, dict) else {}
         except (OSError, ValueError, json.JSONDecodeError) as exc:
             logger.debug(f"Could not read bundle stamp: {exc}")
-            return False
+            return {}
 
-    def _write_stamp(self, generated_at: str, applied_at: float) -> None:
+    def _is_stamp_fresh(self) -> bool:
+        data = self._read_stamp()
+        if not data:
+            return False
+        try:
+            applied_at = float(data.get("applied_at", 0))
+        except (TypeError, ValueError):
+            return False
+        return (time.time() - applied_at) < self.max_age
+
+    def _write_stamp(
+        self,
+        generated_at: str,
+        applied_at: float,
+        etag: str | None = None,
+        last_modified: str | None = None,
+    ) -> None:
+        payload: dict[str, object] = {
+            "generated_at": generated_at,
+            "applied_at": applied_at,
+        }
+        if etag:
+            payload["etag"] = etag
+        if last_modified:
+            payload["last_modified"] = last_modified
         try:
             REMOTE_SNAPSHOT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
             self.stamp_file.write_text(
-                json.dumps({"generated_at": generated_at, "applied_at": applied_at}, indent=2),
+                json.dumps(payload, indent=2),
                 encoding="utf-8",
             )
         except OSError as exc:

--- a/tests/test_bundle_snapshot_client.py
+++ b/tests/test_bundle_snapshot_client.py
@@ -19,6 +19,7 @@ from services.bundle_snapshot_client import (
     BundleSnapshotError,
     reset_bundle_snapshot_client,
 )
+from services.bundle_snapshot_client.http import BundleResponse
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -217,7 +218,7 @@ def test_stale_stamp_triggers_download(tmp_client: BundleSnapshotClient) -> None
         encoding="utf-8",
     )
     bundle = _make_bundle()
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         result = tmp_client.apply()
     updated, _ = result
     assert updated is True
@@ -225,10 +226,105 @@ def test_stale_stamp_triggers_download(tmp_client: BundleSnapshotClient) -> None
 
 def test_missing_stamp_triggers_download(tmp_client: BundleSnapshotClient) -> None:
     bundle = _make_bundle()
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         result = tmp_client.apply()
     updated, _ = result
     assert updated is True
+
+
+# ---------------------------------------------------------------------------
+# Conditional request (304) + manifest short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_stale_stamp_sends_conditional_headers(tmp_client: BundleSnapshotClient) -> None:
+    """A stale stamp with stored validators issues a conditional request."""
+    tmp_client.stamp_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_client.stamp_file.write_text(
+        json.dumps(
+            {
+                "applied_at": time.time() - 9999,
+                "generated_at": "2026-03-26T12:00:00Z",
+                "etag": '"abc123"',
+                "last_modified": "Thu, 26 Mar 2026 12:00:00 GMT",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with patch.object(
+        tmp_client,
+        "_http_get_bytes",
+        return_value=BundleResponse(content=None, not_modified=True),
+    ) as mock_get:
+        tmp_client.apply()
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["etag"] == '"abc123"'
+    assert kwargs["last_modified"] == "Thu, 26 Mar 2026 12:00:00 GMT"
+
+
+def test_not_modified_skips_merge_and_refreshes_stamp(tmp_client: BundleSnapshotClient) -> None:
+    """A 304 response skips the merge but refreshes applied_at so the TTL resets."""
+    tmp_client.stamp_file.parent.mkdir(parents=True, exist_ok=True)
+    old_applied = time.time() - 9999
+    tmp_client.stamp_file.write_text(
+        json.dumps(
+            {
+                "applied_at": old_applied,
+                "generated_at": "2026-03-26T12:00:00Z",
+                "etag": '"abc123"',
+            }
+        ),
+        encoding="utf-8",
+    )
+    with (
+        patch.object(
+            tmp_client,
+            "_http_get_bytes",
+            return_value=BundleResponse(content=None, not_modified=True),
+        ),
+        patch.object(tmp_client, "_parse_bundle") as mock_parse,
+    ):
+        updated, archetypes_by_format = tmp_client.apply()
+
+    mock_parse.assert_not_called()
+    assert updated is False
+    assert archetypes_by_format is None
+    stamp = json.loads(tmp_client.stamp_file.read_text())
+    assert stamp["generated_at"] == "2026-03-26T12:00:00Z"
+    assert stamp["etag"] == '"abc123"'
+    assert stamp["applied_at"] > old_applied  # refreshed -> TTL reset
+
+
+def test_unchanged_manifest_short_circuits_merge(tmp_client: BundleSnapshotClient) -> None:
+    """When the server ignores validators but generated_at is unchanged, skip the merge."""
+    tmp_client.stamp_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_client.stamp_file.write_text(
+        json.dumps({"applied_at": time.time() - 9999, "generated_at": "2026-03-26T12:00:00Z"}),
+        encoding="utf-8",
+    )
+    bundle = _make_bundle()  # default manifest generated_at == stored value
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
+        updated, archetypes_by_format = tmp_client.apply()
+
+    assert updated is False
+    assert archetypes_by_format is None
+
+
+def test_apply_persists_validators_in_stamp(tmp_client: BundleSnapshotClient) -> None:
+    """ETag / Last-Modified from a full download are persisted for the next request."""
+    bundle = _make_bundle()
+    response = BundleResponse(
+        content=bundle,
+        etag='"v2"',
+        last_modified="Fri, 27 Mar 2026 12:00:00 GMT",
+    )
+    with patch.object(tmp_client, "_http_get_bytes", return_value=response):
+        tmp_client.apply()
+
+    stamp = json.loads(tmp_client.stamp_file.read_text())
+    assert stamp["etag"] == '"v2"'
+    assert stamp["last_modified"] == "Fri, 27 Mar 2026 12:00:00 GMT"
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +334,7 @@ def test_missing_stamp_triggers_download(tmp_client: BundleSnapshotClient) -> No
 
 def test_apply_writes_archetype_list_cache(tmp_client: BundleSnapshotClient) -> None:
     bundle = _make_bundle()
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()
 
     data = json.loads(tmp_client.archetype_list_cache_file.read_text())
@@ -250,7 +346,7 @@ def test_apply_writes_archetype_list_cache(tmp_client: BundleSnapshotClient) -> 
 
 def test_apply_writes_archetype_decks_cache(tmp_client: BundleSnapshotClient) -> None:
     bundle = _make_bundle()
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()
 
     data = json.loads(tmp_client.archetype_decks_cache_file.read_text())
@@ -262,7 +358,7 @@ def test_apply_writes_archetype_decks_cache(tmp_client: BundleSnapshotClient) ->
 
 def test_apply_writes_stamp_file(tmp_client: BundleSnapshotClient) -> None:
     bundle = _make_bundle()
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()
 
     stamp = json.loads(tmp_client.stamp_file.read_text())
@@ -272,7 +368,7 @@ def test_apply_writes_stamp_file(tmp_client: BundleSnapshotClient) -> None:
 
 def test_apply_writes_format_card_pool_db(tmp_client: BundleSnapshotClient) -> None:
     bundle = _make_bundle()
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()
 
     repo = FormatCardPoolRepository(tmp_client.format_card_pool_db_file)
@@ -285,7 +381,7 @@ def test_apply_writes_format_card_pool_db(tmp_client: BundleSnapshotClient) -> N
 
 def test_apply_writes_radar_db(tmp_client: BundleSnapshotClient) -> None:
     bundle = _make_bundle()
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()
 
     repo = RadarRepository(tmp_client.radar_db_file)
@@ -302,7 +398,7 @@ def test_apply_merges_with_existing_archetype_list_cache(tmp_client: BundleSnaps
     tmp_client.archetype_list_cache_file.write_text(json.dumps(existing), encoding="utf-8")
 
     bundle = _make_bundle()
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()
 
     data = json.loads(tmp_client.archetype_list_cache_file.read_text())
@@ -326,7 +422,7 @@ def test_apply_multiple_formats(tmp_client: BundleSnapshotClient) -> None:
         },
     ]
     bundle = _make_bundle(archetypes=archetypes, decks=[])
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()
 
     data = json.loads(tmp_client.archetype_list_cache_file.read_text())
@@ -368,7 +464,7 @@ def test_malformed_archetype_entry_skipped(tmp_client: BundleSnapshotClient) -> 
         {"schema_version": "1", "kind": "archetype_list"},  # missing format
     ]
     bundle = _make_bundle(archetypes=archetypes, decks=[])
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()  # should not raise
 
     data = json.loads(tmp_client.archetype_list_cache_file.read_text())
@@ -386,7 +482,7 @@ def test_deck_entry_missing_href_skipped(tmp_client: BundleSnapshotClient) -> No
         }
     ]
     bundle = _make_bundle(decks=decks)
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()  # should not raise
 
 
@@ -403,7 +499,7 @@ def test_apply_hydrates_deck_text_cache(tmp_client: BundleSnapshotClient, tmp_pa
 
     bundle = _make_bundle()
     with (
-        patch.object(tmp_client, "_http_get_bytes", return_value=bundle),
+        patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)),
         patch("repositories.deck_text_cache.get_deck_cache", return_value=cache),
     ):
         tmp_client.apply()
@@ -424,7 +520,7 @@ def test_deck_text_hydration_skips_existing(
 
     bundle = _make_bundle()
     with (
-        patch.object(tmp_client, "_http_get_bytes", return_value=bundle),
+        patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)),
         patch("repositories.deck_text_cache.get_deck_cache", return_value=cache),
     ):
         tmp_client._hydrate_deck_texts([("1234", "4 Lightning Bolt\n", "mtggoldfish")])
@@ -445,7 +541,7 @@ def test_deck_text_entry_missing_deck_id_skipped(tmp_client: BundleSnapshotClien
         }
     ]
     bundle = _make_bundle(deck_texts=deck_texts)
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         tmp_client.apply()  # should not raise
 
 
@@ -456,7 +552,7 @@ def test_deck_text_entry_missing_deck_id_skipped(tmp_client: BundleSnapshotClien
 
 def test_apply_returns_archetypes_by_format(tmp_client: BundleSnapshotClient) -> None:
     bundle = _make_bundle()
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         updated, archetypes_by_format = tmp_client.apply()
 
     assert updated is True
@@ -483,7 +579,7 @@ def test_apply_returns_archetypes_for_all_formats(tmp_client: BundleSnapshotClie
         },
     ]
     bundle = _make_bundle(archetypes=archetypes, decks=[])
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         updated, archetypes_by_format = tmp_client.apply()
 
     assert updated is True
@@ -581,7 +677,7 @@ def test_apply_merges_mtgo_decklists_into_archetype_cache(
     cache = DeckTextCache(db_path=db_path)
     bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
 
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         with patch("repositories.deck_text_cache.get_deck_cache", return_value=cache):
             tmp_client.apply()
 
@@ -606,7 +702,7 @@ def test_apply_mtgo_deck_text_stored_in_cache(
     cache = DeckTextCache(db_path=db_path)
     bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
 
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         with patch("repositories.deck_text_cache.get_deck_cache", return_value=cache):
             tmp_client.apply()
 
@@ -625,7 +721,7 @@ def test_apply_mtgo_unmatched_archetype_skipped(
     cache = DeckTextCache(db_path=db_path)
     bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
 
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         with patch("repositories.deck_text_cache.get_deck_cache", return_value=cache):
             tmp_client.apply()
 
@@ -644,7 +740,7 @@ def test_apply_mtgo_preserves_goldfish_decks(
     cache = DeckTextCache(db_path=db_path)
     bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
 
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         with patch("repositories.deck_text_cache.get_deck_cache", return_value=cache):
             tmp_client.apply()
 
@@ -666,7 +762,7 @@ def test_apply_mtgo_deduplicates_on_re_hydration(
     cache = DeckTextCache(db_path=db_path)
     bundle = _make_bundle(mtgo_decklists=[_MTGO_DECKLIST_ENTRY])
 
-    with patch.object(tmp_client, "_http_get_bytes", return_value=bundle):
+    with patch.object(tmp_client, "_http_get_bytes", return_value=BundleResponse(content=bundle)):
         with patch("repositories.deck_text_cache.get_deck_cache", return_value=cache):
             tmp_client.apply()
             # Force a second apply by clearing the stamp

--- a/utils/constants/timing.py
+++ b/utils/constants/timing.py
@@ -54,8 +54,12 @@ BRIDGE_PROCESS_TERMINATE_TIMEOUT_SECONDS = 2
 REMOTE_SNAPSHOT_MAX_AGE_SECONDS = 2 * ONE_HOUR_SECONDS  # re-download if manifest is older than this
 REMOTE_SNAPSHOT_REQUEST_TIMEOUT_SECONDS = 30
 
-# Bundle snapshot — re-download bundle if stamp is older than this
-REMOTE_SNAPSHOT_BUNDLE_MAX_AGE_SECONDS = ONE_HOUR_SECONDS
+# Bundle snapshot — revalidate bundle if stamp is older than this.
+# Set to the real upstream regeneration cadence: a stale stamp triggers a
+# *conditional* request (If-None-Match / If-Modified-Since), so an unchanged
+# bundle returns 304 and skips the multi-MB download + merge entirely. The TTL
+# only bounds how often that cheap revalidation HEAD/GET round-trip happens.
+REMOTE_SNAPSHOT_BUNDLE_MAX_AGE_SECONDS = 6 * ONE_HOUR_SECONDS
 
 # SQLite cache settings
 SQLITE_CONNECTION_TIMEOUT_SECONDS = 30.0


### PR DESCRIPTION
## Summary

Stops re-downloading and re-merging the full client bundle on nearly every cold start. Previously the bundle download was unconditional, so an unchanged multi-MB bundle was re-downloaded, gunzipped, tar-parsed and re-merged into SQLite on each launch (~14.45s download + ~6.2s merge). The download helper now sends the stored `ETag`/`Last-Modified` as a conditional request (`If-None-Match`/`If-Modified-Since`); a `304 Not Modified` short-circuits the entire download + gunzip + tar-parse + SQLite merge. As a belt-and-suspenders fallback when the server ignores validators, the merge is also skipped when the downloaded manifest `generated_at` matches the stored stamp. On a 304 the stamp's `applied_at` is refreshed so the cheap revalidation only recurs once per TTL, and the stamp TTL is raised from 1h to 6h to match the upstream regeneration cadence. ETag/Last-Modified are now persisted in the stamp file alongside `generated_at`.

Files: `services/bundle_snapshot_client/http.py` (new `BundleResponse`, conditional headers + 304 handling for both curl_cffi and urllib paths), `services/bundle_snapshot_client/stamp.py` (`_read_stamp`, persist validators), `services/bundle_snapshot_client/service.py` (`apply()` revalidation + short-circuit), `services/bundle_snapshot_client/protocol.py`, `utils/constants/timing.py` (TTL 1h -> 6h).

## Verification

Run on Windows Python (3.13, wx available) via WSL interop:
- `python -m pytest tests/test_bundle_snapshot_client.py -q` -> 30 passed (includes 4 new tests: conditional headers sent, 304 skips merge + refreshes stamp, unchanged-manifest short-circuit, validators persisted).
- `python -m pytest tests/test_remote_snapshot_client.py -q` -> 16 passed.
- `python -m ruff check` and `python -m black --check` on all changed files: clean.
- `python -m py_compile` on changed modules: clean.

Not verified in WSL: the actual cold-start timing improvement and the real upstream server's ETag/Last-Modified/304 behavior, which depend on running the packaged app on Windows against the live snapshot host. The conditional-request and short-circuit logic is exercised by unit tests with mocked responses, but the end-to-end "second launch shows a fast 304 short-circuit" check (per the issue's Verify step) needs a real launch and was not performed here.

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)