### PR TITLE
fix: retry os.replace on transient Windows PermissionError (WinError 5) in atomic writes

### DIFF
--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,72 @@
+"""Tests for atomic file writes, including Windows transient-lock retries."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import utils.atomic_io as atomic_io
+from utils.atomic_io import atomic_write_bytes, atomic_write_json, atomic_write_text
+
+
+def test_atomic_write_bytes_roundtrip(tmp_path: Path) -> None:
+    target = tmp_path / "data.bin"
+    atomic_write_bytes(target, b"hello")
+    assert target.read_bytes() == b"hello"
+
+
+def test_atomic_write_json_roundtrip(tmp_path: Path) -> None:
+    target = tmp_path / "data.json"
+    atomic_write_json(target, {"a": 1, "b": [1, 2, 3]})
+    assert target.read_text(encoding="utf-8").strip().startswith("{")
+    assert '"a"' in target.read_text(encoding="utf-8")
+
+
+def test_atomic_write_overwrites_existing(tmp_path: Path) -> None:
+    target = tmp_path / "data.txt"
+    atomic_write_text(target, "first")
+    atomic_write_text(target, "second")
+    assert target.read_text(encoding="utf-8") == "second"
+
+
+def test_replace_retries_on_transient_permission_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient PermissionError (Windows WinError 5) should be retried."""
+    target = tmp_path / "data.txt"
+    target.write_text("old", encoding="utf-8")
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src: object, dst: object) -> None:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise PermissionError(5, "Acesso negado")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(atomic_io.os, "replace", flaky_replace)
+    monkeypatch.setattr(atomic_io.time, "sleep", lambda _seconds: None)
+
+    atomic_write_text(target, "new")
+
+    assert calls["n"] == 3
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_replace_reraises_after_exhausting_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A persistent PermissionError should surface after all retries."""
+    target = tmp_path / "data.txt"
+
+    def always_denied(src: object, dst: object) -> None:
+        raise PermissionError(5, "Acesso negado")
+
+    monkeypatch.setattr(atomic_io.os, "replace", always_denied)
+    monkeypatch.setattr(atomic_io.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(PermissionError):
+        atomic_write_text(target, "new")

--- a/utils/atomic_io.py
+++ b/utils/atomic_io.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 import threading
+import time
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -14,6 +15,24 @@ import msgspec.json
 
 _lock_registry: dict[Path, threading.RLock] = {}
 _lock_registry_lock = threading.Lock()
+
+# Windows briefly holds a handle on the destination (antivirus, Search
+# indexer, or a concurrent reader) which makes os.replace fail with
+# PermissionError / WinError 5. The lock is transient, so retry with a
+# short backoff before giving up.
+_REPLACE_RETRIES = 5
+_REPLACE_BACKOFF = 0.05
+
+
+def _replace_with_retry(src: Path, dst: Path) -> None:
+    for attempt in range(_REPLACE_RETRIES):
+        try:
+            os.replace(src, dst)
+            return
+        except PermissionError:
+            if attempt == _REPLACE_RETRIES - 1:
+                raise
+            time.sleep(_REPLACE_BACKOFF * (attempt + 1))
 
 
 def _get_path_lock(path: Path) -> threading.RLock:
@@ -59,7 +78,7 @@ def atomic_write_bytes(path: Path, data: bytes) -> None:
                 fh.write(data)
                 fh.flush()
                 os.fsync(fh.fileno())
-            os.replace(tmp_file, path)
+            _replace_with_retry(tmp_file, path)
             _fsync_dir(path.parent)
         finally:
             if tmp_file.exists():
@@ -80,7 +99,7 @@ def atomic_write_stream(path: Path, chunks: Iterable[bytes]) -> None:
                     fh.write(chunk)
                 fh.flush()
                 os.fsync(fh.fileno())
-            os.replace(tmp_file, path)
+            _replace_with_retry(tmp_file, path)
             _fsync_dir(path.parent)
         finally:
             if tmp_file.exists():


### PR DESCRIPTION
## Problem

After PR #552 was merged, the metagame analysis frame surfaces this error in production:

```
[WinError 5] Acesso negado: 'C:\Claude\MTGO_Tools\cache\.archetype_decks_cache.json.66x7rs_l.tmp'
  -> 'C:\Claude\MTGO_Tools\cache\archetype_decks_cache.json'
```

The atomic-write helpers in `utils/atomic_io.py` write to a temp file then `os.replace()` it over the destination. On Windows the destination is briefly locked by antivirus, the Search indexer, or a concurrent reader, so `os.replace` intermittently fails with `PermissionError` / `WinError 5`. The cache write is then lost and the error bubbles up to `metagame_analysis.handlers._handle_error`.

## Fix

Wrap the rename in `_replace_with_retry()`, which retries `os.replace` up to 5 times with a short linear backoff (50ms × attempt). The lock is transient and clears within milliseconds. A persistent failure still raises after retries are exhausted, so genuine permission problems are not silently swallowed.

Both `atomic_write_bytes` and `atomic_write_stream` route through the helper.

## Tests

New `tests/test_atomic_io.py`:
- roundtrip + overwrite coverage for bytes/json/text writes
- a flaky `os.replace` that fails twice then succeeds → write completes, exactly 3 attempts
- a persistently denied `os.replace` → `PermissionError` re-raised after retries

```
$ python3 -m pytest tests/test_atomic_io.py -q
5 passed
```

ruff + black + py_compile all clean. These tests are platform-independent (the Windows lock is simulated via monkeypatch), so CI validates them off-Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)