### PR TITLE
refactor: extract match_history compute kernels into properties.py

### DIFF
--- a/tests/test_match_history_metrics.py
+++ b/tests/test_match_history_metrics.py
@@ -1,0 +1,166 @@
+"""Tests for the wx-free compute kernels of the match history viewer.
+
+These cover the pure functions extracted from
+``widgets/frames/match_history/handlers.py`` into ``properties.py``:
+``resolve_match_perspective``, ``compute_history_metrics`` and
+``compute_opponent_stats``. ``wx`` is not importable in the WSL dev
+environment and the package ``__init__`` pulls in the wx-dependent frame, so
+``properties.py`` is loaded directly by file path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+from pathlib import Path
+
+
+def _load_properties_module() -> types.ModuleType:
+    """Import the match history ``properties.py`` directly by file path."""
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "widgets"
+        / "frames"
+        / "match_history"
+        / "properties.py"
+    )
+    spec = importlib.util.spec_from_file_location("_mh_properties_under_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_props = _load_properties_module()
+resolve_match_perspective = _props.resolve_match_perspective
+compute_history_metrics = _props.compute_history_metrics
+compute_opponent_stats = _props.compute_opponent_stats
+
+
+# ----------------------------------------------------------------- resolve_match_perspective
+def test_resolve_perspective_player1_is_us() -> None:
+    match = {
+        "players": ["me", "them"],
+        "winner": "me",
+        "match_score": "2-1",
+        "player1_archetype": "Burn",
+        "player2_archetype": "Control",
+        "player1_mulligans": [1, 0],
+        "player2_mulligans": [0],
+    }
+    out = resolve_match_perspective(match, "me")
+    assert out["our_name"] == "me"
+    assert out["opp_name"] == "them"
+    assert out["our_archetype"] == "Burn"
+    assert out["opp_archetype"] == "Control"
+    assert out["our_mulligans"] == [1, 0]
+    assert out["our_score"] == 2
+    assert out["opp_score"] == 1
+    assert out["we_won"] is True
+
+
+def test_resolve_perspective_player2_is_us() -> None:
+    match = {
+        "players": ["them", "me"],
+        "winner": "them",
+        "match_score": "2-0",
+        "player1_archetype": "Control",
+        "player2_archetype": "Burn",
+        "player1_mulligans": [0],
+        "player2_mulligans": [1, 1],
+    }
+    out = resolve_match_perspective(match, "ME")  # case-insensitive
+    assert out["our_name"] == "me"
+    assert out["opp_name"] == "them"
+    assert out["our_archetype"] == "Burn"
+    assert out["our_mulligans"] == [1, 1]
+    assert out["our_score"] == 0
+    assert out["opp_score"] == 2
+    assert out["we_won"] is False
+
+
+def test_resolve_perspective_no_username_defaults_to_player1() -> None:
+    match = {"players": ["a", "b"], "winner": "b", "match_score": "1-2"}
+    out = resolve_match_perspective(match, None)
+    assert out["our_name"] == "a"
+    assert out["opp_name"] == "b"
+    assert out["our_score"] == 1
+    assert out["opp_score"] == 2
+    assert out["we_won"] is False
+
+
+def test_resolve_perspective_bad_score_falls_back_to_zero() -> None:
+    out = resolve_match_perspective({"players": ["a", "b"], "match_score": "??"}, None)
+    assert out["our_score"] == 0
+    assert out["opp_score"] == 0
+
+
+# -------------------------------------------------------------------- compute_history_metrics
+def _metric(match_win: bool, won: int, total: int, mulls: int) -> dict[str, object]:
+    return {
+        "match_win": match_win,
+        "games_won": won,
+        "games_total": total,
+        "total_mulligans": mulls,
+    }
+
+
+def test_compute_history_metrics_empty_returns_none() -> None:
+    assert compute_history_metrics([], []) is None
+
+
+def test_compute_history_metrics_aggregates() -> None:
+    matches = [
+        _metric(True, 2, 3, 1),
+        _metric(False, 1, 2, 2),
+    ]
+    out = compute_history_metrics(matches, matches)
+    assert out is not None
+    assert out["total_matches"] == 2
+    assert out["match_wins"] == 1
+    assert out["games_won"] == 3
+    assert out["games_played"] == 5
+    assert out["total_mulligans"] == 3
+    assert out["games_with_data"] == 5
+    assert out["match_rate"] == 50.0
+    assert out["game_rate"] == 60.0
+    assert out["mulligan_rate"] == 60.0
+    assert out["avg_mulligans_per_match"] == 1.5
+    assert out["filtered"] is not None
+    assert out["filtered"]["match_total"] == 2
+
+
+def test_compute_history_metrics_unfiltered_filtered_is_none() -> None:
+    matches = [_metric(True, 2, 2, 0)]
+    out = compute_history_metrics(matches, [])
+    assert out is not None
+    assert out["filtered"] is None
+
+
+def test_compute_history_metrics_zero_games_no_div_by_zero() -> None:
+    matches = [_metric(False, 0, 0, 0)]
+    out = compute_history_metrics(matches, matches)
+    assert out is not None
+    assert out["game_rate"] == 0.0
+    assert out["mulligan_rate"] == 0.0
+    assert out["games_with_data"] == 0
+
+
+# --------------------------------------------------------------------- compute_opponent_stats
+def test_compute_opponent_stats_empty_returns_none() -> None:
+    assert compute_opponent_stats([]) is None
+
+
+def test_compute_opponent_stats_aggregates() -> None:
+    metrics = [
+        _metric(True, 2, 3, 1),
+        _metric(False, 0, 2, 0),
+    ]
+    out = compute_opponent_stats(metrics)
+    assert out is not None
+    assert out["total"] == 2
+    assert out["wins"] == 1
+    assert out["total_mulligans"] == 1
+    assert out["games_played"] == 5
+    assert out["win_pct"] == 50.0
+    assert out["mull_rate"] == 20.0

--- a/widgets/frames/match_history/handlers.py
+++ b/widgets/frames/match_history/handlers.py
@@ -9,6 +9,12 @@ import wx
 import wx.dataview as dv
 from loguru import logger
 
+from widgets.frames.match_history.properties import (
+    compute_history_metrics,
+    compute_opponent_stats,
+    resolve_match_perspective,
+)
+
 
 class MatchHistoryHandlersMixin:
     """Callbacks and worker-thread bridges for :class:`MatchHistoryFrame`."""
@@ -91,52 +97,18 @@ class MatchHistoryHandlersMixin:
             if not isinstance(match, dict):
                 continue
 
-            players = match.get("players", [])
-            winner = match.get("winner")
-            match_score_str = match.get("match_score", "?-?")
             timestamp = match.get("timestamp")
             date_str = timestamp.strftime("%Y-%m-%d %H:%M") if timestamp else "Unknown"
 
-            player1_name = players[0] if len(players) > 0 else "Unknown"
-            player2_name = players[1] if len(players) > 1 else "Unknown"
-            player1_archetype = match.get("player1_archetype", "Unknown")
-            player2_archetype = match.get("player2_archetype", "Unknown")
-
-            try:
-                score_parts = match_score_str.split("-")
-                player1_score = int(score_parts[0])
-                player2_score = int(score_parts[1])
-            except (ValueError, IndexError):
-                player1_score = 0
-                player2_score = 0
-
-            if self.current_username:
-                if player1_name.lower() == self.current_username.lower():
-                    our_name = player1_name
-                    opp_name = player2_name
-                    our_archetype = player1_archetype
-                    opp_archetype = player2_archetype
-                    our_mulligans = match.get("player1_mulligans", [])
-                    our_score = player1_score
-                    opp_score = player2_score
-                else:
-                    our_name = player2_name
-                    opp_name = player1_name
-                    our_archetype = player2_archetype
-                    opp_archetype = player1_archetype
-                    our_mulligans = match.get("player2_mulligans", [])
-                    our_score = player2_score
-                    opp_score = player1_score
-            else:
-                our_name = player1_name
-                opp_name = player2_name
-                our_archetype = player1_archetype
-                opp_archetype = player2_archetype
-                our_mulligans = match.get("player1_mulligans", [])
-                our_score = player1_score
-                opp_score = player2_score
-
-            we_won = winner == our_name
+            perspective = resolve_match_perspective(match, self.current_username)
+            our_name = perspective["our_name"]
+            opp_name = perspective["opp_name"]
+            our_archetype = perspective["our_archetype"]
+            opp_archetype = perspective["opp_archetype"]
+            our_mulligans = perspective["our_mulligans"]
+            our_score = perspective["our_score"]
+            opp_score = perspective["opp_score"]
+            we_won = perspective["we_won"]
 
             total_mulls = sum(our_mulligans) if our_mulligans else 0
             mull_detail = ", ".join(str(m) for m in our_mulligans) if our_mulligans else "0"
@@ -230,19 +202,18 @@ class MatchHistoryHandlersMixin:
             self._clear_opp_stats()
             return
 
-        metrics = self._iter_matches(matches)
-        total = len(metrics)
-        wins = sum(1 for m in metrics if m["match_win"])
-        total_mulls = sum(m["total_mulligans"] for m in metrics)
-        games_played = sum(m["games_total"] for m in metrics)
-        win_pct = (wins / total * 100) if total else 0.0
-        mull_rate = (total_mulls / games_played * 100) if games_played else 0.0
+        stats = compute_opponent_stats(self._iter_matches(matches))
+        if not stats:
+            self._clear_opp_stats()
+            return
 
         self.opp_match_rate_label.SetLabel(
-            f"Vs. {opp_name} Match Win Rate: {win_pct:.1f}% ({wins}/{total})"
+            f"Vs. {opp_name} Match Win Rate: {stats['win_pct']:.1f}%"
+            f" ({stats['wins']}/{stats['total']})"
         )
         self.opp_mull_rate_label.SetLabel(
-            f"Vs. {opp_name} Mull Rate: {mull_rate:.1f}%" f" ({total_mulls}/{games_played} games)"
+            f"Vs. {opp_name} Mull Rate: {stats['mull_rate']:.1f}%"
+            f" ({stats['total_mulligans']}/{stats['games_played']} games)"
         )
 
     def _clear_opp_stats(self) -> None:
@@ -264,35 +235,6 @@ class MatchHistoryHandlersMixin:
             self.avg_mulligans_label.SetLabel(f"{self._t('match.metrics.avg_mulligans')}: \u2014")
             return
 
-        total_matches = len(matches)
-        match_wins = sum(1 for match in matches if match["match_win"])
-        games_won = sum(match["games_won"] for match in matches)
-        games_played = sum(match["games_total"] for match in matches)
-
-        total_mulligans = sum(match["total_mulligans"] for match in matches)
-        games_with_data = sum(match["games_total"] for match in matches if match["games_total"] > 0)
-        mulligan_rate = (total_mulligans / games_with_data * 100) if games_with_data else 0.0
-        avg_mulligans_per_match = total_mulligans / total_matches if total_matches else 0.0
-
-        match_rate = (match_wins / total_matches) * 100 if total_matches else 0.0
-        game_rate = (games_won / games_played) * 100 if games_played else 0.0
-
-        self.match_rate_label.SetLabel(
-            f"{self._t('match.metrics.abs_match_rate')}: {match_rate:.1f}%"
-            f" ({match_wins}/{total_matches})"
-        )
-        self.game_rate_label.SetLabel(
-            f"{self._t('match.metrics.abs_game_rate')}: {game_rate:.1f}%"
-            f" ({games_won}/{games_played or 1})"
-        )
-        self.mulligan_rate_label.SetLabel(
-            f"{self._t('match.metrics.mulligan_rate')}: {mulligan_rate:.1f}%"
-            f" ({total_mulligans}/{games_with_data} games)"
-        )
-        self.avg_mulligans_label.SetLabel(
-            f"{self._t('match.metrics.avg_mulligans')}: {avg_mulligans_per_match:.2f}"
-        )
-
         start = self._parse_date_input(self.start_date_ctrl.GetValue())
         end = self._parse_date_input(self.end_date_ctrl.GetValue())
         if start or end:
@@ -300,21 +242,35 @@ class MatchHistoryHandlersMixin:
         else:
             filtered = matches
 
-        if filtered:
-            filtered_match_wins = sum(1 for match in filtered if match["match_win"])
-            filtered_games_won = sum(match["games_won"] for match in filtered)
-            filtered_games_total = sum(match["games_total"] for match in filtered)
-            filtered_match_rate = (filtered_match_wins / len(filtered)) * 100
-            filtered_game_rate = (
-                (filtered_games_won / filtered_games_total) * 100 if filtered_games_total else 0.0
-            )
+        metrics = compute_history_metrics(matches, filtered)
+
+        self.match_rate_label.SetLabel(
+            f"{self._t('match.metrics.abs_match_rate')}: {metrics['match_rate']:.1f}%"
+            f" ({metrics['match_wins']}/{metrics['total_matches']})"
+        )
+        self.game_rate_label.SetLabel(
+            f"{self._t('match.metrics.abs_game_rate')}: {metrics['game_rate']:.1f}%"
+            f" ({metrics['games_won']}/{metrics['games_played'] or 1})"
+        )
+        self.mulligan_rate_label.SetLabel(
+            f"{self._t('match.metrics.mulligan_rate')}: {metrics['mulligan_rate']:.1f}%"
+            f" ({metrics['total_mulligans']}/{metrics['games_with_data']} games)"
+        )
+        self.avg_mulligans_label.SetLabel(
+            f"{self._t('match.metrics.avg_mulligans')}: {metrics['avg_mulligans_per_match']:.2f}"
+        )
+
+        filtered_metrics = metrics["filtered"]
+        if filtered_metrics:
             self.filtered_match_rate_label.SetLabel(
-                f"{self._t('match.metrics.filtered_match_rate')}: {filtered_match_rate:.1f}%"
-                f" ({filtered_match_wins}/{len(filtered)})"
+                f"{self._t('match.metrics.filtered_match_rate')}:"
+                f" {filtered_metrics['match_rate']:.1f}%"
+                f" ({filtered_metrics['match_wins']}/{filtered_metrics['match_total']})"
             )
             self.filtered_game_rate_label.SetLabel(
-                f"{self._t('match.metrics.filtered_game_rate')}: {filtered_game_rate:.1f}%"
-                f" ({filtered_games_won}/{filtered_games_total})"
+                f"{self._t('match.metrics.filtered_game_rate')}:"
+                f" {filtered_metrics['game_rate']:.1f}%"
+                f" ({filtered_metrics['games_won']}/{filtered_metrics['games_total']})"
             )
         else:
             self.filtered_match_rate_label.SetLabel(

--- a/widgets/frames/match_history/properties.py
+++ b/widgets/frames/match_history/properties.py
@@ -11,6 +11,154 @@ if TYPE_CHECKING:
     pass
 
 
+# --------------------------------------------------------------------------- pure kernels
+# The functions below are wx-free and depend only on their arguments so they can
+# be unit-tested off-Windows. The mixin methods are thin wrappers around them.
+
+
+def resolve_match_perspective(
+    match: dict[str, Any], current_username: str | None
+) -> dict[str, Any]:
+    """Resolve a single match from "our" perspective.
+
+    Given a raw match dict and the current username, derive the names,
+    archetypes, mulligans and scores for "us" vs the opponent. When the
+    username is unknown (or does not match either player), player 1 is
+    treated as "us". Pure: no wx, no ``self`` state.
+    """
+    players = match.get("players", [])
+    winner = match.get("winner")
+
+    player1_name = players[0] if len(players) > 0 else "Unknown"
+    player2_name = players[1] if len(players) > 1 else "Unknown"
+    player1_archetype = match.get("player1_archetype", "Unknown")
+    player2_archetype = match.get("player2_archetype", "Unknown")
+
+    match_score_str = match.get("match_score", "?-?")
+    try:
+        score_parts = match_score_str.split("-")
+        player1_score = int(score_parts[0])
+        player2_score = int(score_parts[1])
+    except (ValueError, IndexError, AttributeError):
+        player1_score = 0
+        player2_score = 0
+
+    use_player2 = bool(current_username and player1_name.lower() != current_username.lower())
+    if use_player2:
+        our_name = player2_name
+        opp_name = player1_name
+        our_archetype = player2_archetype
+        opp_archetype = player1_archetype
+        our_mulligans = match.get("player2_mulligans", [])
+        our_score = player2_score
+        opp_score = player1_score
+    else:
+        our_name = player1_name
+        opp_name = player2_name
+        our_archetype = player1_archetype
+        opp_archetype = player2_archetype
+        our_mulligans = match.get("player1_mulligans", [])
+        our_score = player1_score
+        opp_score = player2_score
+
+    return {
+        "our_name": our_name,
+        "opp_name": opp_name,
+        "our_archetype": our_archetype,
+        "opp_archetype": opp_archetype,
+        "our_mulligans": our_mulligans,
+        "our_score": our_score,
+        "opp_score": opp_score,
+        "we_won": winner == our_name,
+    }
+
+
+def compute_history_metrics(
+    matches: list[dict[str, Any]], filtered: list[dict[str, Any]]
+) -> dict[str, Any] | None:
+    """Compute aggregate history metrics from per-match metric dicts.
+
+    ``matches`` and ``filtered`` are lists of the dicts produced by
+    :meth:`MatchHistoryPropertiesMixin._iter_matches`. Returns ``None`` when
+    ``matches`` is empty (nothing to display). Pure: no wx, no ``self`` state.
+    """
+    if not matches:
+        return None
+
+    total_matches = len(matches)
+    match_wins = sum(1 for match in matches if match["match_win"])
+    games_won = sum(match["games_won"] for match in matches)
+    games_played = sum(match["games_total"] for match in matches)
+
+    total_mulligans = sum(match["total_mulligans"] for match in matches)
+    games_with_data = sum(match["games_total"] for match in matches if match["games_total"] > 0)
+    mulligan_rate = (total_mulligans / games_with_data * 100) if games_with_data else 0.0
+    avg_mulligans_per_match = total_mulligans / total_matches if total_matches else 0.0
+
+    match_rate = (match_wins / total_matches) * 100 if total_matches else 0.0
+    game_rate = (games_won / games_played) * 100 if games_played else 0.0
+
+    result: dict[str, Any] = {
+        "total_matches": total_matches,
+        "match_wins": match_wins,
+        "games_won": games_won,
+        "games_played": games_played,
+        "total_mulligans": total_mulligans,
+        "games_with_data": games_with_data,
+        "mulligan_rate": mulligan_rate,
+        "avg_mulligans_per_match": avg_mulligans_per_match,
+        "match_rate": match_rate,
+        "game_rate": game_rate,
+        "filtered": None,
+    }
+
+    if filtered:
+        filtered_match_wins = sum(1 for match in filtered if match["match_win"])
+        filtered_games_won = sum(match["games_won"] for match in filtered)
+        filtered_games_total = sum(match["games_total"] for match in filtered)
+        filtered_match_rate = (filtered_match_wins / len(filtered)) * 100
+        filtered_game_rate = (
+            (filtered_games_won / filtered_games_total) * 100 if filtered_games_total else 0.0
+        )
+        result["filtered"] = {
+            "match_wins": filtered_match_wins,
+            "match_total": len(filtered),
+            "games_won": filtered_games_won,
+            "games_total": filtered_games_total,
+            "match_rate": filtered_match_rate,
+            "game_rate": filtered_game_rate,
+        }
+
+    return result
+
+
+def compute_opponent_stats(metrics: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Aggregate per-match metric dicts into opponent win/mulligan stats.
+
+    ``metrics`` is a list of the dicts produced by
+    :meth:`MatchHistoryPropertiesMixin._iter_matches`, already filtered to a
+    single opponent. Returns ``None`` when empty. Pure: no wx, no ``self`` state.
+    """
+    if not metrics:
+        return None
+
+    total = len(metrics)
+    wins = sum(1 for m in metrics if m["match_win"])
+    total_mulls = sum(m["total_mulligans"] for m in metrics)
+    games_played = sum(m["games_total"] for m in metrics)
+    win_pct = (wins / total * 100) if total else 0.0
+    mull_rate = (total_mulls / games_played * 100) if games_played else 0.0
+
+    return {
+        "total": total,
+        "wins": wins,
+        "total_mulligans": total_mulls,
+        "games_played": games_played,
+        "win_pct": win_pct,
+        "mull_rate": mull_rate,
+    }
+
+
 class MatchHistoryPropertiesMixin:
     """Getters, state setters, and pure-data helpers for :class:`MatchHistoryFrame`.
 


### PR DESCRIPTION
## Summary
Extracts the pure computation that was inlined alongside wx event handling in the two overlong `MatchHistoryHandlersMixin` methods into three wx-free, unit-testable module-level functions in `widgets/frames/match_history/properties.py`: `resolve_match_perspective` (per-match perspective resolution used by `_populate_history`), `compute_history_metrics` (absolute + date-filtered aggregate rates used by `_update_metrics`), and `compute_opponent_stats` (opponent aggregates used by `_update_opp_stats`). The handlers now call these helpers, shrinking the overlong methods while keeping the mixin's public surface stable. The change is behavior-preserving — the only formatting difference is concatenated f-strings that render identically to the originals.

## Verification
- `python -m ruff check` on the two changed source files and the new test: passed.
- `python -m black --check` on the same files: passed (no reformat needed).
- `python -m py_compile widgets/frames/match_history/handlers.py widgets/frames/match_history/properties.py`: passed.
- Added `tests/test_match_history_metrics.py` (10 tests) exercising all three extracted kernels, including empty-input, division-by-zero, case-insensitive username matching, player1/player2 perspective, and filtered vs unfiltered metrics. `python -m pytest tests/test_match_history_metrics.py -q`: 10 passed. The test loads `properties.py` by file path because the package `__init__` imports the wx-dependent frame.
- NOT verified in WSL: actual wx label rendering and the live match-history viewer behavior — `wx` is not importable here and the GUI runs only on Windows. The handler methods that call the kernels could not be executed (they require wx); their formatting was reviewed by hand and matches the originals.

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
