### PR TITLE
test: cover analyze_deck land estimation, totals, and malformed lines

### DIFF
--- a/tests/test_deck_service.py
+++ b/tests/test_deck_service.py
@@ -58,6 +58,7 @@ def test_analyze_deck_preserves_fractional_quantities(deck_service):
     # Check total counts
     assert stats["mainboard_count"] == pytest.approx(7.83)
     assert stats["sideboard_count"] == pytest.approx(4.67)
+    assert stats["total_cards"] == pytest.approx(12.5)
 
 
 def test_analyze_deck_merges_duplicate_entries(deck_service):
@@ -81,3 +82,52 @@ def test_analyze_deck_merges_duplicate_entries(deck_service):
     sideboard_dict = dict(stats["sideboard_cards"])
     assert sideboard_dict["Abrade"] == 3
     assert stats["unique_sideboard"] == 1
+    assert stats["total_cards"] == 9
+
+
+def test_analyze_deck_estimates_lands_from_mainboard(deck_service):
+    """estimated_lands sums mainboard cards whose name matches a land keyword."""
+    deck_text = "4 Island\n" "3 Mountain\n" "4 Lightning Bolt\n" "\n" "Sideboard\n" "2 Swamp\n"
+
+    stats = deck_service.analyze_deck(deck_text)
+
+    # Only mainboard lands count; the sideboard Swamp is excluded.
+    assert stats["estimated_lands"] == 7
+
+
+def test_analyze_deck_counts_multi_keyword_land_once(deck_service):
+    """A card matching several land keywords is counted once, not per keyword."""
+    # "Island" matches both the "island" and "land" keywords.
+    deck_text = "4 Island\n"
+
+    stats = deck_service.analyze_deck(deck_text)
+
+    assert stats["estimated_lands"] == 4
+
+
+def test_analyze_deck_skips_malformed_lines(deck_service):
+    """Lines without a numeric count or a card name are skipped, not errors."""
+    deck_text = "Deck\n" "Burn\n" "x Lightning Bolt\n" "2 Island\n" "1.5 Consider\n"
+
+    stats = deck_service.analyze_deck(deck_text)
+
+    mainboard_dict = dict(stats["mainboard_cards"])
+    # The valid lines are parsed; malformed ones are dropped.
+    assert ("Island", 2) in stats["mainboard_cards"]
+    assert ("Consider", pytest.approx(1.5)) in stats["mainboard_cards"]
+    # "Burn", "x Lightning Bolt", and "Deck" produce no entries.
+    assert "Burn" not in mainboard_dict
+    assert "Lightning Bolt" not in mainboard_dict
+    assert "Deck" not in mainboard_dict
+    assert stats["unique_mainboard"] == 2
+
+
+def test_build_card_list_narrows_integers_to_int(deck_service):
+    """Whole-number totals are returned as int, fractional totals stay float."""
+    deck_text = "4 Island\n2.5 Lightning Bolt\n"
+
+    stats = deck_service.analyze_deck(deck_text)
+    mainboard_dict = dict(stats["mainboard_cards"])
+
+    assert isinstance(mainboard_dict["Island"], int)
+    assert isinstance(mainboard_dict["Lightning Bolt"], float)


### PR DESCRIPTION
Strengthens `tests/test_deck_service.py` to close the test-quality gaps reported in #581: the `estimated_lands` substring detection in `analyze_deck`, the `total_cards` aggregate, the malformed-line tolerance of `_iter_entries`, and the int-vs-float narrowing in `_build_card_list`. New tests assert that mainboard-only lands are summed and that a name matching multiple keywords (e.g. "Island" matching both `island` and `land`) is counted once; that `total_cards` is verified in both the fractional and merge cases; that single-token, non-numeric-count, and stray header lines are skipped while surrounding valid lines parse; and that whole-number totals come back as `int` while fractional totals stay `float`. No production code was changed.

## Verification
- `python -m ruff check tests/test_deck_service.py` — passed.
- `python -m black --check tests/test_deck_service.py` — passed after reformatting.
- The full test module could not be collected in WSL because `tests/test_deck_service.py` imports `services.deck_service`, whose import chain pulls in `wx` (`utils/constants/keyboard.py`), which is not installable here. To confirm the new assertions match real behavior, I loaded `services/deck_service/parser.py` in isolation (it has no wx dependency) and ran the exact inputs: estimated_lands=7 (sideboard Swamp excluded), multi-keyword Island counted once=4, malformed lines dropped leaving `[('Island', 2), ('Consider', 1.5)]`, total_cards=12.5 and 9, and Island narrowed to `int` / Lightning Bolt kept as `float`. All matched the test expectations.
- Not verified in WSL: running the assertions through the actual pytest collection path (blocked by the wx import) and any wx/UI behavior. CI on Windows should run the full module.

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)