### PR TITLE
perf: persistent read connection + memoized format card-pool reads (#522)

### DIFF
--- a/repositories/format_card_pool_repository/protocol.py
+++ b/repositories/format_card_pool_repository/protocol.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 
 class FormatCardPoolRepositoryProto(Protocol):
     """Cross-mixin ``self`` surface for ``FormatCardPoolRepository``."""
 
     db_path: Path
+    _read_lock: threading.RLock
+    _summary_cache: dict[str, Any]
+    _card_total_cache: dict[tuple[str, str], int | None]
 
     def _connect(self) -> sqlite3.Connection: ...
+
+    def _read_connection(self) -> sqlite3.Connection: ...
+
+    def _invalidate_read_state(self) -> None: ...

--- a/repositories/format_card_pool_repository/reads.py
+++ b/repositories/format_card_pool_repository/reads.py
@@ -26,26 +26,34 @@ class ReadsMixin(_Base):
         fmt = format_name.strip().lower()
         if not fmt:
             return False
-        with self._connect() as conn:
-            row = conn.execute(
-                "SELECT 1 FROM format_card_pools WHERE format_name = ? LIMIT 1",
-                (fmt,),
-            ).fetchone()
+        with self._read_lock:
+            row = (
+                self._read_connection()
+                .execute(
+                    "SELECT 1 FROM format_card_pools WHERE format_name = ? LIMIT 1",
+                    (fmt,),
+                )
+                .fetchone()
+            )
         return row is not None
 
     def get_card_names(self, format_name: str) -> set[str]:
         fmt = format_name.strip().lower()
         if not fmt:
             return set()
-        with self._connect() as conn:
-            rows = conn.execute(
-                """
+        with self._read_lock:
+            rows = (
+                self._read_connection()
+                .execute(
+                    """
                 SELECT card_name
                 FROM format_card_pool_cards
                 WHERE format_name = ?
                 """,
-                (fmt,),
-            ).fetchall()
+                    (fmt,),
+                )
+                .fetchall()
+            )
         return {str(row[0]) for row in rows}
 
     def get_card_total(self, format_name: str, card_name: str) -> int | None:
@@ -56,48 +64,75 @@ class ReadsMixin(_Base):
         means "the snapshot didn't include this card at all" — the upstream
         bundle's pool sample is a filtered subset of legal cards, so missing
         rows are normal.
+
+        Hit on every card hover/selection, so results are memoized per
+        ``(format, card)`` and the cache is cleared on snapshot writes.
         """
         fmt = format_name.strip().lower()
         if not fmt or not card_name:
             return None
-        with self._connect() as conn:
-            row = conn.execute(
-                """
+        key = (fmt, card_name)
+        with self._read_lock:
+            cache = self._card_total_cache
+            if key in cache:
+                return cache[key]
+            row = (
+                self._read_connection()
+                .execute(
+                    """
                 SELECT copies_played
                 FROM format_card_pool_cards
                 WHERE format_name = ? AND card_name = ?
                 """,
-                (fmt, card_name),
-            ).fetchone()
-        return int(row[0]) if row else None
+                    (fmt, card_name),
+                )
+                .fetchone()
+            )
+            total = int(row[0]) if row else None
+            cache[key] = total
+        return total
 
     def get_top_cards(self, format_name: str, limit: int = 100) -> list[FormatCardPoolCardTotal]:
         fmt = format_name.strip().lower()
         if not fmt:
             return []
         limit = max(1, int(limit))
-        with self._connect() as conn:
-            rows = conn.execute(
-                """
+        with self._read_lock:
+            rows = (
+                self._read_connection()
+                .execute(
+                    """
                 SELECT card_name, copies_played
                 FROM format_card_pool_cards
                 WHERE format_name = ? AND copies_played > 0
                 ORDER BY copies_played DESC, card_name ASC
                 LIMIT ?
                 """,
-                (fmt, limit),
-            ).fetchall()
+                    (fmt, limit),
+                )
+                .fetchall()
+            )
         return [
             FormatCardPoolCardTotal(card_name=row[0], copies_played=int(row[1])) for row in rows
         ]
 
     def get_summary(self, format_name: str) -> FormatCardPoolSummary | None:
+        """Return the snapshot summary for a format.
+
+        Hit on every card hover/selection alongside :meth:`get_card_total`, so
+        the result is memoized per format and cleared on snapshot writes.
+        """
         fmt = format_name.strip().lower()
         if not fmt:
             return None
-        with self._connect() as conn:
-            row = conn.execute(
-                """
+        with self._read_lock:
+            cache = self._summary_cache
+            if fmt in cache:
+                return cache[fmt]
+            row = (
+                self._read_connection()
+                .execute(
+                    """
                 SELECT
                     p.format_name,
                     p.generated_at,
@@ -116,22 +151,29 @@ class ReadsMixin(_Base):
                     p.total_decks_analyzed,
                     p.decks_failed
                 """,
-                (fmt,),
-            ).fetchone()
-        if row is None:
-            return None
-        return FormatCardPoolSummary(
-            format_name=str(row[0]),
-            generated_at=str(row[1]),
-            source=str(row[2]),
-            total_decks_analyzed=int(row[3]),
-            decks_failed=int(row[4]),
-            unique_cards=int(row[5]),
-        )
+                    (fmt,),
+                )
+                .fetchone()
+            )
+            if row is None:
+                cache[fmt] = None
+                return None
+            summary = FormatCardPoolSummary(
+                format_name=str(row[0]),
+                generated_at=str(row[1]),
+                source=str(row[2]),
+                total_decks_analyzed=int(row[3]),
+                decks_failed=int(row[4]),
+                unique_cards=int(row[5]),
+            )
+            cache[fmt] = summary
+        return summary
 
     def list_formats(self) -> list[str]:
-        with self._connect() as conn:
-            rows = conn.execute(
-                "SELECT format_name FROM format_card_pools ORDER BY format_name ASC"
-            ).fetchall()
+        with self._read_lock:
+            rows = (
+                self._read_connection()
+                .execute("SELECT format_name FROM format_card_pools ORDER BY format_name ASC")
+                .fetchall()
+            )
         return [str(row[0]) for row in rows]

--- a/repositories/format_card_pool_repository/schema.py
+++ b/repositories/format_card_pool_repository/schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from typing import TYPE_CHECKING
 
 from utils.constants import SQLITE_CONNECTION_TIMEOUT_SECONDS
@@ -21,6 +22,11 @@ class SchemaMixin(_Base):
     """SQLite connection helper and table bootstrap."""
 
     def _initialize(self) -> None:
+        # Lock guards the shared read connection and the read-side memo caches.
+        self._read_lock = threading.RLock()
+        self._read_conn_obj: sqlite3.Connection | None = None
+        self._summary_cache = {}
+        self._card_total_cache = {}
         with self._connect() as conn:
             conn.executescript("""
                 CREATE TABLE IF NOT EXISTS format_card_pools (
@@ -49,3 +55,40 @@ class SchemaMixin(_Base):
         conn = sqlite3.connect(self.db_path, timeout=SQLITE_CONNECTION_TIMEOUT_SECONDS)
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
+
+    def _read_connection(self) -> sqlite3.Connection:
+        """Return a persistent connection reused across read queries.
+
+        Reopening a fresh ``sqlite3.connect`` per query dominates the cost of
+        the small lookups issued on every card hover/selection, so reads share
+        a single long-lived connection. ``check_same_thread=False`` lets the
+        background worker reuse it too; all access is serialized via
+        ``self._read_lock``.
+        """
+        conn = self._read_conn_obj
+        if conn is None:
+            conn = sqlite3.connect(
+                self.db_path,
+                timeout=SQLITE_CONNECTION_TIMEOUT_SECONDS,
+                check_same_thread=False,
+            )
+            conn.execute("PRAGMA foreign_keys = ON")
+            self._read_conn_obj = conn
+        return conn
+
+    def _invalidate_read_state(self) -> None:
+        """Drop memoized reads and recycle the shared read connection.
+
+        Called after writes so the next read observes the new snapshot rather
+        than a stale cached value or a connection holding an old read view.
+        """
+        with self._read_lock:
+            self._summary_cache.clear()
+            self._card_total_cache.clear()
+            conn = self._read_conn_obj
+            self._read_conn_obj = None
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass

--- a/repositories/format_card_pool_repository/writes.py
+++ b/repositories/format_card_pool_repository/writes.py
@@ -76,6 +76,9 @@ class WritesMixin(_Base):
                 ],
             )
             conn.commit()
+        # The snapshot changed; drop memoized reads and recycle the shared
+        # read connection so subsequent reads observe the new data.
+        self._invalidate_read_state()
         return True
 
     def bulk_replace(self, entries: list[dict[str, Any]]) -> int:

--- a/tests/test_format_card_pool_repository.py
+++ b/tests/test_format_card_pool_repository.py
@@ -1,0 +1,115 @@
+"""Tests for FormatCardPoolRepository read caching and connection reuse.
+
+Covers issue #522: reads share a persistent SQLite connection and memoize the
+hover/selection hot path (``get_card_total`` / ``get_summary``), and writes
+invalidate that state so the next read sees the new snapshot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repositories.format_card_pool_repository import FormatCardPoolRepository
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return FormatCardPoolRepository(db_path=tmp_path / "format_card_pool.db")
+
+
+def _entry(format_name="modern", cards=None, copy_totals=None):
+    return {
+        "format": format_name,
+        "generated_at": "2026-05-29",
+        "source": "test",
+        "total_decks_analyzed": 10,
+        "decks_failed": 0,
+        "cards": cards if cards is not None else ["Lightning Bolt", "Brainstorm"],
+        "copy_totals": (
+            copy_totals
+            if copy_totals is not None
+            else [{"card_name": "Lightning Bolt", "copies_played": 40}]
+        ),
+    }
+
+
+def test_get_card_total_and_summary_basic(repo):
+    assert repo.replace_format_pool(_entry()) is True
+
+    assert repo.get_card_total("modern", "Lightning Bolt") == 40
+    # tracked but never played -> 0, not None
+    assert repo.get_card_total("modern", "Brainstorm") == 0
+    # absent from snapshot -> None
+    assert repo.get_card_total("modern", "Nonexistent Card") is None
+
+    summary = repo.get_summary("modern")
+    assert summary is not None
+    assert summary.unique_cards == 2
+    assert summary.total_decks_analyzed == 10
+
+
+def test_read_connection_is_persistent(repo):
+    repo.replace_format_pool(_entry())
+    repo.get_card_total("modern", "Lightning Bolt")
+    first = repo._read_conn_obj
+    assert first is not None
+    repo.get_summary("modern")
+    assert repo._read_conn_obj is first
+
+
+def test_card_total_is_memoized(repo):
+    repo.replace_format_pool(_entry())
+    repo.get_card_total("modern", "Lightning Bolt")
+    assert ("modern", "Lightning Bolt") in repo._card_total_cache
+    # Mutate the row directly via a separate connection; the memoized value
+    # must persist until an explicit invalidation.
+    with repo._connect() as conn:
+        conn.execute(
+            "UPDATE format_card_pool_cards SET copies_played = 999 "
+            "WHERE format_name = ? AND card_name = ?",
+            ("modern", "Lightning Bolt"),
+        )
+        conn.commit()
+    assert repo.get_card_total("modern", "Lightning Bolt") == 40
+
+
+def test_summary_negative_lookup_is_cached(repo):
+    assert repo.get_summary("legacy") is None
+    assert "legacy" in repo._summary_cache
+    assert repo._summary_cache["legacy"] is None
+
+
+def test_write_invalidates_read_caches(repo):
+    repo.replace_format_pool(_entry())
+    assert repo.get_card_total("modern", "Lightning Bolt") == 40
+    assert repo.get_summary("modern").unique_cards == 2
+    prev_conn = repo._read_conn_obj
+
+    # New snapshot for the same format with different data.
+    repo.replace_format_pool(
+        _entry(
+            cards=["Lightning Bolt"],
+            copy_totals=[{"card_name": "Lightning Bolt", "copies_played": 7}],
+        )
+    )
+
+    assert repo._card_total_cache == {}
+    assert repo._summary_cache == {}
+    assert repo._read_conn_obj is None or repo._read_conn_obj is not prev_conn
+
+    assert repo.get_card_total("modern", "Lightning Bolt") == 7
+    assert repo.get_card_total("modern", "Brainstorm") is None
+    assert repo.get_summary("modern").unique_cards == 1
+
+
+def test_bulk_replace_invalidates(repo):
+    repo.replace_format_pool(_entry())
+    assert repo.get_card_total("modern", "Lightning Bolt") == 40
+    repo.bulk_replace(
+        [
+            _entry(
+                copy_totals=[{"card_name": "Lightning Bolt", "copies_played": 3}],
+            )
+        ]
+    )
+    assert repo.get_card_total("modern", "Lightning Bolt") == 3


### PR DESCRIPTION
## Summary

Card hover (after the 120ms debounce) and selection both reach `_set_format_stats`, which issues up to two `get_card_total` calls plus one `get_summary` against `FormatCardPoolRepository`. Each read previously opened a fresh `sqlite3.connect` + PRAGMA, and that connect/teardown overhead — not the queries — dominated, costing ~39ms median per settled hover on the main thread and hitching paint/scroll. This PR makes the repository reuse a single long-lived read connection (`check_same_thread=False`, serialized with an `RLock` so background workers can share it) instead of reopening per query, and memoizes the hover/selection hot path: `(format -> summary)` and `(format, card -> total)`. Writes (`replace_format_pool` / `bulk_replace`) clear the memo caches and recycle the read connection so the next read observes the new snapshot. This is the lower-risk option (1) from the issue.

## Verification

- `python -m ruff check` on all changed files: passed.
- `python -m black --check` on all changed files: passed (after formatting).
- Added `tests/test_format_card_pool_repository.py` (6 tests: basic lookups including tracked-0 vs absent-None, persistent-connection reuse, `(format, card)` memoization, negative-summary caching, and cache+connection invalidation on `replace_format_pool` and `bulk_replace`). These tests pass locally — but note `utils.constants` transitively imports `wx`, which is not importable in WSL, so the suite was run here only with a temporary local `wx` stub (the stub is NOT part of this change). On Windows CI the tests run normally, matching the existing repository tests (e.g. `test_metagame_repository.py`) which have the same wx-import dependency.
- NOT verified in WSL: actual wx UI behavior / perceived hover-scroll smoothness, and the before/after hover timing measurement on a populated `cache/format_card_pool.db` (requires the running app on Windows).

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)