### PR TITLE
fix: shut image service down on reset to stop daemon-thread leak (CI _enter_buffered_busy crash)

### DIFF
--- a/services/image_service/__init__.py
+++ b/services/image_service/__init__.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 # after the module became a package.
 import time  # noqa: F401
 
+from loguru import logger
+
 from services.image_service.disk_cache import CardImageCache
 from services.image_service.download_queue import CardImageDownloadQueue
 from services.image_service.downloader import (
@@ -60,8 +62,21 @@ def get_image_service() -> ImageService:
 
 
 def reset_image_service() -> None:
-    """Reset the global image service (use in tests for isolation)."""
+    """Reset the global image service (use in tests for isolation).
+
+    Shut the live instance down before dropping it so its background
+    download-queue daemon thread and ThreadPoolExecutor are joined/cancelled
+    rather than leaked. A leaked daemon thread that is still running (e.g.
+    mid-download) at interpreter shutdown can throw and then deadlock on the
+    stderr buffer lock during finalization — the ``_enter_buffered_busy``
+    fatal error that crashed CI even when every test passed.
+    """
     global _default_service
+    if _default_service is not None:
+        try:
+            _default_service.shutdown()
+        except Exception as exc:  # pragma: no cover - defensive teardown
+            logger.warning(f"Image service shutdown during reset failed: {exc}")
     _default_service = None
 
 


### PR DESCRIPTION
## Problem

CI on `main` (Windows) intermittently crashed with:

```
Exception in thread Thread-59 (worker):
Fatal Python error: _enter_buffered_busy: could not acquire lock for
<_io.BufferedWriter name='<stderr>'> at interpreter shutdown, possibly
due to daemon threads
```

**Every test passed** — the crash happens *after* pytest reports success, during interpreter finalization, and on Windows that produces a non-zero exit code, so the CI step goes red.

### Root cause

`reset_image_service()` (run by the autouse `reset_global_state` fixture after **every** test) only did `_default_service = None`. It never called `.shutdown()`, so the `ImageService`'s background `card-image-download-queue` daemon thread and its `ThreadPoolExecutor` were **leaked**. Across a session these accumulate (hence `Thread-59`).

A leaked daemon thread still running — e.g. mid-download — at interpreter shutdown throws and then deadlocks acquiring the stderr buffer lock during finalization → `_enter_buffered_busy` → `abort()`.

### Why CI-only

It's a shutdown-timing race. On the CI runner the background network calls (deck/image scrapes) hang or fail slowly, so threads are still in-flight at exit. Locally they finish first, so the interpreter exits cleanly.

## Fix

`reset_image_service()` now shuts the live instance down before dropping the reference. `ImageService.shutdown()` does a bounded `join` on the queue thread, `executor.shutdown(wait=False, cancel_futures=True)`, and terminates worker processes — all safe to call unconditionally. Each test now drains the thread instead of leaking it.

## Verification

- `py_compile` + `ruff` clean.
- 49 image-service tests pass (Windows Python).
- Direct check: `card-image-download-queue` thread is alive after `get_image_service()`, and **gone** after `reset_image_service()` (was leaked before).

## Scope

Targets the dominant leaker (image service — the only resettable singleton exposing a real `shutdown()`). Other untracked daemon threads (`archetype-bg-*`, widget-handler `worker` threads) aren't owned by resettable globals and are out of scope here. If flakiness persists, a session-teardown `logger.remove()` would neutralize the crash regardless of which thread leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)