### PR TITLE
test: exercise real card-image pixel helpers (#564)

### DIFF
--- a/tests/test_card_image_display_logic.py
+++ b/tests/test_card_image_display_logic.py
@@ -1,23 +1,43 @@
-"""Pixel-level regression tests for CardImageDisplay image processing methods.
+"""Pixel-level regression tests for CardImageDisplay image processing.
 
-These tests verify semantic equivalence of the PIL replacements by running
-both the original Python-loop implementation and the new PIL/numpy implementation
-against the same inputs and comparing outputs pixel-by-pixel.
+These tests drive the *production* pure-byte helpers in ``utils.image_effects``
+(``blend_rgb_bytes``, ``rounded_corner_mask_bytes``,
+``apply_rounded_corner_alpha_bytes``) — the same functions the wx-dependent
+``_blend_bitmaps`` / ``_apply_rounded_corners_to_image`` /
+``apply_rounded_corner_alpha`` call internally. A regression in the production
+math therefore fails these tests.
 
-No wx display is required — only PIL and numpy.
+No wx display is required — the helpers operate on raw bytes, so only PIL and
+numpy are needed.
 """
 
+import importlib.util
 import random
+from pathlib import Path
 
-import numpy as np
 import pytest
-from PIL import Image as PilImage
-from PIL import ImageDraw
 
-# ── helpers that replicate the original implementations ──────────────────────
+from utils.image_effects import (
+    apply_rounded_corner_alpha_bytes,
+    blend_rgb_bytes,
+    rounded_corner_mask_bytes,
+)
+
+# Load the wx-free ``ui_images`` constants submodule by file path. Importing it
+# normally (``from utils.constants...``) would execute the constants package
+# ``__init__`` which pulls in wx (unavailable off-Windows), so we side-step it.
+_ui_images_path = Path(__file__).resolve().parent.parent / "utils" / "constants" / "ui_images.py"
+_spec = importlib.util.spec_from_file_location("_ui_images_for_test", _ui_images_path)
+_ui_images = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_ui_images)
+CARD_IMAGE_CORNER_RADIUS = _ui_images.CARD_IMAGE_CORNER_RADIUS
+CARD_IMAGE_DISPLAY_HEIGHT = _ui_images.CARD_IMAGE_DISPLAY_HEIGHT
+CARD_IMAGE_DISPLAY_WIDTH = _ui_images.CARD_IMAGE_DISPLAY_WIDTH
+
+# ── reference implementations (pre-PIL pure-Python loops) ────────────────────
 
 
-def _blend_bitmaps_original(data1: bytes, data2: bytes, alpha: float) -> bytes:
+def _blend_bitmaps_reference(data1: bytes, data2: bytes, alpha: float) -> bytes:
     """Original pure-Python blend loop (reference implementation)."""
     blended = bytearray(len(data1))
     for i in range(0, len(data1), 3):
@@ -27,15 +47,7 @@ def _blend_bitmaps_original(data1: bytes, data2: bytes, alpha: float) -> bytes:
     return bytes(blended)
 
 
-def _blend_bitmaps_pil(data1: bytes, data2: bytes, w: int, h: int, alpha: float) -> bytes:
-    """PIL Image.blend replacement — must match original semantics."""
-    pil1 = PilImage.frombytes("RGB", (w, h), data1)
-    pil2 = PilImage.frombytes("RGB", (w, h), data2)
-    blended = PilImage.blend(pil1, pil2, alpha)
-    return blended.tobytes()
-
-
-def _apply_corners_original(alpha_data: bytes, w: int, h: int, radius: int) -> bytes:
+def _apply_corners_reference(alpha_data: bytes, w: int, h: int, radius: int) -> bytes:
     """Original nested-loop corner masking (reference implementation)."""
     arr = bytearray(alpha_data)
 
@@ -61,33 +73,22 @@ def _apply_corners_original(alpha_data: bytes, w: int, h: int, radius: int) -> b
     return bytes(arr)
 
 
-def _apply_corners_pil_numpy(alpha_data: bytes, w: int, h: int, radius: int) -> bytes:
-    """PIL+numpy replacement — must match original semantics."""
-    mask_pil = PilImage.new("L", (w, h), 0)
-    draw = ImageDraw.Draw(mask_pil)
-    draw.rounded_rectangle([0, 0, w - 1, h - 1], radius=radius, fill=255)
-    mask_bytes = np.frombuffer(mask_pil.tobytes(), dtype=np.uint8)
-    existing = np.frombuffer(alpha_data, dtype=np.uint8)
-    result = np.minimum(existing, mask_bytes)
-    return result.tobytes()
-
-
-# ── blend tests ──────────────────────────────────────────────────────────────
+# ── blend tests (exercise production blend_rgb_bytes) ────────────────────────
 
 W, H = 8, 8  # Small image for fast tests; pixel math is identical at any size
 
 
 @pytest.mark.parametrize("alpha", [0.0, 0.15, 0.5, 0.85, 1.0])
-def test_blend_pil_matches_original(alpha):
-    """PIL blend output must be pixel-identical to the original loop (±1 rounding)."""
+def test_blend_matches_reference(alpha):
+    """Production blend output must match the original loop (±1 rounding)."""
     rng = random.Random(42)
     data1 = bytes(rng.randint(0, 255) for _ in range(W * H * 3))
     data2 = bytes(rng.randint(0, 255) for _ in range(W * H * 3))
 
-    expected = _blend_bitmaps_original(data1, data2, alpha)
-    actual = _blend_bitmaps_pil(data1, data2, W, H, alpha)
+    expected = _blend_bitmaps_reference(data1, data2, alpha)
+    actual = blend_rgb_bytes(data1, data2, W, H, alpha)
 
-    # PIL uses float32 internally; allow ±1 rounding tolerance
+    # PIL uses float32 internally; allow ±1 rounding tolerance.
     for i, (e, a) in enumerate(zip(expected, actual)):
         assert abs(e - a) <= 1, f"Pixel mismatch at byte {i}: expected {e}, got {a} (alpha={alpha})"
 
@@ -95,7 +96,7 @@ def test_blend_pil_matches_original(alpha):
 def test_blend_identical_images_returns_same():
     """Blending identical images must return the original."""
     data = bytes([100, 150, 200] * (W * H))
-    result = _blend_bitmaps_pil(data, data, W, H, 0.5)
+    result = blend_rgb_bytes(data, data, W, H, 0.5)
     for i in range(0, len(data), 3):
         assert abs(result[i] - data[i]) <= 1
 
@@ -103,24 +104,25 @@ def test_blend_identical_images_returns_same():
 def test_blend_alpha_zero_returns_first():
     data1 = bytes([10] * W * H * 3)
     data2 = bytes([200] * W * H * 3)
-    result = _blend_bitmaps_pil(data1, data2, W, H, 0.0)
+    result = blend_rgb_bytes(data1, data2, W, H, 0.0)
     assert all(abs(b - 10) <= 1 for b in result)
 
 
 def test_blend_alpha_one_returns_second():
     data1 = bytes([10] * W * H * 3)
     data2 = bytes([200] * W * H * 3)
-    result = _blend_bitmaps_pil(data1, data2, W, H, 1.0)
+    result = blend_rgb_bytes(data1, data2, W, H, 1.0)
     assert all(abs(b - 200) <= 1 for b in result)
 
 
-# ── rounded corner tests ─────────────────────────────────────────────────────
+def test_blend_output_length_matches_input():
+    """Output must be the same RGB byte length as the inputs."""
+    data1 = bytes([10] * W * H * 3)
+    data2 = bytes([200] * W * H * 3)
+    assert len(blend_rgb_bytes(data1, data2, W, H, 0.5)) == W * H * 3
 
-from utils.constants import (  # noqa: E402
-    CARD_IMAGE_CORNER_RADIUS,
-    CARD_IMAGE_DISPLAY_HEIGHT,
-    CARD_IMAGE_DISPLAY_WIDTH,
-)
+
+# ── rounded corner tests (exercise production corner helpers) ─────────────────
 
 RW, RH = 20, 20
 
@@ -144,8 +146,8 @@ def _is_in_corner(x: int, y: int, w: int, h: int, radius: int) -> bool:
 
 
 @pytest.mark.parametrize("iw,ih,radius", _CORNER_CASES)
-def test_corners_pil_matches_original(iw, ih, radius):
-    """PIL+numpy corner mask must agree with the original on all interior pixels.
+def test_corners_match_reference(iw, ih, radius):
+    """Production corner mask must agree with the original on all interior pixels.
 
     PIL's rounded_rectangle rasterises the corner arc slightly differently from
     the discrete circle equation used in the original loop: it may include 1-2
@@ -153,8 +155,8 @@ def test_corners_pil_matches_original(iw, ih, radius):
     identical; PIL must never make a pixel *more* transparent than the original.
     """
     alpha_in = bytes([255] * iw * ih)  # fully opaque
-    expected = _apply_corners_original(alpha_in, iw, ih, radius)
-    actual = _apply_corners_pil_numpy(alpha_in, iw, ih, radius)
+    expected = _apply_corners_reference(alpha_in, iw, ih, radius)
+    actual = apply_rounded_corner_alpha_bytes(alpha_in, iw, ih, radius)
 
     if radius == 0:
         assert expected == actual, "radius=0 must produce identical output"
@@ -180,8 +182,8 @@ def test_corners_pil_matches_original(iw, ih, radius):
         ), f"PIL made pixel more transparent at ({x},{y}): orig={orig_val}, pil={pil_val}"
 
     # Strict invariant: every interior pixel that original kept opaque must
