### PR TITLE
test: cover case-insensitive and edge-case paths in card panel stats lookup

### DIFF
--- a/tests/test_card_panel_stats_lookup.py
+++ b/tests/test_card_panel_stats_lookup.py
@@ -36,3 +36,38 @@ def test_find_card_frequency_matches_full_dfc_name_when_data_uses_canonical() ->
     found = _find_card_frequency(cards, "Fire // Ice")
     assert found is not None
     assert found.total_copies == 2
+
+
+def test_find_card_frequency_is_case_insensitive_for_simple_card() -> None:
+    cards = [_Freq(card_name="lightning bolt", total_copies=4)]
+    found = _find_card_frequency(cards, "Lightning Bolt")
+    assert found is not None
+    assert found.total_copies == 4
+
+
+def test_find_card_frequency_is_case_insensitive_for_dfc_front_face() -> None:
+    cards = [_Freq(card_name="AJANI, NACATL PARIAH", total_copies=3)]
+    found = _find_card_frequency(cards, "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger")
+    assert found is not None
+    assert found.total_copies == 3
+
+
+def test_find_card_frequency_returns_none_when_no_match() -> None:
+    cards = [_Freq(card_name="Lightning Bolt")]
+    assert _find_card_frequency(cards, "Counterspell") is None
+
+
+def test_find_card_frequency_returns_none_for_empty_list() -> None:
+    assert _find_card_frequency([], "Lightning Bolt") is None
+
+
+def test_stats_lookup_names_strips_surrounding_whitespace() -> None:
+    assert _stats_lookup_names("  Lightning Bolt  ") == ["Lightning Bolt"]
+
+
+def test_stats_lookup_names_returns_empty_for_empty_string() -> None:
+    assert _stats_lookup_names("") == []
+
+
+def test_stats_lookup_names_returns_empty_for_whitespace_only() -> None:
+    assert _stats_lookup_names("   ") == []


### PR DESCRIPTION
Adds the missing test coverage flagged in #569 for the two pure helpers in `widgets/panels/card_panel/properties.py`. Previously the `_find_card_frequency` tests used identical casing on both sides, so the core `.lower()` normalization could be deleted with every test still green; the no-match/empty-list `None` paths and `_stats_lookup_names` whitespace-stripping / empty-input branches were also unexercised. This commit adds case-insensitive matching tests (simple card + DFC front face), `None`-return tests (non-match + empty list), and whitespace/empty/whitespace-only input tests. No production code changed.

## Verification
- `python -m ruff check tests/test_card_panel_stats_lookup.py` — passed.
- `python -m black --check tests/test_card_panel_stats_lookup.py` — passed (unchanged).
- Could not run `pytest tests/test_card_panel_stats_lookup.py` in WSL: the `widgets.panels.card_panel` package `__init__.py` imports `wx`, which is not installable here (pre-existing constraint shared by the original tests; CI runs them on Windows). To validate the new assertions I executed the real `properties.py` helper functions in isolation (loading the module source with a stubbed `wx`) and all 8 new cases passed.
- Not verified in WSL: any wx/UI behavior and the full pytest collection of this module — these require the Windows CI environment.

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)