### PR TITLE
test: exercise card-art fixture generator and tighten fixture contracts

### DIFF
--- a/tests/test_card_art_selection_fixture.py
+++ b/tests/test_card_art_selection_fixture.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "card_art_selection"
 COLOR_ORDER = "WUBRG"
+
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+import generate_card_art_selection_fixture as generator  # noqa: E402
 
 
 def _load_json(name: str):
@@ -23,6 +29,14 @@ def test_card_art_selection_fixture_is_complete() -> None:
 
     assert cards
     assert manifest["printing_count"] == len(cards)
+
+    for card in cards:
+        for image_path in card["image_uris"].values():
+            assert not image_path.startswith(("http://", "https://"))
+            assert (FIXTURE_DIR / image_path).exists(), f"missing rewritten image: {image_path}"
+        source_uris = card["source_image_uris"]
+        assert source_uris, f"{card.get('name')} missing source_image_uris"
+        assert source_uris["normal"].startswith("https://")
     assert manifest["full_art_printing_count"] > 0
     assert manifest["image_file_count"] == manifest["printing_count"] * len(manifest["image_sizes"])
     assert (
@@ -48,6 +62,7 @@ def test_card_art_selection_fixture_is_complete() -> None:
                 elif group_name == "nonbasic_land":
                     assert "Land" in (printing.get("type_line") or "")
                     assert "Basic" not in (printing.get("type_line") or "")
+                    assert _color_key(printing) == ""
                 else:
                     assert _color_key(printing) == expected_identity
 
@@ -59,6 +74,15 @@ def test_card_art_selection_fixture_is_complete() -> None:
                 assert set(printing["fixture_image_sources"]) == set(printing["image_uris"])
                 assert printing["fixture_image_sources"]["normal"] != "generated_placeholder"
 
+    non_placeholder_sources = sum(
+        1
+        for printings in printings_by_name.values()
+        for printing in printings
+        for source in printing["fixture_image_sources"].values()
+        if source != "generated_placeholder"
+    )
+    assert non_placeholder_sources == manifest["copied_cached_image_count"]
+
     assert any(
         printing["full_art"] for printings in printings_by_name.values() for printing in printings
     )
@@ -67,3 +91,58 @@ def test_card_art_selection_fixture_is_complete() -> None:
         for printings in printings_by_name.values()
         for printing in printings
     )
+
+
+def test_color_identity_key_orders_by_wubrg() -> None:
+    assert generator.color_identity_key({"color_identity": ["G", "W"]}) == "WG"
+    assert generator.color_identity_key({"color_identity": ["R", "U", "B"]}) == "UBR"
+    assert generator.color_identity_key({}) == ""
+    assert generator.color_identity_key({"color_identity": None}) == ""
+
+
+def test_image_color_mono_and_multicolor() -> None:
+    assert generator.image_color({"color_identity": ["W"]}) == generator.COLOR_SWATCHES["W"]
+    # Colorless cards fall back to the "C" swatch.
+    assert generator.image_color({"color_identity": []}) == generator.COLOR_SWATCHES["C"]
+    # Multicolor averages the component swatches channel-by-channel.
+    white = generator.COLOR_SWATCHES["W"]
+    blue = generator.COLOR_SWATCHES["U"]
+    expected = tuple((white[i] + blue[i]) // 2 for i in range(3))
+    assert generator.image_color({"color_identity": ["W", "U"]}) == expected
+
+
+def test_contrast_color_picks_dark_text_on_light_background() -> None:
+    assert generator.contrast_color((240, 240, 240)) == (20, 22, 25)
+    assert generator.contrast_color((10, 10, 10)) == (245, 245, 240)
+
+
+def test_wrapped_lines_wraps_and_forces_long_words() -> None:
+    assert generator.wrapped_lines("a b c d e", max_chars=3) == ["a b", "c d", "e"]
+    # A single word longer than max_chars is forced onto its own line.
+    assert generator.wrapped_lines("superlongword tail", max_chars=4) == [
+        "superlongword",
+        "tail",
+    ]
+    assert generator.wrapped_lines("", max_chars=10) == []
+
+
+def test_slugify_handles_punctuation_and_empty() -> None:
+    assert generator.slugify("") == "card"
+    assert generator.slugify("!!!") == "card"
+    assert generator.slugify('Miles "Tails" Prower') == "miles-tails-prower"
+
+
+def test_build_printing_record_coalesces_missing_fields() -> None:
+    record = generator.build_printing_record({"id": "abc", "set": "neo"})
+    assert record["id"] == "abc"
+    assert record["set"] == "NEO"
+    assert record["color_identity"] == []
+    assert record["colors"] == []
+    assert record["games"] == []
+    assert record["set_name"] == ""
+    assert record["collector_number"] == ""
+    assert record["image_uris"] == {}
+    assert record["fixture_image_sources"] == {}
+    assert record["full_art"] is False
+    assert record["promo"] is False
+    assert record["digital"] is False


### PR DESCRIPTION
## Summary

Addresses the 2 high / 2 medium findings from the automated test-suite review of `tests/test_card_art_selection_fixture.py`. The test previously only validated the committed static fixture artifacts; this PR adds direct unit coverage for the generator's pure functions in `scripts/generate_card_art_selection_fixture.py` (`color_identity_key`, `image_color`, `contrast_color`, `wrapped_lines`, `slugify`, `build_printing_record`) and tightens the fixture-data assertions: it now verifies the `scryfall_cards.json` URL-rewrite + `source_image_uris` preservation contract, asserts the nonbasic-land bucket's color identity (previously bypassed), and replaces the redundant per-printing normal-source check with a count invariant tying non-placeholder `fixture_image_sources` to `manifest.copied_cached_image_count`.

## Verification

Run from WSL (the generator imports only `PIL`, not `wx`, so it is importable here):
- `python -m pytest tests/test_card_art_selection_fixture.py -q` — 7 passed (1 fixture-data test + 6 new generator unit tests).
- `python -m ruff check tests/test_card_art_selection_fixture.py` — clean.
- `python -m black --check tests/test_card_art_selection_fixture.py` — clean.

Could not verify in WSL: nothing wx/UI-related is involved in this change. One nuance — the cached source images referenced by `fixture_image_sources` live in the local `cache/` directory (not committed), so the new assertions deliberately do not check those cached paths resolve on disk; they validate the rewritten in-fixture image paths (which are committed) and the source-count invariant instead.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)