-    # also be opaque in the PIL result.  This directly verifies the directional
-    # claim and is not dependent on the diff count.
+    # also be opaque in the production result.  This directly verifies the
+    # directional claim and is not dependent on the diff count.
     for i, (e, a) in enumerate(zip(expected, actual)):
         if e == 255:
             assert a == 255, (
@@ -190,24 +192,39 @@ def test_corners_pil_matches_original(iw, ih, radius):
             )
 
 
+def test_corner_mask_interior_is_uniformly_opaque():
+    """The production mask must be 255 everywhere except the rounded corners.
+
+    ``apply_rounded_corner_alpha_bytes`` relies on the mask interior being a
+    flat 255 so ``np.minimum`` preserves (rather than erodes) partial alpha.
+    """
+    radius = 4
+    mask = rounded_corner_mask_bytes(RW, RH, radius)
+    assert len(mask) == RW * RH
+    for i, v in enumerate(mask):
+        x, y = i % RW, i // RW
+        if not _is_in_corner(x, y, RW, RH, radius):
+            assert v == 255, f"interior pixel ({x},{y}) was {v}, expected 255"
+
+
 def test_corners_zero_radius_preserves_all_alpha():
     """radius=0 means no rounding; all pixels should remain opaque."""
     alpha_in = bytes([255] * RW * RH)
