### PR TITLE
test: cover load_meta/write_meta and corrupt-index path in card index storage

### DIFF
--- a/tests/test_card_index_storage.py
+++ b/tests/test_card_index_storage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import msgspec.json
+import msgspec.msgpack
 
 from repositories.card_repository import storage
 from repositories.card_repository.schemas import CardEntry
@@ -49,6 +50,24 @@ def test_load_index_missing_raises(tmp_path: Path) -> None:
         raise AssertionError("expected RuntimeError for missing index")
 
 
+def test_load_index_corrupt_raises_with_detail(tmp_path: Path) -> None:
+    _, index_path, _ = storage.resolve_paths(tmp_path)
+    # A present-but-garbage file must hit the decode-error branch (not the
+    # missing-file guard) and wrap the underlying msgspec.DecodeError detail.
+    index_path.write_bytes(b"\xff\xff not msgpack")
+    try:
+        storage.load_index(index_path)
+    except RuntimeError as exc:
+        message = str(exc)
+        assert "missing or invalid" in message
+        # The bare missing-file guard has no trailing detail; the decode-error
+        # branch appends ``: <exc>`` so a non-empty suffix proves we took it.
+        assert message != "Card data index missing or invalid"
+        assert message.startswith("Card data index missing or invalid: ")
+    else:  # pragma: no cover - failure path
+        raise AssertionError("expected RuntimeError for corrupt index")
+
+
 def test_migrate_legacy_index_converts_json_to_msgpack(tmp_path: Path) -> None:
     _, index_path, _ = storage.resolve_paths(tmp_path)
     legacy_path = storage.legacy_index_path(tmp_path)
@@ -58,6 +77,10 @@ def test_migrate_legacy_index_converts_json_to_msgpack(tmp_path: Path) -> None:
     # Legacy JSON removed, msgpack written, and decodable.
     assert index_path.exists()
     assert not legacy_path.exists()
+    # Confirm the migrated payload is genuine msgpack (not coincidentally
+    # JSON-readable): decode it raw before the typed load_index round-trip.
+    raw = msgspec.msgpack.decode(index_path.read_bytes())
+    assert raw["cards_by_name"]["opt"] == 0
     assert storage.load_index(index_path).cards[0].name == "Opt"
 
 
@@ -86,3 +109,22 @@ def test_migrate_legacy_index_leaves_corrupt_legacy(tmp_path: Path) -> None:
     assert storage.migrate_legacy_index(index_path, legacy_path) is False
     assert not index_path.exists()
     assert legacy_path.exists()
+
+
+def test_load_meta_missing_returns_none(tmp_path: Path) -> None:
+    _, _, meta_path = storage.resolve_paths(tmp_path)
+    assert storage.load_meta(meta_path) is None
+
+
+def test_write_then_load_meta_round_trip(tmp_path: Path) -> None:
+    _, _, meta_path = storage.resolve_paths(tmp_path)
+    # Includes a non-ASCII value since write_meta passes ensure_ascii=False.
+    meta = {"etag": "abc123", "source": "Æther Vial", "count": 34000}
+    storage.write_meta(meta_path, meta)
+    assert storage.load_meta(meta_path) == meta
+
+
+def test_load_meta_invalid_json_returns_none(tmp_path: Path) -> None:
+    _, _, meta_path = storage.resolve_paths(tmp_path)
+    meta_path.write_text("{not valid json", encoding="utf-8")
+    assert storage.load_meta(meta_path) is None


### PR DESCRIPTION
Closes the two medium-severity test-quality findings in `tests/test_card_index_storage.py` from the test-suite review. Adds coverage for the previously-untested `load_meta`/`write_meta` sidecar helpers (missing-file -> None, write/load round-trip with a non-ASCII value since `write_meta` uses `ensure_ascii=False`, and invalid-JSON -> None) and for the corrupt-but-present index branch of `load_index` (asserting `RuntimeError` is raised via the decode-error handler, distinguished from the missing-file guard by the wrapped-detail suffix). Also strengthens the legacy-migration test to decode the migrated file as raw msgpack, proving it is genuine msgpack rather than coincidentally readable. No production code was changed.

## Verification
- `python -m ruff check tests/test_card_index_storage.py` — passed.
- `python -m black --check tests/test_card_index_storage.py` — passed (unchanged).
- `python -m pytest tests/test_card_index_storage.py -q` — this test module imports `repositories.card_repository`, whose package `__init__` transitively imports `wx` (via `utils.constants.keyboard`), so collection fails in WSL where `wx` is not installed. This is a pre-existing limitation affecting the entire file, not introduced here. To validate the new test logic I ran the module with `wx` stubbed by a `MagicMock`: all 11 tests pass (7 pre-existing + 4 new). On Windows CI, where `wx` is importable, the file runs normally.
- Not verified in WSL: any wx/GUI behavior (none is touched by this change).

`Closes #567`

🤖 Generated with [Claude Code](https://claude.com/claude-code)