### PR TITLE
test: cover error/edge branches in collection loading (#573)

### DIFF
--- a/tests/test_collection_loading.py
+++ b/tests/test_collection_loading.py
@@ -19,6 +19,8 @@ def test_card_repository_reads_collection_export():
     names = [card["name"] for card in cards]
     assert names == ["Lightning Bolt", "Island", "Lightning Bolt", "Spell Pierce"]
     assert cards[-1]["quantity"] == 2
+    # The normalized `id` field is preserved from the export entries.
+    assert cards[0]["id"] == 1001
 
 
 def test_card_repository_handles_flat_list_format(tmp_path):
@@ -35,6 +37,61 @@ def test_card_repository_handles_flat_list_format(tmp_path):
     assert len(cards) == 2
     assert [card["name"] for card in cards] == ["Opt", "Consider"]
     assert cards[1]["quantity"] == 2
+    # Entries without an `id` key must not gain a spurious one.
+    assert "id" not in cards[0]
+
+
+def test_card_repository_returns_empty_for_missing_file(tmp_path):
+    repo = CardRepository()
+
+    cards = repo.load_collection_from_file(tmp_path / "does_not_exist.json")
+
+    assert cards == []
+
+
+def test_card_repository_returns_empty_for_invalid_json(tmp_path):
+    repo = CardRepository()
+    bad_path = tmp_path / "broken.json"
+    bad_path.write_bytes(b"{not valid json")
+
+    cards = repo.load_collection_from_file(bad_path)
+
+    assert cards == []
+
+
+def test_card_repository_returns_empty_for_no_entries(tmp_path):
+    repo = CardRepository()
+
+    empty_dict_path = tmp_path / "empty_collection.json"
+    empty_dict_path.write_text(
+        json.dumps({"collection": {"name": "Collection", "items": []}}),
+        encoding="utf-8",
+    )
+    missing_list_path = tmp_path / "missing_list.json"
+    missing_list_path.write_text(json.dumps({"mode": "Collection"}), encoding="utf-8")
+
+    assert repo.load_collection_from_file(empty_dict_path) == []
+    assert repo.load_collection_from_file(missing_list_path) == []
+
+
+def test_card_repository_coerces_and_skips_quantities(tmp_path):
+    repo = CardRepository()
+    list_path = tmp_path / "quantities.json"
+    payload = [
+        {"name": "Float Down", "quantity": "2.5"},  # float-string -> int(float(...)) == 2
+        {"name": "Float Round", "quantity": "3.0"},  # float-string -> 3
+        {"name": "Bad String", "quantity": "abc"},  # non-numeric -> skipped
+        {"name": "Null Qty", "quantity": None},  # None -> skipped
+        {"name": "Negative", "quantity": -1},  # negative -> skipped
+        {"name": "   ", "quantity": 5},  # blank name -> skipped
+        {"name": "", "quantity": 5},  # empty name -> skipped
+    ]
+    list_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    cards = repo.load_collection_from_file(list_path)
+
+    assert [card["name"] for card in cards] == ["Float Down", "Float Round"]
+    assert [card["quantity"] for card in cards] == [2, 3]
 
 
 def test_collection_service_loads_inventory_from_export(tmp_path):
@@ -54,3 +111,56 @@ def test_collection_service_loads_inventory_from_export(tmp_path):
     assert service.get_owned_count("Spell Pierce") == 2
     # Lookups are case-insensitive regardless of caller casing.
     assert service.get_owned_count("lightning bolt") == 5
+
+
+def test_collection_service_load_missing_file_returns_empty(tmp_path):
+    repo = CardRepository()
+    service = CollectionService(card_repository=repo)
+
+    assert service.load_collection(tmp_path / "nope.json")
+
+    assert service.get_inventory() == {}
+    assert service.is_loaded()
+
+
+def test_collection_service_short_circuits_when_already_loaded(tmp_path):
+    repo = CardRepository()
+    service = CollectionService(card_repository=repo)
+
+    temp_file = tmp_path / "collection.json"
+    temp_file.write_text(FIXTURE_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+    calls = {"count": 0}
+    original = repo.load_collection_from_file
+
+    def counting_load(path):
+        calls["count"] += 1
+        return original(path)
+
+    repo.load_collection_from_file = counting_load  # type: ignore[method-assign]
+
+    assert service.load_collection(temp_file)
+    assert calls["count"] == 1
+
+    # A second load without force must not re-read the file.
+    assert service.load_collection(temp_file)
+    assert calls["count"] == 1
+
+    # force=True triggers a fresh read.
+    assert service.load_collection(temp_file, force=True)
+    assert calls["count"] == 2
+
+
+def test_collection_service_returns_false_on_read_error(tmp_path):
+    repo = CardRepository()
+    service = CollectionService(card_repository=repo)
+
+    temp_file = tmp_path / "collection.json"
+    temp_file.write_text(FIXTURE_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+    def boom(path):
+        raise RuntimeError("disk on fire")
+
+    repo.load_collection_from_file = boom  # type: ignore[method-assign]
+
+    assert service.load_collection(temp_file) is False


### PR DESCRIPTION
## Summary

Extends `tests/test_collection_loading.py` to exercise the error and edge branches that the automated test-suite review flagged as untested in `repositories/card_repository/collection.py` (`load_collection_from_file`) and `services/collection_service/cache.py` (`load_collection`). New coverage: missing-file/invalid-JSON/empty-entries returns `[]`; quantity coercion via `int(float(...))` for float-strings; skipping of non-numeric/None/negative quantities and blank names; the normalized `id` pass-through (present and absent); and the service-level already-loaded short-circuit, `force=True` re-read, missing-file (returns `True` with empty inventory), and read-error (returns `False`) branches. No production code changed.

## Verification

- `python -m ruff check tests/test_collection_loading.py` — passed.
- `python -m black --check tests/test_collection_loading.py` — passed (unchanged).
- Ran `pytest tests/test_collection_loading.py -q` from WSL with a minimal in-process `wx` stub (this test module transitively imports `wx` via the constants chain, which is not installable in WSL). All 10 tests pass (3 pre-existing + 7 new). The tested logic itself does not touch `wx`; the stub only satisfies the import chain.
- Not verified in WSL: real `wx`/UI behavior and the full Windows test suite. CI on Windows is the source of truth for the wx-backed import path.

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)