### PR TITLE
test: cover resolve_card_color and None-meta path in card_render tests

### DIFF
--- a/tests/test_card_render.py
+++ b/tests/test_card_render.py
@@ -6,7 +6,11 @@ from typing import Any
 
 import pytest
 
-from widgets.panels.card_table_panel.card_render import build_image_name_candidates
+from widgets.mana_icon_factory import ManaIconFactory
+from widgets.panels.card_table_panel.card_render import (
+    build_image_name_candidates,
+    resolve_card_color,
+)
 
 
 class _CardEntryStub:
@@ -30,6 +34,9 @@ class _CardEntryStub:
     "card, meta, expected",
     [
         ({"name": "Island"}, {}, ["Island"]),
+        # meta=None must short-circuit the alias/promotion branches (lines 31, 36)
+        # and return only the base name.
+        ({"name": "Island"}, None, ["Island"]),
         ({"name": "A // B"}, {}, ["A // B"]),
         ({"name": "A"}, {"aliases": ["Alias1"]}, ["A", "Alias1"]),
         # When meta has no "name" key (plain dict), no DFC promotion happens even
@@ -73,6 +80,7 @@ class _CardEntryStub:
     ],
     ids=[
         "simple-card",
+        "none-meta",
         "dfc-combined-name",
         "non-dfc-alias",
         "dfc-alias-no-promotion-without-meta-name",
@@ -87,3 +95,57 @@ def test_build_image_name_candidates(card: dict[str, Any], meta: Any, expected: 
     """build_image_name_candidates must return the correct candidate list for each input."""
     result = build_image_name_candidates(card, meta)
     assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# resolve_card_color
+# ---------------------------------------------------------------------------
+_FALLBACK = ManaIconFactory.FALLBACK_COLORS
+
+
+@pytest.mark.parametrize(
+    "meta, expected",
+    [
+        # No color info at all -> colorless fallback.
+        ({}, _FALLBACK["c"]),
+        ({"color_identity": []}, _FALLBACK["c"]),
+        ({"color_identity": [], "colors": []}, _FALLBACK["c"]),
+        # Single known color, already lowercase.
+        ({"color_identity": ["w"]}, _FALLBACK["w"]),
+        # Single known color, normalized from uppercase.
+        ({"color_identity": ["W"]}, _FALLBACK["w"]),
+        ({"color_identity": ["U"]}, _FALLBACK["u"]),
+        # Single unknown color -> colorless fallback via .get() default.
+        ({"color_identity": ["X"]}, _FALLBACK["c"]),
+        # color_identity takes precedence over colors when non-empty.
+        ({"color_identity": ["R"], "colors": ["G"]}, _FALLBACK["r"]),
+        # color_identity empty -> falls back to colors.
+        ({"color_identity": [], "colors": ["G"]}, _FALLBACK["g"]),
+        ({"colors": ["B"]}, _FALLBACK["b"]),
+        # Falsy entries (None, "") are filtered out before counting.
+        ({"color_identity": [None, "", "W"]}, _FALLBACK["w"]),
+        ({"color_identity": [None, ""]}, _FALLBACK["c"]),
+        # Two or more colors -> multicolor fallback.
+        ({"color_identity": ["W", "U"]}, _FALLBACK["multicolor"]),
+        ({"color_identity": ["w", "u", "b"]}, _FALLBACK["multicolor"]),
+    ],
+    ids=[
+        "empty-meta",
+        "empty-identity",
+        "empty-identity-and-colors",
+        "single-lowercase",
+        "single-uppercase-normalized",
+        "single-u",
+        "single-unknown-color-falls-back-to-c",
+        "identity-wins-over-colors",
+        "empty-identity-falls-back-to-colors",
+        "colors-only",
+        "falsy-entries-filtered-single",
+        "falsy-entries-filtered-empty",
+        "multicolor-two",
+        "multicolor-three",
+    ],
+)
+def test_resolve_card_color(meta: dict[str, Any], expected: tuple[int, int, int]) -> None:
+    """resolve_card_color must map metadata to the correct placeholder RGB color."""
+    assert resolve_card_color(meta) == expected


### PR DESCRIPTION
Extends `tests/test_card_render.py` to close the two coverage gaps flagged in #570. Adds a parametrized `test_resolve_card_color` that exercises all three return branches of `resolve_card_color` (colorless `c` fallback, single-color lookup including the unknown-color fallback, and the `multicolor` branch), along with the `color_identity`-vs-`colors` precedence, case normalization, and filtering of falsy entries — asserting against `ManaIconFactory.FALLBACK_COLORS`. Also adds a `None`-meta case to `test_build_image_name_candidates` to lock in the `meta is not None` short-circuit on both the aliases lookup and the DFC-promotion branches.

## Verification
- `python -m ruff check tests/test_card_render.py` — passed.
- `python -m black --check tests/test_card_render.py` — passed (unchanged).
- `python -m py_compile tests/test_card_render.py` — passed.
- Could NOT run the tests in WSL: `tests/test_card_render.py` imports from `widgets.panels.card_table_panel`, whose package `__init__.py` transitively imports `wx`, which is not installable off-Windows. This is a pre-existing constraint of this test module (the prior `build_image_name_candidates` tests have the same import chain). The new and existing test bodies are pure Python over plain dicts and `FALLBACK_COLORS` tuples, so actual test execution must be validated by Windows CI.

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)