-    result = _apply_corners_pil_numpy(alpha_in, RW, RH, radius=0)
+    result = apply_rounded_corner_alpha_bytes(alpha_in, RW, RH, radius=0)
     assert all(b == 255 for b in result)
 
 
 def test_corners_does_not_elevate_transparent_pixels():
     """Pixels that are already alpha=0 inside the round rect must stay 0."""
     alpha_in = bytes([0] * RW * RH)
-    result = _apply_corners_pil_numpy(alpha_in, RW, RH, radius=3)
+    result = apply_rounded_corner_alpha_bytes(alpha_in, RW, RH, radius=3)
     assert all(b == 0 for b in result)
 
 
 def test_corners_center_pixel_opaque():
     """Center pixel must always be inside the rounded rect, alpha=255."""
     alpha_in = bytes([255] * RW * RH)
-    result = _apply_corners_pil_numpy(alpha_in, RW, RH, radius=4)
+    result = apply_rounded_corner_alpha_bytes(alpha_in, RW, RH, radius=4)
     center_idx = (RH // 2) * RW + (RW // 2)
     assert result[center_idx] == 255
 
@@ -215,15 +232,15 @@ def test_corners_center_pixel_opaque():
 def test_corners_true_corner_transparent():
     """The (0,0) pixel must be outside a rounded rect with radius > 0."""
     alpha_in = bytes([255] * RW * RH)
-    result = _apply_corners_pil_numpy(alpha_in, RW, RH, radius=4)
+    result = apply_rounded_corner_alpha_bytes(alpha_in, RW, RH, radius=4)
     assert result[0] == 0  # top-left corner pixel
 
 
 def test_corners_preserves_partial_alpha_in_interior():
     """np.minimum must not clip partial alpha values that lie inside the rounded rect.
 
-    If the PIL mask interior is not uniformly 255, np.minimum would silently
-    erode valid semi-transparent pixels.  This test guards against that.
+    If the mask interior is not uniformly 255, np.minimum would silently erode
+    valid semi-transparent pixels.  This test guards against that.
     """
     rng = random.Random(99)
     radius = 3
@@ -235,7 +252,7 @@ def test_corners_preserves_partial_alpha_in_interior():
     alpha_list[interior_y * RW + interior_x] = partial_value
     alpha_in = bytes(alpha_list)
 
-    result = _apply_corners_pil_numpy(alpha_in, RW, RH, radius)
+    result = apply_rounded_corner_alpha_bytes(alpha_in, RW, RH, radius)
     center_idx = interior_y * RW + interior_x
     assert (
         result[center_idx] == partial_value

--- a/utils/image_effects.py
+++ b/utils/image_effects.py
@@ -2,10 +2,48 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-import wx
 from PIL import Image as PilImage
 from PIL import ImageDraw
+
+if TYPE_CHECKING:
+    import wx
+
+
+def rounded_corner_mask_bytes(w: int, h: int, radius: int) -> bytes:
+    """Return a ``w*h`` grayscale rounded-rectangle mask as raw bytes.
+
+    Interior pixels are ``255``; pixels outside the rounded corners are ``0``.
+    Rasterised by PIL (C-native) so it matches the discrete-circle reference
+    implementation on all interior pixels.
+    """
+    mask_pil = PilImage.new("L", (w, h), 0)
+    ImageDraw.Draw(mask_pil).rounded_rectangle([0, 0, w - 1, h - 1], radius=radius, fill=255)
+    return mask_pil.tobytes()
+
+
+def apply_rounded_corner_alpha_bytes(existing_alpha: bytes, w: int, h: int, radius: int) -> bytes:
+    """Combine an existing per-pixel alpha buffer with a rounded-corner mask.
+
+    Existing alpha inside the rounded region is preserved via per-pixel ``min``;
+    pixels outside the rounded corners become fully transparent.
+    """
+    mask = np.frombuffer(rounded_corner_mask_bytes(w, h, radius), dtype=np.uint8)
+    existing = np.frombuffer(existing_alpha, dtype=np.uint8)
+    return np.minimum(existing, mask).tobytes()
+
+
+def blend_rgb_bytes(data1: bytes, data2: bytes, w: int, h: int, alpha: float) -> bytes:
+    """Blend two raw RGB byte buffers: ``out = data1*(1-alpha) + data2*alpha``.
+
+    Both buffers must describe ``w*h`` RGB images (3 bytes/pixel, no alpha),
+    matching ``wx.Image.GetData()`` / ``PIL.Image.frombytes("RGB")``.
+    """
+    pil1 = PilImage.frombytes("RGB", (w, h), data1)
+    pil2 = PilImage.frombytes("RGB", (w, h), data2)
+    return PilImage.blend(pil1, pil2, alpha).tobytes()
 
 
 def apply_rounded_corner_alpha(image: wx.Image, radius: int) -> wx.Image:
@@ -20,10 +58,7 @@ def apply_rounded_corner_alpha(image: wx.Image, radius: int) -> wx.Image:
         img.InitAlpha()
 
     w, h = img.GetWidth(), img.GetHeight()
-    mask_pil = PilImage.new("L", (w, h), 0)
-    ImageDraw.Draw(mask_pil).rounded_rectangle([0, 0, w - 1, h - 1], radius=radius, fill=255)
-    mask_bytes = np.frombuffer(mask_pil.tobytes(), dtype=np.uint8)
-    existing_alpha = np.frombuffer(bytes(img.GetAlpha()), dtype=np.uint8)
-    new_alpha = np.minimum(existing_alpha, mask_bytes)
-    img.SetAlpha(new_alpha.tobytes())
+    # bytes(img.GetAlpha()) creates a copy, so frombuffer is not read-only.
+    new_alpha = apply_rounded_corner_alpha_bytes(bytes(img.GetAlpha()), w, h, radius)
+    img.SetAlpha(new_alpha)
     return img

--- a/widgets/panels/card_image_display/properties.py
+++ b/widgets/panels/card_image_display/properties.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import numpy as np
 import wx
-from PIL import Image as PilImage
-from PIL import ImageDraw
 
+from utils.image_effects import apply_rounded_corner_alpha_bytes, blend_rgb_bytes
 from utils.perf import timed
 
 
@@ -33,15 +31,13 @@ class CardImageDisplayPropertiesMixin:
             img1 = img1.Resize(img2.GetSize(), (0, 0))
             w1, h1 = w2, h2
 
-        # Convert wx.Image RGB data to PIL, blend in C, convert back.
+        # Blend RGB data in C (via PIL) and convert back.
         # wx.Image.GetData() always returns raw RGB bytes (3 bytes/pixel, no alpha),
         # matching PIL.Image.frombytes("RGB"). Semantics: out = img1*(1-alpha) + img2*alpha.
-        pil1 = PilImage.frombytes("RGB", (w1, h1), bytes(img1.GetData()))
-        pil2 = PilImage.frombytes("RGB", (w2, h2), bytes(img2.GetData()))
-        blended = PilImage.blend(pil1, pil2, alpha)
+        blended = blend_rgb_bytes(bytes(img1.GetData()), bytes(img2.GetData()), w1, h1, alpha)
 
         result = wx.Image(w1, h1)
-        result.SetData(blended.tobytes())
+        result.SetData(blended)
         return wx.Bitmap(result)
 
     def _get_flip_icon_rect(self) -> wx.Rect:
@@ -57,17 +53,9 @@ class CardImageDisplayPropertiesMixin:
 
         w, h = img.GetWidth(), img.GetHeight()
 
-        # Build a binary rounded-rectangle mask via PIL (C-native rasterisation).
-        # Interior pixels are 255; outside-corner pixels are 0.
-        mask_pil = PilImage.new("L", (w, h), 0)
-        draw = ImageDraw.Draw(mask_pil)
-        draw.rounded_rectangle([0, 0, w - 1, h - 1], radius=radius, fill=255)
-        mask_bytes = np.frombuffer(mask_pil.tobytes(), dtype=np.uint8)
-
-        # Apply mask: np.minimum preserves partial alpha inside the rect and
-        # forces alpha=0 in the transparent corner regions.
-        # bytes(img.GetAlpha()) creates a copy, so frombuffer is not read-only.
-        existing_alpha = np.frombuffer(bytes(img.GetAlpha()), dtype=np.uint8)
-        new_alpha = np.minimum(existing_alpha, mask_bytes)
-        img.SetAlpha(new_alpha.tobytes())
+        # Apply a rounded-rectangle mask: partial alpha inside the rect is
+        # preserved, alpha is forced to 0 in the transparent corner regions.
+        # bytes(img.GetAlpha()) creates a copy, so the buffer is not read-only.
+        new_alpha = apply_rounded_corner_alpha_bytes(bytes(img.GetAlpha()), w, h, radius)
+        img.SetAlpha(new_alpha)
         return img


### PR DESCRIPTION
## Summary

`tests/test_card_image_display_logic.py` claimed to be a pixel-level regression test for `CardImageDisplay`'s image pipeline but never called any production code — it reimplemented the blend and rounded-corner algorithms locally and tested those copies, so it validated PIL/numpy rather than the app and could not detect a real regression. This PR extracts the pure-byte math out of `CardImageDisplayPropertiesMixin` and `utils.image_effects` into shared, wx-free helpers (`blend_rgb_bytes`, `rounded_corner_mask_bytes`, `apply_rounded_corner_alpha_bytes`). The production methods (`_blend_bitmaps`, `_apply_rounded_corners_to_image`, `apply_rounded_corner_alpha`) now delegate to those helpers, and the tests call the same helpers directly (still comparing against the original pure-Python loop as a reference). A regression in the production math — e.g. swapping `np.minimum` for `np.maximum` or changing the blend formula — now fails the tests. A new test also asserts the mask interior is uniformly opaque (the invariant `np.minimum` relies on) and that the blend output length matches its input.

The `wx` import in `utils/image_effects.py` is moved under `TYPE_CHECKING` (it was only used in an annotation, stringified by `from __future__ import annotations`) so the pure helpers import without wx, and the test loads the wx-free `ui_images` constants by file path instead of through the constants package (whose `__init__` pulls in wx). As a result this test file now runs in WSL/CI, not only on Windows.

## Verification

Run from WSL:
- `python -m pytest tests/test_card_image_display_logic.py -q` -> 19 passed.
- `python -m ruff check` and `python -m black --check` on all three changed files -> clean.
- `python -m py_compile` on all three changed files -> OK.
- Confirmed `utils.image_effects` now imports with no `wx` installed, and that `widgets/.../properties.py` has no remaining `numpy`/PIL references.

Could NOT be verified in WSL (no wx): the wx-dependent wrappers `_blend_bitmaps`, `_apply_rounded_corners_to_image`, and `apply_rounded_corner_alpha` were not executed end-to-end (they need `wx.Image`/`wx.Bitmap`). Their wx-specific glue (`ConvertToImage`, `GetData`/`SetData`, `Copy`, `InitAlpha`, `GetAlpha`/`SetAlpha`, the size-mismatch resize branch in `_blend_bitmaps`) is unchanged in behavior but is only callable on Windows; this remains covered by the Windows test suite.

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)