### PR TITLE
fix: collapse duplicate "Any" deck reload on archetype load

### DIFF
--- a/tests/ui/test_deck_selector.py
+++ b/tests/ui/test_deck_selector.py
@@ -72,6 +72,69 @@ def test_format_change_reloads_decks_with_any_selected(
 
 
 @pytest.mark.usefixtures("wx_app")
+def test_duplicate_archetype_delivery_skips_redundant_deck_reload(
+    deck_selector_factory,
+):
+    """Stale-while-revalidate delivers archetypes twice (cached, then a
+    background-refreshed copy). The second, identical delivery must NOT trigger
+    a second "Any" deck reload — that was the duplicate "Loading decks for Any"
+    seen on startup.
+    """
+    frame = deck_selector_factory()
+    try:
+        load_decks_calls: list[dict[str, object]] = []
+        original_load_decks = frame._load_decks
+
+        def recording_load_decks(**kwargs):
+            load_decks_calls.append(kwargs)
+            return original_load_decks(**kwargs)
+
+        frame._load_decks = recording_load_decks  # type: ignore[assignment]
+
+        archetypes = [
+            {"name": "Mono Red Aggro", "href": "mono-red-aggro"},
+            {"name": "Azorius Control", "href": "azorius-control"},
+        ]
+        frame._on_archetypes_loaded(archetypes)  # cached delivery
+        frame._on_archetypes_loaded(list(archetypes))  # background refresh (identical)
+        pump_ui_events(wx.GetApp())
+
+        assert load_decks_calls == [{"scope": "all"}]
+    finally:
+        frame.Destroy()
+
+
+@pytest.mark.usefixtures("wx_app")
+def test_load_decks_debounces_rapid_identical_target(
+    deck_selector_factory,
+):
+    """A second _load_decks for the same target within 1s is debounced, while a
+    different target fires immediately.
+    """
+    frame = deck_selector_factory()
+    try:
+        real_load_decks = type(frame)._load_decks
+        controller_calls: list[dict[str, object]] = []
+        original_ctrl_load = frame.controller.load_decks
+
+        def recording_ctrl_load(**kwargs):
+            controller_calls.append(kwargs)
+            return original_ctrl_load(**kwargs)
+
+        frame.controller.load_decks = recording_ctrl_load  # type: ignore[assignment]
+
+        real_load_decks(frame, scope="all")
+        real_load_decks(frame, scope="all")  # identical target, <1s → debounced
+        assert len(controller_calls) == 1
+
+        # A distinct target is never debounced.
+        real_load_decks(frame, scope="archetype", archetype={"name": "X", "href": "x"})
+        assert len(controller_calls) == 2
+    finally:
+        frame.Destroy()
+
+
+@pytest.mark.usefixtures("wx_app")
 def test_present_deck_text_updates_ui_without_download_io(
     deck_selector_factory,
 ):

--- a/widgets/frames/app_frame/frame/__init__.py
+++ b/widgets/frames/app_frame/frame/__init__.py
@@ -108,6 +108,13 @@ class AppFrame(
         self._pending_deck_restore: bool = False
         self._is_first_deck_load: bool = True
         self._all_loaded_decks: list[dict[str, Any]] = []
+        # Dedup state for the "Any" deck reload triggered on archetype load.
+        # Archetype fetch uses stale-while-revalidate, which delivers results
+        # twice (cached then background-refreshed); see _on_archetypes_loaded
+        # and _load_decks for the two guards that collapse the redundant load.
+        self._last_archetype_reload_sig: tuple[str, tuple[str, ...]] | None = None
+        self._last_deck_load_sig: tuple[str, str, str] | None = None
+        self._last_deck_load_time: float = 0.0
 
         self._build_ui()
         self._apply_window_preferences()

--- a/widgets/frames/app_frame/handlers/app_events.py
+++ b/widgets/frames/app_frame/handlers/app_events.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import threading
+import time
 from datetime import date, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -418,6 +419,21 @@ class AppEventHandlers(_Base):
         # so the list reflects the newly loaded format on startup and on every
         # format change — otherwise it shows stale results from the previous
         # format.
+        #
+        # Archetype fetch uses stale-while-revalidate, so this callback fires
+        # twice per fetch: once with the cached/stale list and again with the
+        # background-refreshed list. The "Any" deck list depends only on the
+        # format, not on the archetype contents, so reload decks only when the
+        # (format, archetype names) signature actually changes — this collapses
+        # the redundant second reload when the refresh returns identical data.
+        signature = (self.current_format, tuple(a.get("name", "") for a in self.archetypes))
+        if signature == self._last_archetype_reload_sig:
+            logger.debug(
+                "Archetypes unchanged for {fmt}; skipping redundant deck reload",
+                fmt=self.current_format,
+            )
+            return
+        self._last_archetype_reload_sig = signature
         self._load_decks(scope="all")
 
     def _on_archetypes_error(self: AppFrame, error: Exception) -> None:
@@ -881,6 +897,19 @@ class AppEventHandlers(_Base):
         else:
             wx.MessageBox("Archetype missing.", "Deck Error", wx.OK | wx.ICON_ERROR)
             return
+
+        # Debounce rapid duplicate loads: the same target (scope + format +
+        # name) firing twice within 1s is always redundant — e.g. the
+        # stale-while-revalidate double archetype delivery, or a flurry of
+        # selection events. Distinct targets are never debounced, so genuine
+        # navigation (format switch, archetype click) stays responsive.
+        signature = (scope, self.current_format, name)
+        now = time.monotonic()
+        if signature == self._last_deck_load_sig and (now - self._last_deck_load_time) < 1.0:
+            logger.debug("Debouncing duplicate deck load: {sig}", sig=signature)
+            return
+        self._last_deck_load_sig = signature
+        self._last_deck_load_time = now
 
         self._all_loaded_decks = []
         if not self._is_first_deck_load:

--- a/widgets/frames/app_frame/handlers/app_frame.py
+++ b/widgets/frames/app_frame/handlers/app_frame.py
@@ -304,6 +304,11 @@ class AppFrameHandlersMixin(_Base):
         self._apply_deck_filters()
 
     def fetch_archetypes(self, force: bool = False) -> None:
+        if force:
+            # An explicit reload must always refresh the deck list, even if the
+            # refreshed archetype list is byte-for-byte identical. Clearing the
+            # dedup signature lets _on_archetypes_loaded reload decks again.
+            self._last_archetype_reload_sig = None
         self.research_panel.set_loading_state()
         self.controller.deck_repo.clear_decks_list()
         self.deck_list.Clear()

--- a/widgets/frames/app_frame/protocol.py
+++ b/widgets/frames/app_frame/protocol.py
@@ -84,6 +84,9 @@ class AppFrameProto(Protocol):
     _pending_deck_restore: bool
     _is_first_deck_load: bool
     _all_loaded_decks: list[dict[str, Any]]
+    _last_archetype_reload_sig: tuple[str, tuple[str, ...]] | None
+    _last_deck_load_sig: tuple[str, str, str] | None
+    _last_deck_load_time: float
     _builder_search_pending: bool
     _search_seq: int
 


### PR DESCRIPTION
## Problem

On startup (and every format change) the status log showed **"Loading decks for Any…" twice**, each followed by "Loaded 742 decks for Any" — the full ~1.4s deck query ran twice.

### Root cause

The status line is *not* duplicated inside any method — `on_status(...loading_decks)` is emitted exactly once per accepted `controller.load_decks` call (`controllers/app_controller/archetypes.py:88`). Two log lines = **two real deck loads**.

The deck reload is triggered by `_on_archetypes_loaded` (`app_events.py`), which unconditionally calls `_load_decks(scope="all")`. That callback is the single `on_success` for the archetype fetch, and the fetch uses **stale-while-revalidate** (`repositories/metagame_repository/archetype_resolution.py:44-49`): it delivers the cached/stale archetype list *now* and re-delivers a background-refreshed list *later*. Both deliveries flow through `on_success` → `_on_archetypes_loaded` → `_load_decks`, so decks reload twice. The `loading_decks` guard doesn't collapse them because the second load fires just after the first completes.

## Fix

Two complementary guards (as requested):

1. **Content-equality skip** — `_on_archetypes_loaded` reloads decks only when the `(format, archetype names)` signature changes. The "Any" deck list depends only on the format, so the identical second delivery is skipped. `force=True` (the explicit reload button) clears the signature so it always refreshes.
2. **1s debounce** — `_load_decks` drops a load whose `(scope, format, name)` target matches the previous one within 1 second. Distinct targets (format switch, archetype click) are never debounced, so navigation stays responsive.

## Tests

- `test_duplicate_archetype_delivery_skips_redundant_deck_reload` — identical second archetype delivery triggers only one `_load_decks`.
- `test_load_decks_debounces_rapid_identical_target` — identical target within 1s is debounced; a distinct target fires immediately.
- Existing `test_format_change_reloads_decks_with_any_selected` still passes (format is part of the signature, so a genuine format switch always reloads).

`tests/ui/test_deck_selector.py`: **12 passed** locally (Windows wx). ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)