### PR TITLE
perf(NTH-2): bulk radar hydration — one connection, one WAL transaction

### DIFF
--- a/repositories/radar_repository/writes.py
+++ b/repositories/radar_repository/writes.py
@@ -15,52 +15,107 @@ else:
     _Base = object
 
 
+_RadarRow = tuple[str, str, str, str, str, int, int]
+_CardRow = tuple[str, str, str, str, int, int, int, float, float, float, str]
+
+_INSERT_RADAR = """
+    INSERT INTO radars (
+        format_name,
+        archetype_href,
+        archetype_name,
+        generated_at,
+        source,
+        total_decks_analyzed,
+        decks_failed
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    """
+
+_INSERT_CARD = """
+    INSERT INTO radar_cards (
+        format_name,
+        archetype_href,
+        zone,
+        card_name,
+        appearances,
+        total_copies,
+        max_copies,
+        avg_copies,
+        inclusion_rate,
+        expected_copies,
+        copy_distribution_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+
+def _build_rows(entry: dict[str, Any]) -> tuple[str, str, _RadarRow, list[_CardRow]] | None:
+    """Normalize one snapshot ``entry`` into a radar row and its card rows.
+
+    Returns ``None`` when the entry lacks a usable format/archetype href.
+    """
+    format_name = str(entry.get("format", "")).strip().lower()
+    archetype = entry.get("archetype") or {}
+    if not isinstance(archetype, dict):
+        return None
+    archetype_href = str(archetype.get("href", "")).strip()
+    if not format_name or not archetype_href:
+        return None
+
+    radar_row: _RadarRow = (
+        format_name,
+        archetype_href,
+        str(archetype.get("name", "")).strip(),
+        str(entry.get("generated_at", "")).strip(),
+        str(entry.get("source", "")).strip(),
+        int(entry.get("total_decks_analyzed", 0) or 0),
+        int(entry.get("decks_failed", 0) or 0),
+    )
+
+    card_rows: list[_CardRow] = []
+    for zone, cards in (
+        ("mainboard", entry.get("mainboard_cards", []) or []),
+        ("sideboard", entry.get("sideboard_cards", []) or []),
+    ):
+        if not isinstance(cards, list):
+            continue
+        for card in cards:
+            if not isinstance(card, dict):
+                continue
+            card_name = str(card.get("card_name", "")).strip()
+            if not card_name:
+                continue
+            distribution = card.get("copy_distribution", {}) or {}
+            if not isinstance(distribution, dict):
+                distribution = {}
+            normalized_distribution = {
+                int(key): int(value) for key, value in distribution.items() if str(key).strip()
+            }
+            card_rows.append(
+                (
+                    format_name,
+                    archetype_href,
+                    zone,
+                    card_name,
+                    int(card.get("appearances", 0) or 0),
+                    int(card.get("total_copies", 0) or 0),
+                    int(card.get("max_copies", 0) or 0),
+                    float(card.get("avg_copies", 0.0) or 0.0),
+                    float(card.get("inclusion_rate", 0.0) or 0.0),
+                    float(card.get("expected_copies", 0.0) or 0.0),
+                    json.dumps(normalized_distribution, sort_keys=True),
+                )
+            )
+
+    return format_name, archetype_href, radar_row, card_rows
+
+
 class WritesMixin(_Base):
     """Bulk and per-archetype snapshot replacement."""
 
     def replace_radar(self, entry: dict[str, Any]) -> bool:
-        format_name = str(entry.get("format", "")).strip().lower()
-        archetype = entry.get("archetype") or {}
-        if not isinstance(archetype, dict):
+        built = _build_rows(entry)
+        if built is None:
             return False
-        archetype_href = str(archetype.get("href", "")).strip()
-        if not format_name or not archetype_href:
-            return False
-
-        card_rows: list[tuple[str, str, str, str, int, int, int, float, float, float, str]] = []
-        for zone, cards in (
-            ("mainboard", entry.get("mainboard_cards", []) or []),
-            ("sideboard", entry.get("sideboard_cards", []) or []),
-        ):
-            if not isinstance(cards, list):
-                continue
-            for card in cards:
-                if not isinstance(card, dict):
-                    continue
-                card_name = str(card.get("card_name", "")).strip()
-                if not card_name:
-                    continue
-                distribution = card.get("copy_distribution", {}) or {}
-                if not isinstance(distribution, dict):
-                    distribution = {}
-                normalized_distribution = {
-                    int(key): int(value) for key, value in distribution.items() if str(key).strip()
-                }
-                card_rows.append(
-                    (
-                        format_name,
-                        archetype_href,
-                        zone,
-                        card_name,
-                        int(card.get("appearances", 0) or 0),
-                        int(card.get("total_copies", 0) or 0),
-                        int(card.get("max_copies", 0) or 0),
-                        float(card.get("avg_copies", 0.0) or 0.0),
-                        float(card.get("inclusion_rate", 0.0) or 0.0),
-                        float(card.get("expected_copies", 0.0) or 0.0),
-                        json.dumps(normalized_distribution, sort_keys=True),
-                    )
-                )
+        format_name, archetype_href, radar_row, card_rows = built
 
         with self._connect() as conn:
             conn.execute("BEGIN")
@@ -72,54 +127,51 @@ class WritesMixin(_Base):
                 "DELETE FROM radars WHERE format_name = ? AND archetype_href = ?",
                 (format_name, archetype_href),
             )
-            conn.execute(
-                """
-                INSERT INTO radars (
-                    format_name,
-                    archetype_href,
-                    archetype_name,
-                    generated_at,
-                    source,
-                    total_decks_analyzed,
-                    decks_failed
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    format_name,
-                    archetype_href,
-                    str(archetype.get("name", "")).strip(),
-                    str(entry.get("generated_at", "")).strip(),
-                    str(entry.get("source", "")).strip(),
-                    int(entry.get("total_decks_analyzed", 0) or 0),
-                    int(entry.get("decks_failed", 0) or 0),
-                ),
-            )
-            conn.executemany(
-                """
-                INSERT INTO radar_cards (
-                    format_name,
-                    archetype_href,
-                    zone,
-                    card_name,
-                    appearances,
-                    total_copies,
-                    max_copies,
-                    avg_copies,
-                    inclusion_rate,
-                    expected_copies,
-                    copy_distribution_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                card_rows,
-            )
+            conn.execute(_INSERT_RADAR, radar_row)
+            conn.executemany(_INSERT_CARD, card_rows)
             conn.commit()
         return True
 
     def bulk_replace(self, entries: list[dict[str, Any]]) -> int:
-        replaced = 0
+        """Replace many radar snapshots in a single connection and transaction.
+
+        Hydration during bundle-apply rewrites hundreds of radars at once; doing
+        one connection setup and one fsync-backed commit per entry dominates the
+        bundle merge on the Windows-mounted DB. Accumulate all rows, then write
+        them under one WAL transaction so there is a single commit total.
+        """
+        radar_rows: list[_RadarRow] = []
+        card_rows: list[_CardRow] = []
+        keys: list[tuple[str, str]] = []
         for entry in entries:
             try:
-                replaced += int(self.replace_radar(entry))
+                built = _build_rows(entry)
             except Exception as exc:
                 logger.warning(f"Failed to replace radar snapshot: {exc}")
-        return replaced
+                continue
+            if built is None:
+                continue
+            format_name, archetype_href, radar_row, entry_cards = built
+            keys.append((format_name, archetype_href))
+            radar_rows.append(radar_row)
+            card_rows.extend(entry_cards)
+
+        if not radar_rows:
+            return 0
+
+        with self._connect() as conn:
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute("PRAGMA synchronous = NORMAL")
+            conn.execute("BEGIN")
+            conn.executemany(
+                "DELETE FROM radar_cards WHERE format_name = ? AND archetype_href = ?",
+                keys,
+            )
+            conn.executemany(
+                "DELETE FROM radars WHERE format_name = ? AND archetype_href = ?",
+                keys,
+            )
+            conn.executemany(_INSERT_RADAR, radar_rows)
+            conn.executemany(_INSERT_CARD, card_rows)
+            conn.commit()
+        return len(radar_rows)

--- a/tests/test_radar_bulk_replace.py
+++ b/tests/test_radar_bulk_replace.py
@@ -1,0 +1,107 @@
+"""Tests for the single-transaction bulk path of :class:`RadarRepository`."""
+
+from __future__ import annotations
+
+import pytest
+
+from repositories.radar_repository import RadarRepository
+
+
+def _radar(*, fmt: str, href: str, name: str, decks: int, mb: list[dict] | None = None) -> dict:
+    return {
+        "format": fmt,
+        "generated_at": "2026-05-01T00:00:00Z",
+        "source": "test",
+        "archetype": {"name": name, "href": href},
+        "total_decks_analyzed": decks,
+        "decks_failed": 0,
+        "mainboard_cards": mb or [],
+        "sideboard_cards": [],
+    }
+
+
+def _card(name: str, *, copies: int) -> dict:
+    return {
+        "card_name": name,
+        "appearances": copies,
+        "total_copies": copies * 2,
+        "max_copies": 4,
+        "avg_copies": 2.0,
+        "inclusion_rate": 0.5,
+        "expected_copies": 1.0,
+        "copy_distribution": {"4": copies},
+    }
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return RadarRepository(tmp_path / "radar_cache.db")
+
+
+def test_bulk_replace_persists_all_entries(repo):
+    entries = [
+        _radar(
+            fmt="modern", href="modern-burn", name="Burn", decks=10, mb=[_card("Bolt", copies=10)]
+        ),
+        _radar(fmt="modern", href="modern-prowess", name="Prowess", decks=20),
+        _radar(fmt="legacy", href="legacy-control", name="Control", decks=5),
+    ]
+
+    replaced = repo.bulk_replace(entries)
+
+    assert replaced == 3
+    burn = repo.get_radar("modern", "modern-burn")
+    assert burn is not None
+    assert burn.total_decks_analyzed == 10
+    assert [c.card_name for c in burn.mainboard_cards] == ["Bolt"]
+    assert repo.get_total_decks("modern") == 30
+    assert repo.get_total_decks("legacy") == 5
+
+
+def test_bulk_replace_skips_invalid_entries(repo):
+    entries = [
+        _radar(fmt="modern", href="modern-burn", name="Burn", decks=10),
+        {"format": "", "archetype": {"href": "x"}},  # missing format
+        {"format": "modern", "archetype": {"href": ""}},  # missing href
+        {"format": "modern", "archetype": "not-a-dict"},  # malformed archetype
+    ]
+
+    replaced = repo.bulk_replace(entries)
+
+    assert replaced == 1
+    assert repo.get_radar("modern", "modern-burn") is not None
+
+
+def test_bulk_replace_overwrites_existing_snapshot(repo):
+    repo.bulk_replace(
+        [
+            _radar(
+                fmt="modern",
+                href="modern-burn",
+                name="Burn",
+                decks=10,
+                mb=[_card("Bolt", copies=4)],
+            )
+        ]
+    )
+    # Re-hydrate with new data for the same key.
+    repo.bulk_replace(
+        [
+            _radar(
+                fmt="modern",
+                href="modern-burn",
+                name="Burn",
+                decks=99,
+                mb=[_card("Bolt", copies=8)],
+            )
+        ]
+    )
+
+    burn = repo.get_radar("modern", "modern-burn")
+    assert burn is not None
+    assert burn.total_decks_analyzed == 99
+    assert burn.mainboard_cards[0].appearances == 8
+
+
+def test_bulk_replace_empty_returns_zero(repo):
+    assert repo.bulk_replace([]) == 0


### PR DESCRIPTION
## Summary
Radar hydration during bundle-apply called `replace_radar` once per entry, opening a fresh SQLite connection and issuing an fsync-backed commit per radar (~498 connection setups + ~498 commits). On the `/mnt/c` Windows-mounted DB those per-call fsyncs dominate the ~14.45s bundle merge. `bulk_replace` now accumulates all radar/card rows, opens ONE connection with `PRAGMA journal_mode=WAL` + `synchronous=NORMAL`, and writes every delete/insert inside a single `BEGIN…COMMIT` via `executemany`, so there is one commit total instead of one per radar. The row-normalization logic is factored into a shared `_build_rows` helper; the per-archetype `replace_radar` live-update path keeps its original behavior unchanged.

## Verification
Run from WSL (the app runs on Windows; `wx` is not importable here):
- `python -m ruff check repositories/radar_repository/writes.py tests/test_radar_bulk_replace.py` — passed.
- `python -m black --check repositories/radar_repository/writes.py tests/test_radar_bulk_replace.py` — passed.
- `python -m py_compile` on both files — passed.
- Radar repository tests, run with a minimal `wx` stub because `utils.constants` transitively imports `wx` (the documented WSL limitation): `tests/test_radar_bulk_replace.py` (4 new tests: persistence, invalid-entry skipping, overwrite-on-rehydrate, empty input) and the existing `tests/test_radar_card_stats.py` — 9 passed.

Could NOT verify in WSL: the actual bundle-apply / `_hydrate_radars` timing on the Windows-mounted DB (the measure step `python -m automation.cli open-app --wait`), and any wx/UI behavior. CI on Windows should run the radar tests without the stub.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)