### PR TITLE
refactor: decompose card_image_display/handlers.py into loader/animation/renderer mixins + protocol.py

### DIFF
--- a/widgets/panels/card_image_display/animation.py
+++ b/widgets/panels/card_image_display/animation.py
@@ -1,0 +1,59 @@
+"""Fade-transition animation timer loop for the card image display widget."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import wx
+
+from utils.constants import (
+    CARD_IMAGE_ANIMATION_ALPHA_STEP,
+    CARD_IMAGE_ANIMATION_INTERVAL_MS,
+)
+
+if TYPE_CHECKING:
+    from widgets.panels.card_image_display.protocol import CardImageDisplayProto
+
+    _Base = CardImageDisplayProto
+else:
+    _Base = object
+
+
+class _AnimationMixin(_Base):
+    """Drives the cross-fade between the current and target card bitmaps."""
+
+    def _start_fade_animation(self, target_bitmap: wx.Bitmap) -> None:
+        # Cancel any existing animation
+        if self.animation_timer and self.animation_timer.IsRunning():
+            self.animation_timer.Stop()
+
+        # Set up animation state
+        self.animation_current_bitmap = self.bitmap_ctrl.GetBitmap()
+        self.animation_target_bitmap = target_bitmap
+        self.animation_alpha = 0.0
+
+        # Create and start timer (60 FPS)
+        self.animation_timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self._on_animation_tick, self.animation_timer)
+        self.animation_timer.Start(CARD_IMAGE_ANIMATION_INTERVAL_MS)  # ~60 FPS
+
+    def _on_animation_tick(self, event: wx.TimerEvent) -> None:
+        # Increment alpha (fade speed)
+        self.animation_alpha += CARD_IMAGE_ANIMATION_ALPHA_STEP
+
+        if self.animation_alpha >= 1.0:
+            # Animation complete
+            self.animation_timer.Stop()
+            self.bitmap_ctrl.SetBitmap(self.animation_target_bitmap)
+            self.animation_current_bitmap = None
+            self.animation_target_bitmap = None
+            self.Refresh()
+            return
+
+        # Create blended bitmap
+        blended = self._blend_bitmaps(
+            self.animation_current_bitmap, self.animation_target_bitmap, self.animation_alpha
+        )
+
+        self.bitmap_ctrl.SetBitmap(blended)
+        self.Refresh()

--- a/widgets/panels/card_image_display/bitmap_renderer.py
+++ b/widgets/panels/card_image_display/bitmap_renderer.py
@@ -1,0 +1,157 @@
+"""Bitmap rendering (canvas, border, flip icon, placeholder) for the card image display widget."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import wx
+
+from utils.constants import (
+    CARD_IMAGE_FLIP_ICON_TEXT_SCALE,
+    CARD_IMAGE_PLACEHOLDER_INSET,
+)
+
+if TYPE_CHECKING:
+    from widgets.panels.card_image_display.protocol import CardImageDisplayProto
+
+    _Base = CardImageDisplayProto
+else:
+    _Base = object
+
+
+class _BitmapRendererMixin(_Base):
+    """Composites the card canvas, anti-aliased border, flip icon and placeholder bitmaps."""
+
+    def _create_rounded_bitmap(self, masked_image: wx.Image) -> wx.Bitmap:
+        """Composite a pre-masked card image onto the dark, bordered canvas.
+
+        ``masked_image`` must already have its rounded-corner alpha applied
+        (done off-thread in :meth:`_decode_image_worker`); this method performs
+        only the UI-thread DC compositing of the background, border and flip
+        icon.
+        """
+        # Create a bitmap canvas
+        bitmap = wx.Bitmap(self.image_width, self.image_height)
+        dc = wx.MemoryDC(bitmap)
+
+        # Fill background with parent color
+        bg_color = self.GetParent().GetBackgroundColour()
+        dc.SetBackground(wx.Brush(bg_color))
+        dc.Clear()
+
+        # Draw dark background rounded rectangle
+        dc.SetPen(wx.Pen(wx.Colour(40, 40, 40), 1))
+        dc.SetBrush(wx.Brush(wx.Colour(40, 40, 40)))
+        dc.DrawRoundedRectangle(0, 0, self.image_width, self.image_height, self.corner_radius)
+
+        # Center the image
+        img_width = masked_image.GetWidth()
+        img_height = masked_image.GetHeight()
+        x = (self.image_width - img_width) // 2
+        y = (self.image_height - img_height) // 2
+
+        # Draw the (already masked) image
+        dc.DrawBitmap(wx.Bitmap(masked_image), x, y, True)
+
+        # Draw border using GraphicsContext for smooth anti-aliased edges
+        gc = wx.GraphicsContext.Create(dc)
+        if gc:
+            gc.SetPen(wx.Pen(wx.Colour(60, 60, 60), 1))
+            gc.SetBrush(wx.TRANSPARENT_BRUSH)
+            path = gc.CreatePath()
+            path.AddRoundedRectangle(
+                0.5, 0.5, self.image_width - 1, self.image_height - 1, self.corner_radius
+            )
+            gc.DrawPath(path)
+
+            # Draw flip icon overlay if enabled
+            if self.show_flip_icon_overlay:
+                self._draw_flip_icon_on_gc(gc)
+        else:
+            # Fallback border without antialiasing
+            dc.SetPen(wx.Pen(wx.Colour(60, 60, 60), 1))
+            dc.SetBrush(wx.TRANSPARENT_BRUSH)
+            dc.DrawRoundedRectangle(0, 0, self.image_width, self.image_height, self.corner_radius)
+
+        dc.SelectObject(wx.NullBitmap)
+        return bitmap
+
+    def _draw_flip_icon_on_gc(self, gc: wx.GraphicsContext) -> None:
+        # Calculate icon position (top-left corner)
+        icon_x = self.flip_icon_margin
+        icon_y = self.flip_icon_margin
+
+        # Draw semi-transparent shadow effect
+        # Outer shadow
+        gc.SetBrush(
+            gc.CreateRadialGradientBrush(
+                icon_x + self.flip_icon_size / 2,
+                icon_y + self.flip_icon_size / 2 + 2,
+                icon_x + self.flip_icon_size / 2,
+                icon_y + self.flip_icon_size / 2 + 2,
+                self.flip_icon_size / 2 + 2,
+                wx.Colour(0, 0, 0, 100),  # semi-transparent black shadow
+                wx.Colour(0, 0, 0, 0),  # fully transparent
+            )
+        )
+        gc.SetPen(wx.TRANSPARENT_PEN)
+        gc.DrawEllipse(icon_x - 2, icon_y, self.flip_icon_size + 4, self.flip_icon_size + 4)
+
+        # Main background circle (black with semi-transparency)
+        gc.SetBrush(
+            gc.CreateRadialGradientBrush(
+                icon_x + self.flip_icon_size / 2,
+                icon_y + self.flip_icon_size / 2,
+                icon_x + self.flip_icon_size / 2,
+                icon_y + self.flip_icon_size / 2,
+                self.flip_icon_size / 2,
+                wx.Colour(40, 40, 40, 220),  # center: dark gray, semi-transparent
+                wx.Colour(20, 20, 20, 200),  # edge: darker gray, semi-transparent
+            )
+        )
+        gc.SetPen(wx.Pen(wx.Colour(80, 80, 80, 200), 2))
+        gc.DrawEllipse(icon_x, icon_y, self.flip_icon_size, self.flip_icon_size)
+
+        # Draw the flip icon text (yellow)
+        font_size = int(self.flip_icon_size * CARD_IMAGE_FLIP_ICON_TEXT_SCALE)
+        font = wx.Font(wx.FontInfo(font_size).Bold())
+        gc.SetFont(font, wx.Colour(255, 220, 0, 255))  # Yellow text, opaque
+
+        text = "⟳"
+        tw, th = gc.GetTextExtent(text)
+        text_x = icon_x + (self.flip_icon_size - tw) / 2
+        text_y = icon_y + (self.flip_icon_size - th) / 2
+        gc.DrawText(text, text_x, text_y)
+
+    def _create_placeholder_bitmap(self, text: str) -> wx.Bitmap:
+        bitmap = wx.Bitmap(self.image_width, self.image_height)
+        dc = wx.MemoryDC(bitmap)
+
+        # Background
+        bg_color = self.GetParent().GetBackgroundColour()
+        dc.SetBackground(wx.Brush(bg_color))
+        dc.Clear()
+
+        # Draw rounded rectangle
+        dc.SetPen(wx.Pen(wx.Colour(80, 80, 80), 2))
+        dc.SetBrush(wx.Brush(wx.Colour(50, 50, 50)))
+        dc.DrawRoundedRectangle(
+            CARD_IMAGE_PLACEHOLDER_INSET,
+            CARD_IMAGE_PLACEHOLDER_INSET,
+            self.image_width - (CARD_IMAGE_PLACEHOLDER_INSET * 2),
+            self.image_height - (CARD_IMAGE_PLACEHOLDER_INSET * 2),
+            self.corner_radius,
+        )
+
+        # Draw text
+        dc.SetTextForeground(wx.Colour(150, 150, 150))
+        font = wx.Font(12, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
+        dc.SetFont(font)
+
+        text_width, text_height = dc.GetTextExtent(text)
+        text_x = (self.image_width - text_width) // 2
+        text_y = (self.image_height - text_height) // 2
+        dc.DrawText(text, text_x, text_y)
+
+        dc.SelectObject(wx.NullBitmap)
+        return bitmap

--- a/widgets/panels/card_image_display/frame.py
+++ b/widgets/panels/card_image_display/frame.py
@@ -19,11 +19,21 @@ from utils.constants import (
     CARD_IMAGE_FLIP_ICON_MARGIN,
     CARD_IMAGE_FLIP_ICON_SIZE,
 )
+from widgets.panels.card_image_display.animation import _AnimationMixin
+from widgets.panels.card_image_display.bitmap_renderer import _BitmapRendererMixin
 from widgets.panels.card_image_display.handlers import CardImageDisplayHandlersMixin
+from widgets.panels.card_image_display.image_loader import _ImageLoaderMixin
 from widgets.panels.card_image_display.properties import CardImageDisplayPropertiesMixin
 
 
-class CardImageDisplay(CardImageDisplayHandlersMixin, CardImageDisplayPropertiesMixin, wx.Panel):
+class CardImageDisplay(
+    CardImageDisplayHandlersMixin,
+    _ImageLoaderMixin,
+    _AnimationMixin,
+    _BitmapRendererMixin,
+    CardImageDisplayPropertiesMixin,
+    wx.Panel,
+):
     """A panel that displays MTG card images with navigation and animations."""
 
     def __init__(

--- a/widgets/panels/card_image_display/handlers.py
+++ b/widgets/panels/card_image_display/handlers.py
@@ -1,41 +1,28 @@
-"""Event handlers, workers, public state setters, and bitmap renderers for the card image display widget."""
+"""Public state setters and input/event callbacks for the card image display widget."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from threading import Thread
+from typing import TYPE_CHECKING
 
 import wx
-from loguru import logger
 
-from utils.constants import (
-    CARD_IMAGE_ANIMATION_ALPHA_STEP,
-    CARD_IMAGE_ANIMATION_INTERVAL_MS,
-    CARD_IMAGE_FLIP_ICON_TEXT_SCALE,
-    CARD_IMAGE_PLACEHOLDER_INSET,
-)
-from utils.perf import timed
+if TYPE_CHECKING:
+    from widgets.panels.card_image_display.protocol import CardImageDisplayProto
+
+    _Base = CardImageDisplayProto
+else:
+    _Base = object
 
 
-class CardImageDisplayHandlersMixin:
-    """Event callbacks, public state setters, UI populators, and bitmap renderers for :class:`CardImageDisplay`."""
+class CardImageDisplayHandlersMixin(_Base):
+    """Public state setters and input/event callbacks for :class:`CardImageDisplay`.
 
-    # Attributes supplied by :class:`CardImageDisplay` / the properties mixin.
-    image_width: int
-    image_height: int
-    corner_radius: int
-    show_flip_icon_overlay: bool
-    flip_icon_size: int
-    flip_icon_margin: int
-    image_paths: list[Path]
-    current_index: int
-    _image_load_gen: int
-    animation_timer: wx.Timer | None
-    animation_alpha: float
-    animation_target_bitmap: wx.Bitmap | None
-    animation_current_bitmap: wx.Bitmap | None
-    bitmap_ctrl: wx.StaticBitmap
-    image_panel: wx.Panel
+    The heavier concerns live in peer mixins: off-thread image loading in
+    :class:`_ImageLoaderMixin`, the fade-transition loop in
+    :class:`_AnimationMixin`, and bitmap rendering in
+    :class:`_BitmapRendererMixin`.
+    """
 
     def show_placeholder(self, text: str = "No image") -> None:
         self.image_paths = []
@@ -67,125 +54,6 @@ class CardImageDisplayHandlersMixin:
 
     def show_image(self, image_path: Path) -> bool:
         return self.show_images([image_path] if image_path else [])
-
-    def _load_image_at_index(self, index: int, animate: bool = True) -> bool:
-        """Kick off an off-thread decode/scale/mask, then composite on the UI thread.
-
-        The expensive work (``wx.Image`` decode, high-quality ``Scale`` and the
-        PIL/numpy rounded-corner masking) runs in a background thread so rapid
-        card selection / face flips / printing navigation do not hitch the UI.
-        Only the lightweight DC compositing + ``SetBitmap`` runs on the main
-        thread, marshalled via :func:`wx.CallAfter`. Mirrors the off-thread
-        pattern in ``card_table_panel/pile_view.py``.
-
-        Returns ``True`` when a load was dispatched (the path exists and is in
-        range); the actual decode result is applied asynchronously.
-        """
-        if not 0 <= index < len(self.image_paths):
-            return False
-
-        image_path = self.image_paths[index]
-
-        # Bump the generation so any in-flight decode for a previous image is
-        # discarded when it reaches the UI thread.
-        self._image_load_gen += 1
-        gen = self._image_load_gen
-
-        Thread(
-            target=self._decode_image_worker,
-            args=(gen, image_path, animate),
-            daemon=True,
-        ).start()
-        return True
-
-    @timed
-    def _decode_image_worker(self, gen: int, image_path: Path, animate: bool) -> None:
-        """Background worker: decode, scale and rounded-corner mask ``image_path``.
-
-        Produces a ready ``wx.Image`` and marshals the final composite back to
-        the UI thread. No wx UI objects are touched here — ``wx.Image`` is a
-        plain pixel container and the masking is pure PIL/numpy.
-        """
-        try:
-            img = wx.Image(str(image_path), wx.BITMAP_TYPE_ANY)
-            if not img.IsOk():
-                logger.debug(f"Failed to load image: {image_path}")
-                return
-
-            # Scale to fit while maintaining aspect ratio.
-            img_width = img.GetWidth()
-            img_height = img.GetHeight()
-            scale = min(self.image_width / img_width, self.image_height / img_height)
-            new_width = int(img_width * scale)
-            new_height = int(img_height * scale)
-            img = img.Scale(new_width, new_height, wx.IMAGE_QUALITY_HIGH)
-
-            # Apply the rounded-corner alpha mask off-thread (PIL/numpy only).
-            masked_image = self._apply_rounded_corners_to_image(img, self.corner_radius)
-        except Exception as exc:
-            logger.exception(f"Error loading image {image_path}: {exc}")
-            return
-
-        wx.CallAfter(self._apply_decoded_image, gen, masked_image, animate)
-
-    def _apply_decoded_image(self, gen: int, masked_image: wx.Image, animate: bool) -> None:
-        """UI-thread: composite the pre-masked image and display it.
-
-        Discards stale results via the generation counter so only the most
-        recent request is shown.
-        """
-        if gen != self._image_load_gen:
-            return
-        try:
-            # Composite background, border and flip icon around the masked image.
-            bitmap = self._create_rounded_bitmap(masked_image)
-
-            # Display with or without animation.
-            if animate and self.bitmap_ctrl.GetBitmap().IsOk():
-                self._start_fade_animation(bitmap)
-            else:
-                self.bitmap_ctrl.SetBitmap(bitmap)
-                self.Refresh()
-        except RuntimeError:
-            # Widget was destroyed (e.g. during app shutdown) while a
-            # CallAfter callback was still pending – silently bail out.
-            return
-
-    def _start_fade_animation(self, target_bitmap: wx.Bitmap) -> None:
-        # Cancel any existing animation
-        if self.animation_timer and self.animation_timer.IsRunning():
-            self.animation_timer.Stop()
-
-        # Set up animation state
-        self.animation_current_bitmap = self.bitmap_ctrl.GetBitmap()
-        self.animation_target_bitmap = target_bitmap
-        self.animation_alpha = 0.0
-
-        # Create and start timer (60 FPS)
-        self.animation_timer = wx.Timer(self)
-        self.Bind(wx.EVT_TIMER, self._on_animation_tick, self.animation_timer)
-        self.animation_timer.Start(CARD_IMAGE_ANIMATION_INTERVAL_MS)  # ~60 FPS
-
-    def _on_animation_tick(self, event: wx.TimerEvent) -> None:
-        # Increment alpha (fade speed)
-        self.animation_alpha += CARD_IMAGE_ANIMATION_ALPHA_STEP
-
-        if self.animation_alpha >= 1.0:
-            # Animation complete
-            self.animation_timer.Stop()
-            self.bitmap_ctrl.SetBitmap(self.animation_target_bitmap)
-            self.animation_current_bitmap = None
-            self.animation_target_bitmap = None
-            self.Refresh()
-            return
-
-        # Create blended bitmap
-        blended = self._blend_bitmaps(
-            self.animation_current_bitmap, self.animation_target_bitmap, self.animation_alpha
-        )
-
-        self.bitmap_ctrl.SetBitmap(blended)
-        self.Refresh()
 
     def _update_navigation(self) -> None:
         has_alternate_face = len(self.image_paths) > 1
@@ -235,140 +103,6 @@ class CardImageDisplayHandlersMixin:
         self.current_index = (self.current_index + 1) % len(self.image_paths)
         self._load_image_at_index(self.current_index, animate=True)
         self._update_navigation()
-
-    def _create_rounded_bitmap(self, masked_image: wx.Image) -> wx.Bitmap:
-        """Composite a pre-masked card image onto the dark, bordered canvas.
-
-        ``masked_image`` must already have its rounded-corner alpha applied
-        (done off-thread in :meth:`_decode_image_worker`); this method performs
-        only the UI-thread DC compositing of the background, border and flip
-        icon.
-        """
-        # Create a bitmap canvas
-        bitmap = wx.Bitmap(self.image_width, self.image_height)
-        dc = wx.MemoryDC(bitmap)
-
-        # Fill background with parent color
-        bg_color = self.GetParent().GetBackgroundColour()
-        dc.SetBackground(wx.Brush(bg_color))
-        dc.Clear()
-
-        # Draw dark background rounded rectangle
-        dc.SetPen(wx.Pen(wx.Colour(40, 40, 40), 1))
-        dc.SetBrush(wx.Brush(wx.Colour(40, 40, 40)))
-        dc.DrawRoundedRectangle(0, 0, self.image_width, self.image_height, self.corner_radius)
-
-        # Center the image
-        img_width = masked_image.GetWidth()
-        img_height = masked_image.GetHeight()
-        x = (self.image_width - img_width) // 2
-        y = (self.image_height - img_height) // 2
-
-        # Draw the (already masked) image
-        dc.DrawBitmap(wx.Bitmap(masked_image), x, y, True)
-
-        # Draw border using GraphicsContext for smooth anti-aliased edges
-        gc = wx.GraphicsContext.Create(dc)
-        if gc:
-            gc.SetPen(wx.Pen(wx.Colour(60, 60, 60), 1))
-            gc.SetBrush(wx.TRANSPARENT_BRUSH)
-            path = gc.CreatePath()
-            path.AddRoundedRectangle(
-                0.5, 0.5, self.image_width - 1, self.image_height - 1, self.corner_radius
-            )
-            gc.DrawPath(path)
-
-            # Draw flip icon overlay if enabled
-            if self.show_flip_icon_overlay:
-                self._draw_flip_icon_on_gc(gc)
-        else:
-            # Fallback border without antialiasing
-            dc.SetPen(wx.Pen(wx.Colour(60, 60, 60), 1))
-            dc.SetBrush(wx.TRANSPARENT_BRUSH)
-            dc.DrawRoundedRectangle(0, 0, self.image_width, self.image_height, self.corner_radius)
-
-        dc.SelectObject(wx.NullBitmap)
-        return bitmap
-
-    def _draw_flip_icon_on_gc(self, gc: wx.GraphicsContext) -> None:
-        # Calculate icon position (top-left corner)
-        icon_x = self.flip_icon_margin
-        icon_y = self.flip_icon_margin
-
-        # Draw semi-transparent shadow effect
-        # Outer shadow
-        gc.SetBrush(
-            gc.CreateRadialGradientBrush(
-                icon_x + self.flip_icon_size / 2,
-                icon_y + self.flip_icon_size / 2 + 2,
-                icon_x + self.flip_icon_size / 2,
-                icon_y + self.flip_icon_size / 2 + 2,
-                self.flip_icon_size / 2 + 2,
-                wx.Colour(0, 0, 0, 100),  # semi-transparent black shadow
-                wx.Colour(0, 0, 0, 0),  # fully transparent
-            )
-        )
-        gc.SetPen(wx.TRANSPARENT_PEN)
-        gc.DrawEllipse(icon_x - 2, icon_y, self.flip_icon_size + 4, self.flip_icon_size + 4)
-
-        # Main background circle (black with semi-transparency)
-        gc.SetBrush(
-            gc.CreateRadialGradientBrush(
-                icon_x + self.flip_icon_size / 2,
-                icon_y + self.flip_icon_size / 2,
-                icon_x + self.flip_icon_size / 2,
-                icon_y + self.flip_icon_size / 2,
-                self.flip_icon_size / 2,
-                wx.Colour(40, 40, 40, 220),  # center: dark gray, semi-transparent
-                wx.Colour(20, 20, 20, 200),  # edge: darker gray, semi-transparent
-            )
-        )
-        gc.SetPen(wx.Pen(wx.Colour(80, 80, 80, 200), 2))
-        gc.DrawEllipse(icon_x, icon_y, self.flip_icon_size, self.flip_icon_size)
-
-        # Draw the flip icon text (yellow)
-        font_size = int(self.flip_icon_size * CARD_IMAGE_FLIP_ICON_TEXT_SCALE)
-        font = wx.Font(wx.FontInfo(font_size).Bold())
-        gc.SetFont(font, wx.Colour(255, 220, 0, 255))  # Yellow text, opaque
-
-        text = "⟳"
-        tw, th = gc.GetTextExtent(text)
-        text_x = icon_x + (self.flip_icon_size - tw) / 2
-        text_y = icon_y + (self.flip_icon_size - th) / 2
-        gc.DrawText(text, text_x, text_y)
-
-    def _create_placeholder_bitmap(self, text: str) -> wx.Bitmap:
-        bitmap = wx.Bitmap(self.image_width, self.image_height)
-        dc = wx.MemoryDC(bitmap)
-
-        # Background
-        bg_color = self.GetParent().GetBackgroundColour()
-        dc.SetBackground(wx.Brush(bg_color))
-        dc.Clear()
-
-        # Draw rounded rectangle
-        dc.SetPen(wx.Pen(wx.Colour(80, 80, 80), 2))
-        dc.SetBrush(wx.Brush(wx.Colour(50, 50, 50)))
-        dc.DrawRoundedRectangle(
-            CARD_IMAGE_PLACEHOLDER_INSET,
-            CARD_IMAGE_PLACEHOLDER_INSET,
-            self.image_width - (CARD_IMAGE_PLACEHOLDER_INSET * 2),
-            self.image_height - (CARD_IMAGE_PLACEHOLDER_INSET * 2),
-            self.corner_radius,
-        )
-
-        # Draw text
-        dc.SetTextForeground(wx.Colour(150, 150, 150))
-        font = wx.Font(12, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
-        dc.SetFont(font)
-
-        text_width, text_height = dc.GetTextExtent(text)
-        text_x = (self.image_width - text_width) // 2
-        text_y = (self.image_height - text_height) // 2
-        dc.DrawText(text, text_x, text_y)
-
-        dc.SelectObject(wx.NullBitmap)
-        return bitmap
 
     def show_flip_icon(self) -> None:
         if not self.show_flip_icon_overlay:

--- a/widgets/panels/card_image_display/image_loader.py
+++ b/widgets/panels/card_image_display/image_loader.py
@@ -1,0 +1,106 @@
+"""Off-thread image-loading pipeline for the card image display widget."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Thread
+from typing import TYPE_CHECKING
+
+import wx
+from loguru import logger
+
+from utils.perf import timed
+
+if TYPE_CHECKING:
+    from widgets.panels.card_image_display.protocol import CardImageDisplayProto
+
+    _Base = CardImageDisplayProto
+else:
+    _Base = object
+
+
+class _ImageLoaderMixin(_Base):
+    """Decode/scale/mask images off-thread and composite them on the UI thread."""
+
+    def _load_image_at_index(self, index: int, animate: bool = True) -> bool:
+        """Kick off an off-thread decode/scale/mask, then composite on the UI thread.
+
+        The expensive work (``wx.Image`` decode, high-quality ``Scale`` and the
+        PIL/numpy rounded-corner masking) runs in a background thread so rapid
+        card selection / face flips / printing navigation do not hitch the UI.
+        Only the lightweight DC compositing + ``SetBitmap`` runs on the main
+        thread, marshalled via :func:`wx.CallAfter`. Mirrors the off-thread
+        pattern in ``card_table_panel/pile_view.py``.
+
+        Returns ``True`` when a load was dispatched (the path exists and is in
+        range); the actual decode result is applied asynchronously.
+        """
+        if not 0 <= index < len(self.image_paths):
+            return False
+
+        image_path = self.image_paths[index]
+
+        # Bump the generation so any in-flight decode for a previous image is
+        # discarded when it reaches the UI thread.
+        self._image_load_gen += 1
+        gen = self._image_load_gen
+
+        Thread(
+            target=self._decode_image_worker,
+            args=(gen, image_path, animate),
+            daemon=True,
+        ).start()
+        return True
+
+    @timed
+    def _decode_image_worker(self, gen: int, image_path: Path, animate: bool) -> None:
+        """Background worker: decode, scale and rounded-corner mask ``image_path``.
+
+        Produces a ready ``wx.Image`` and marshals the final composite back to
+        the UI thread. No wx UI objects are touched here — ``wx.Image`` is a
+        plain pixel container and the masking is pure PIL/numpy.
+        """
+        try:
+            img = wx.Image(str(image_path), wx.BITMAP_TYPE_ANY)
+            if not img.IsOk():
+                logger.debug(f"Failed to load image: {image_path}")
+                return
+
+            # Scale to fit while maintaining aspect ratio.
+            img_width = img.GetWidth()
+            img_height = img.GetHeight()
+            scale = min(self.image_width / img_width, self.image_height / img_height)
+            new_width = int(img_width * scale)
+            new_height = int(img_height * scale)
+            img = img.Scale(new_width, new_height, wx.IMAGE_QUALITY_HIGH)
+
+            # Apply the rounded-corner alpha mask off-thread (PIL/numpy only).
+            masked_image = self._apply_rounded_corners_to_image(img, self.corner_radius)
+        except Exception as exc:
+            logger.exception(f"Error loading image {image_path}: {exc}")
+            return
+
+        wx.CallAfter(self._apply_decoded_image, gen, masked_image, animate)
+
+    def _apply_decoded_image(self, gen: int, masked_image: wx.Image, animate: bool) -> None:
+        """UI-thread: composite the pre-masked image and display it.
+
+        Discards stale results via the generation counter so only the most
+        recent request is shown.
+        """
+        if gen != self._image_load_gen:
+            return
+        try:
+            # Composite background, border and flip icon around the masked image.
+            bitmap = self._create_rounded_bitmap(masked_image)
+
+            # Display with or without animation.
+            if animate and self.bitmap_ctrl.GetBitmap().IsOk():
+                self._start_fade_animation(bitmap)
+            else:
+                self.bitmap_ctrl.SetBitmap(bitmap)
+                self.Refresh()
+        except RuntimeError:
+            # Widget was destroyed (e.g. during app shutdown) while a
+            # CallAfter callback was still pending – silently bail out.
+            return

--- a/widgets/panels/card_image_display/protocol.py
+++ b/widgets/panels/card_image_display/protocol.py
@@ -1,0 +1,81 @@
+"""Shared ``self`` contract that the :class:`CardImageDisplay` mixins assume."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import wx
+
+
+class CardImageDisplayProto(Protocol):
+    """Cross-mixin ``self`` surface for ``CardImageDisplay``.
+
+    Typed once here so each helper mixin can inherit it (via a
+    ``TYPE_CHECKING`` ``_Base``) instead of re-declaring the shared attributes
+    and the wx :class:`wx.Panel` methods every mixin reaches for.
+    """
+
+    # Geometry / styling (set in ``CardImageDisplay.__init__``).
+    image_width: int
+    image_height: int
+    corner_radius: int
+
+    # Flip icon state.
+    show_flip_icon_overlay: bool
+    flip_icon_size: int
+    flip_icon_margin: int
+
+    # Image navigation state.
+    image_paths: list[Path]
+    current_index: int
+
+    # Generation counter guarding stale off-thread decodes.
+    _image_load_gen: int
+
+    # Fade-animation state.
+    animation_timer: wx.Timer | None
+    animation_alpha: float
+    animation_target_bitmap: wx.Bitmap | None
+    animation_current_bitmap: wx.Bitmap | None
+
+    # UI components.
+    bitmap_ctrl: wx.StaticBitmap
+    image_panel: wx.Panel
+
+    # ── wx.Panel surface the mixins call ────────────────────────────────
+    def Refresh(self, *args, **kwargs) -> None: ...
+
+    def GetParent(self) -> wx.Window: ...
+
+    def Bind(self, *args, **kwargs) -> None: ...
+
+    # ── Cross-mixin helpers ─────────────────────────────────────────────
+    # Properties mixin (pure helpers).
+    def _blend_bitmaps(self, bmp1: wx.Bitmap, bmp2: wx.Bitmap, alpha: float) -> wx.Bitmap: ...
+
+    def _get_flip_icon_rect(self) -> wx.Rect: ...
+
+    def _apply_rounded_corners_to_image(self, image: wx.Image, radius: int) -> wx.Image: ...
+
+    # Image-loader mixin.
+    def _load_image_at_index(self, index: int, animate: bool = ...) -> bool: ...
+
+    def _apply_decoded_image(self, gen: int, masked_image: wx.Image, animate: bool) -> None: ...
+
+    # Animation mixin.
+    def _start_fade_animation(self, target_bitmap: wx.Bitmap) -> None: ...
+
+    def _on_animation_tick(self, event: wx.TimerEvent) -> None: ...
+
+    # Bitmap-renderer mixin.
+    def _create_rounded_bitmap(self, masked_image: wx.Image) -> wx.Bitmap: ...
+
+    def _draw_flip_icon_on_gc(self, gc: wx.GraphicsContext) -> None: ...
+
+    def _create_placeholder_bitmap(self, text: str) -> wx.Bitmap: ...
+
+    # Handlers / public state.
+    def _update_navigation(self) -> None: ...
+
+    def _toggle_face(self) -> None: ...


### PR DESCRIPTION
## Summary

Decomposes the 385-LOC `CardImageDisplayHandlersMixin` (in `widgets/panels/card_image_display/handlers.py`) into single-concern peer mixins composed in `frame.py`, and adds a `protocol.py` typing the shared `self` surface so each new mixin inherits a `TYPE_CHECKING` `_Base` (matching the existing `card_table_panel` package convention). Method bodies were moved verbatim — this is a pure structural refactor with no behavior change. `handlers.py` now holds only the public state API (`show_*` / flip-icon) and input/event callbacks, dropping from 385 to ~120 LOC.

New files:
- `image_loader.py` → `_ImageLoaderMixin` (off-thread decode/scale/mask pipeline + generation-counter logic)
- `animation.py` → `_AnimationMixin` (fade-transition timer loop)
- `bitmap_renderer.py` → `_BitmapRendererMixin` (canvas / border / flip-icon / placeholder rendering)
- `protocol.py` → `CardImageDisplayProto` (cross-mixin `self` contract: `image_paths`, `current_index`, `_image_load_gen`, animation fields, `bitmap_ctrl`, the wx.Panel methods and the cross-mixin helpers)

`frame.py` composes all mixins on `CardImageDisplay`; the pure-helper `CardImageDisplayPropertiesMixin` (`_blend_bitmaps`, `_get_flip_icon_rect`, `_apply_rounded_corners_to_image`) is unchanged.

## Verification

Run from WSL (the app runs on Windows; `wx` is not importable here):
- `python -m ruff check widgets/panels/card_image_display/` → All checks passed
- `python -m black --check widgets/panels/card_image_display/` → 8 files unchanged
- `python -m py_compile` on all package files → OK
- AST-parsed every package file → OK
- Confirmed every method referenced in `handlers.py` (`_load_image_at_index`, `_create_placeholder_bitmap`, etc.) is now provided by a peer mixin in the `CardImageDisplay` composition.

Could NOT be verified in WSL (requires Windows + wx):
- Actual import / class construction (`utils.constants` transitively imports `wx`).
- `tests/test_card_image_display_logic.py` — collection fails on `import wx` via `utils.constants`; this is pre-existing on `main` and unrelated to this change, so the test must run on Windows CI.
- Runtime MRO instantiation and all wx/UI behavior (image loading, fade animation, flip-icon rendering, click/key handling).

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)
