### PR TITLE
test: cover untested deck builder hotkey branches (#577)

### DIFF
--- a/tests/test_deck_builder_hotkeys.py
+++ b/tests/test_deck_builder_hotkeys.py
@@ -146,9 +146,9 @@ class _ResultsCtrl:
 class _Panel(DeckBuilderPanelHandlersMixin):
     """Concrete subclass wiring just enough state for the hotkey paths."""
 
-    def __init__(self, selected: dict[str, Any] | None) -> None:
+    def __init__(self, selected: dict[str, Any] | None, first_selected: int = 0) -> None:
         self._selected = selected
-        self.results_ctrl = _ResultsCtrl()
+        self.results_ctrl = _ResultsCtrl(first_selected)
         self.main_calls: list[tuple[str, int]] = []
         self.side_calls: list[tuple[str, int]] = []
         self.active_zone_calls: list[str] = []
@@ -227,6 +227,45 @@ def test_ctrl_digit_is_skipped() -> None:
     panel._on_result_key_down(event)
     assert panel.main_calls == []
     assert event.skipped is True
+
+
+def test_alt_digit_is_skipped() -> None:
+    """Alt-modified digits are left for the global app hotkey handler."""
+    panel = _Panel({"name": "Island"})
+    event = _KeyEvent(ord("1"), alt=True)
+    panel._on_result_key_down(event)
+    assert panel.main_calls == []
+    assert event.skipped is True
+
+
+def test_plus_with_no_selection_is_skipped() -> None:
+    """'+' with nothing selected must not add a phantom card; it Skips instead."""
+    panel = _Panel({"name": "Island"}, first_selected=_WX.NOT_FOUND)
+    event = _KeyEvent(ord("+"))
+    panel._on_result_key_down(event)
+    assert panel.active_zone_calls == []
+    assert panel.main_calls == []
+    assert panel.side_calls == []
+    assert event.skipped is True
+
+
+@pytest.mark.parametrize("card", [{}, {"name": ""}])
+def test_digit_with_unnamed_card_does_nothing(card: dict[str, Any]) -> None:
+    """A selected card without a usable name must not be added to a zone."""
+    panel = _Panel(card)
+    event = _KeyEvent(ord("1"))
+    panel._on_result_key_down(event)
+    assert panel.main_calls == []
+    assert panel.side_calls == []
+
+
+@pytest.mark.parametrize("card", [{}, {"name": ""}])
+def test_plus_with_unnamed_card_does_nothing(card: dict[str, Any]) -> None:
+    """The '+' active-zone shortcut must not add a card lacking a name."""
+    panel = _Panel(card)
+    event = _KeyEvent(ord("+"))
+    panel._on_result_key_down(event)
+    assert panel.active_zone_calls == []
 
 
 def test_unmapped_key_is_skipped() -> None:


### PR DESCRIPTION
## Summary

Adds unit tests for three previously-unexercised branches in `DeckBuilderPanelHandlersMixin`'s result-list hotkey logic (`widgets/panels/deck_builder_panel/handlers.py`): the Alt-modified digit `Skip` path in `_on_result_key_down`, the `+` active-zone shortcut with no selection (`wx.NOT_FOUND` -> `Skip`), and the `name`-missing guards in `_on_add_to_zone` / `_add_result_by_index`. The `_Panel` test double now accepts a `first_selected` argument so the empty-selection `+` path can be driven with `wx.NOT_FOUND`. No production code changed — this is a test-only quality fix.

## Verification

- `python -m ruff check tests/test_deck_builder_hotkeys.py` — passed
- `python -m black --check tests/test_deck_builder_hotkeys.py` — passed (unchanged)
- `python -m pytest tests/test_deck_builder_hotkeys.py -q` — 23 passed

These tests are wx-independent (they use the existing in-file `wx` stub and faithful event/panel doubles), so they run fully in WSL. No GUI or real `wx` import was attempted; actual wx event dispatch behavior on the Windows host is not exercised by these tests (as before).

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)