### PR TITLE
test: cover collection_service error/edge branches (#574)

### DIFF
--- a/tests/test_collection_service.py
+++ b/tests/test_collection_service.py
@@ -1,12 +1,16 @@
 """Tests for CollectionService business logic."""
 
 import json
+import os
+import time
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 
 from services.collection_service import CollectionService
+from services.collection_service.cache import CollectionStatus
+from services.collection_service.parsing import build_inventory
 
 
 @pytest.fixture
@@ -318,9 +322,28 @@ Sideboard
 
     analysis = collection_service.analyze_deck_ownership(deck_text)
 
+    # The bare "Sideboard" header line splits to a single token and is skipped,
+    # leaving the two real card lines.
     assert analysis["total_unique"] == 2
     assert analysis["fully_owned"] == 1  # Lightning Bolt
     assert analysis["partially_owned"] == 1  # Dismember (3/4)
+
+
+def test_analyze_deck_ownership_strips_sideboard_prefix(collection_service):
+    """A card name literally prefixed with 'Sideboard ' is stripped (deck_analysis.py:34-35)."""
+    collection_service.set_inventory({"Dismember": 4})
+
+    deck_text = "4 Sideboard Dismember"
+
+    analysis = collection_service.analyze_deck_ownership(deck_text)
+
+    # The "Sideboard " prefix is stripped so the requirement keys on "Dismember".
+    assert analysis["total_unique"] == 1
+    assert analysis["fully_owned"] == 1
+    assert ("Dismember", 4) not in analysis["missing_cards"]
+    # No requirement should retain the raw "Sideboard Dismember" name.
+    missing = collection_service.get_missing_cards_list(deck_text)
+    assert missing == []
 
 
 def test_get_missing_cards_list(collection_service):
@@ -350,7 +373,31 @@ def test_get_collection_statistics(collection_service, mock_card_repo):
     assert stats["unique_cards"] == 3
     assert stats["total_cards"] == 34
     assert stats["average_copies"] == pytest.approx(34 / 3)
-    assert "rarity_distribution" in stats
+    # Lightning Bolt (4, common) + Island (20, basic) + Mountain (10, basic).
+    assert stats["rarity_distribution"] == {"common": 4, "basic": 30}
+
+
+def test_get_collection_statistics_missing_metadata_skipped(collection_service, mock_card_repo):
+    """Cards whose metadata is None are skipped from the rarity aggregation (stats.py if metadata)."""
+    mock_card_repo.get_card_metadata = Mock(
+        side_effect=lambda name: {"Lightning Bolt": {"rarity": "common"}}.get(name)
+    )
+    collection_service.set_inventory({"Lightning Bolt": 4, "Unknown Card": 7})
+
+    stats = collection_service.get_collection_statistics()
+
+    # Unknown Card has no metadata -> excluded; only Lightning Bolt is counted.
+    assert stats["rarity_distribution"] == {"common": 4}
+
+
+def test_get_collection_statistics_default_unknown_rarity(collection_service, mock_card_repo):
+    """Metadata lacking a 'rarity' key defaults to 'unknown' (stats.py:33)."""
+    mock_card_repo.get_card_metadata = Mock(return_value={"name": "Some Card"})
+    collection_service.set_inventory({"Some Card": 3})
+
+    stats = collection_service.get_collection_statistics()
+
+    assert stats["rarity_distribution"] == {"unknown": 3}
 
 
 def test_get_collection_statistics_not_loaded(collection_service):
@@ -406,3 +453,281 @@ def test_get_total_cards(collection_service):
     collection_service.set_inventory({"Lightning Bolt": 4, "Island": 20, "Mountain": 10})
 
     assert collection_service.get_total_cards() == 34
+
+
+# ============= build_inventory Normalization Tests =============
+
+
+def test_build_inventory_sums_duplicate_names():
+    """Duplicate entries accumulate into a single normalized key (parsing.py:24)."""
+    cards = [
+        {"name": "Lightning Bolt", "quantity": 4},
+        {"name": "lightning bolt", "quantity": 3},
+    ]
+
+    inventory = build_inventory(cards)
+
+    assert inventory == {"lightning bolt": 7}
+
+
+def test_build_inventory_skips_invalid_entries():
+    """Non-dict entries and entries with missing/empty names are dropped."""
+    cards = [
+        "not a dict",
+        {"quantity": 4},  # missing name
+        {"name": "", "quantity": 4},  # empty name
+        {"name": "Island", "quantity": 2},
+    ]
+
+    inventory = build_inventory(cards)
+
+    assert inventory == {"island": 2}
+
+
+def test_build_inventory_coerces_invalid_quantity():
+    """A non-integer/None quantity coerces to 0 and is therefore dropped (parsing.py:17-22)."""
+    cards = [
+        {"name": "Island", "quantity": None},
+        {"name": "Mountain", "quantity": "not a number"},
+        {"name": "Forest", "quantity": "5"},  # numeric string is accepted
+    ]
+
+    inventory = build_inventory(cards)
+
+    assert inventory == {"forest": 5}
+
+
+def test_build_inventory_drops_zero_quantity():
+    """Entries with quantity 0 are skipped (parsing.py:21)."""
+    cards = [
+        {"name": "Island", "quantity": 0},
+        {"name": "Mountain", "quantity": 1},
+    ]
+
+    inventory = build_inventory(cards)
+
+    assert inventory == {"mountain": 1}
+
+
+def test_build_inventory_preserves_casing_when_not_normalizing():
+    """normalize_names=False keeps the original key casing (parsing.py:23)."""
+    cards = [{"name": "Lightning Bolt", "quantity": 4}]
+
+    inventory = build_inventory(cards, normalize_names=False)
+
+    assert inventory == {"Lightning Bolt": 4}
+
+
+# ============= get_owned_status Tests =============
+
+
+def test_get_owned_status_empty_inventory(collection_service):
+    """Empty inventory returns the subdued 'no collection loaded' display state (ownership.py:48-49)."""
+    collection_service.set_inventory({})
+
+    status, color = collection_service.get_owned_status("Lightning Bolt", 4)
+
+    assert status == "Owned —"
+    assert color == (185, 191, 202)
+
+
+def test_get_owned_status_populated_matches_format(collection_service):
+    """With a populated inventory, get_owned_status delegates to format_owned_status."""
+    from services.collection_service.ownership import format_owned_status
+
+    collection_service.set_inventory({"Lightning Bolt": 2})
+
+    assert collection_service.get_owned_status("Lightning Bolt", 4) == format_owned_status(2, 4)
+    assert collection_service.get_owned_status("Lightning Bolt", 2) == format_owned_status(2, 2)
+
+
+# ============= Cache Error / Formatter Tests =============
+
+
+def test_load_from_cached_file_malformed(collection_service, tmp_path):
+    """A corrupt cache file raises ValueError and clears the inventory (cache.py:106-109)."""
+    collection_service.set_inventory({"Island": 5})
+
+    filepath = tmp_path / "collection_full_trade_20240101.json"
+    filepath.write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Failed to parse collection file"):
+        collection_service.load_from_cached_file(tmp_path)
+
+    assert collection_service.get_collection_size() == 0
+    assert collection_service.is_loaded() is False
+
+
+def test_load_cached_status_recent(collection_service, tmp_path):
+    """A fresh cache file produces a 'recent' label (cache.py:111-123)."""
+    collection_data = [
+        {"name": "Lightning Bolt", "quantity": 4},
+        {"name": "Island", "quantity": 10},
+    ]
+    filepath = tmp_path / "collection_full_trade_20240101.json"
+    filepath.write_text(json.dumps(collection_data), encoding="utf-8")
+
+    status = collection_service.load_cached_status(tmp_path)
+
+    assert isinstance(status, CollectionStatus)
+    assert status.card_count == 2
+    assert status.filepath == filepath
+    assert status.age_hours == 0
+    assert "recent" in status.label
+    assert filepath.name in status.label
+
+
+def test_load_cached_status_hours_ago(collection_service, tmp_path):
+    """A backdated cache file produces an 'Nh ago' label (cache.py:116)."""
+    collection_data = [{"name": "Island", "quantity": 10}]
+    filepath = tmp_path / "collection_full_trade_20240101.json"
+    filepath.write_text(json.dumps(collection_data), encoding="utf-8")
+
+    # Backdate mtime by ~3 hours.
+    three_hours_ago = time.time() - 3 * 60 * 60
+    os.utime(filepath, (three_hours_ago, three_hours_ago))
+
+    status = collection_service.load_cached_status(tmp_path)
+
+    assert status.age_hours == 3
+    assert "3h ago" in status.label
+
+
+# ============= Exporter Error Tests =============
+
+
+def test_export_to_file_invalid_data(collection_service, tmp_path):
+    """Non-serializable card data is wrapped as ValueError (exporter.py:43-45)."""
+    cards = [{"name": "Lightning Bolt", "quantity": {1, 2, 3}}]  # set is not JSON serializable
+
+    with pytest.raises(ValueError, match="Invalid card data for export"):
+        collection_service.export_to_file(cards, tmp_path)
+
+
+# ============= BridgeRefreshMixin Tests =============
+
+
+def test_refresh_from_bridge_recent_cache_short_circuits(collection_service, tmp_path):
+    """A recent cached file with force=False returns False and reports success with no cards."""
+    collection_data = [{"name": "Island", "quantity": 10}]
+    filepath = tmp_path / "collection_full_trade_20240101.json"
+    filepath.write_text(json.dumps(collection_data), encoding="utf-8")
+
+    fetch = Mock()
+    successes: list[tuple] = []
+    errors: list[str] = []
+
+    result = collection_service.refresh_from_bridge_async(
+        tmp_path,
+        force=False,
+        on_success=lambda path, cards: successes.append((path, cards)),
+        on_error=errors.append,
+        cache_max_age_seconds=10_000,
+        fetch_collection=fetch,
+    )
+
+    assert result is False
+    fetch.assert_not_called()
+    assert successes == [(filepath, [])]
+    assert errors == []
+
+
+def _run_refresh_and_wait(service, tmp_path, **kwargs):
+    """Drive refresh_from_bridge_async and join the worker thread before asserting."""
+    import threading
+
+    before = set(threading.enumerate())
+    result = service.refresh_from_bridge_async(tmp_path, **kwargs)
+    for thread in set(threading.enumerate()) - before:
+        thread.join(timeout=5)
+    return result
+
+
+def test_refresh_from_bridge_force_exports_and_succeeds(collection_service, tmp_path):
+    """force=True bypasses the cache, exports fetched cards and calls on_success with them."""
+    cards = [{"name": "Lightning Bolt", "quantity": 4}]
+    fetch = Mock(return_value={"cards": cards})
+    successes: list[tuple] = []
+    errors: list[str] = []
+
+    result = _run_refresh_and_wait(
+        collection_service,
+        tmp_path,
+        force=True,
+        on_success=lambda path, c: successes.append((path, c)),
+        on_error=errors.append,
+        fetch_collection=fetch,
+    )
+
+    assert result is True
+    fetch.assert_called_once()
+    assert errors == []
+    assert len(successes) == 1
+    saved_path, saved_cards = successes[0]
+    assert saved_cards == cards
+    assert saved_path.exists()
+    assert "collection_full_trade_" in saved_path.name
+
+
+def test_refresh_from_bridge_empty_collection_routes_to_error(collection_service, tmp_path):
+    """An empty dict from the bridge routes to on_error."""
+    fetch = Mock(return_value={})
+    errors: list[str] = []
+
+    _run_refresh_and_wait(
+        collection_service,
+        tmp_path,
+        force=True,
+        on_error=errors.append,
+        fetch_collection=fetch,
+    )
+
+    assert errors == ["Bridge returned empty collection"]
+
+
+def test_refresh_from_bridge_empty_cards_routes_to_error(collection_service, tmp_path):
+    """A payload with no cards routes to on_error."""
+    fetch = Mock(return_value={"cards": []})
+    errors: list[str] = []
+
+    _run_refresh_and_wait(
+        collection_service,
+        tmp_path,
+        force=True,
+        on_error=errors.append,
+        fetch_collection=fetch,
+    )
+
+    assert errors == ["No cards in collection data"]
+
+
+def test_refresh_from_bridge_missing_bridge_routes_to_error(collection_service, tmp_path):
+    """A FileNotFoundError from fetch reports the bridge-missing message."""
+    fetch = Mock(side_effect=FileNotFoundError("bridge.exe missing"))
+    errors: list[str] = []
+
+    _run_refresh_and_wait(
+        collection_service,
+        tmp_path,
+        force=True,
+        on_error=errors.append,
+        fetch_collection=fetch,
+    )
+
+    assert errors == ["MTGO Bridge not found. Build the bridge executable."]
+
+
+def test_refresh_from_bridge_generic_failure_routes_to_error(collection_service, tmp_path):
+    """A generic fetch failure reports the exception text via on_error."""
+    fetch = Mock(side_effect=RuntimeError("network down"))
+    errors: list[str] = []
+
+    _run_refresh_and_wait(
+        collection_service,
+        tmp_path,
+        force=True,
+        on_error=errors.append,
+        fetch_collection=fetch,
+    )
+
+    assert errors == ["network down"]


### PR DESCRIPTION
This PR addresses the 2 high + 6 medium test-quality findings in `tests/test_collection_service.py` from issue #574. It adds focused, non-wx unit tests for the previously unexercised error/edge branches across the `services/collection_service/` mixins: the full `BridgeRefreshMixin.refresh_from_bridge_async` async path (driven synchronously via an injected fake `fetch_collection` and joining the worker thread), the `cache.py` malformed-file branch and `load_cached_status` label formatter, direct `build_inventory` normalization rules, `get_owned_status` empty-inventory display state, the `get_collection_statistics` rarity aggregation (concrete value + missing-metadata skip + `unknown` default), the `export_to_file` non-serializable -> `ValueError` wrapping, and a real `Sideboard `-prefix stripping case. No production code was changed.

## Verification
- `python -m ruff check tests/test_collection_service.py` — passed.
- `python -m black --check tests/test_collection_service.py` — passed (unchanged).
- Tests were run on the Windows interpreter via `cmd.exe /c "python -m pytest tests\test_collection_service.py -q"` (required because `utils.constants` transitively imports `wx`, which is not importable in WSL): **47 passed**.
- Could NOT be checked in WSL: importing `wx` / running the module under the WSL interpreter (the pre-existing import chain pulls in `wx`); no GUI/UI behavior was exercised. CI on Windows remains the source of truth for the full suite.

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)