### PR TITLE
test: cover malformed lines and fractional counts in deck parser

### DIFF
--- a/tests/test_deck_utils.py
+++ b/tests/test_deck_utils.py
@@ -100,6 +100,59 @@ Sideboard
     assert summary["unique_sideboard"] == 1
 
 
+def test_analyze_deck_skips_malformed_lines():
+    """Verify lines without a leading numeric count or with too few parts are ignored."""
+    deck_with_noise = """Deck
+4 Lightning Bolt
+// comment
+x Counterspell
+3 Island
+Wasteland
+"""
+    summary = DeckService().analyze_deck(deck_with_noise)
+    mainboard_dict = dict(summary["mainboard_cards"])
+    # Only the two valid, count-prefixed lines parse.
+    assert mainboard_dict == {"Lightning Bolt": 4, "Island": 3}
+    assert summary["unique_mainboard"] == 2
+    assert summary["mainboard_count"] == 7
+
+
+def test_deck_to_dictionary_skips_malformed_lines():
+    """Verify deck_to_dictionary ignores non-numeric counts and single-token lines."""
+    deck_with_noise = """Deck
+2 Ragavan, Nimble Pilferer
+// comment
+Wasteland
+1 Blood Moon
+"""
+    parsed = DeckService().deck_to_dictionary(deck_with_noise)
+    assert parsed == {"Ragavan, Nimble Pilferer": 2.0, "Blood Moon": 1.0}
+
+
+def test_analyze_deck_preserves_fractional_quantities():
+    """Averaged decks use fractional counts; whole numbers must stay int, fractions stay float."""
+    averaged_deck = """2.5 Lightning Bolt
+3 Island
+"""
+    summary = DeckService().analyze_deck(averaged_deck)
+    mainboard_dict = dict(summary["mainboard_cards"])
+
+    assert mainboard_dict["Lightning Bolt"] == 2.5
+    assert isinstance(mainboard_dict["Lightning Bolt"], float)
+    assert mainboard_dict["Island"] == 3
+    assert isinstance(mainboard_dict["Island"], int)
+
+
+def test_deck_to_dictionary_preserves_fractional_quantities():
+    """deck_to_dictionary keeps float counts intact for averaged decks."""
+    averaged_deck = """2.5 Lightning Bolt
+3 Island
+"""
+    parsed = DeckService().deck_to_dictionary(averaged_deck)
+    assert parsed["Lightning Bolt"] == 2.5
+    assert parsed["Island"] == 3.0
+
+
 def test_sanitize_filename_removes_null_bytes():
     """Verify null bytes are replaced with underscores (consecutive underscores collapsed)."""
     assert sanitize_filename("test\x00file") == "test_file"


### PR DESCRIPTION
## Summary

Addresses the two medium-severity test-quality findings in issue #582 by adding four targeted tests to `tests/test_deck_utils.py` that exercise previously uncovered branches of the deck parser. Two tests feed malformed deck-list noise (a `Deck` header, a `// comment`, a non-numeric `x Counterspell` count, and bare single-token card names) and assert those lines are silently skipped while valid count-prefixed lines around them still parse (covering the `len(parts) < 2` and `float(parts[0])` `ValueError` skip paths in `_iter_entries`). Two more tests pass a fractional count (`2.5 Lightning Bolt`) alongside a whole number (`3 Island`) and assert the fraction is preserved as a `float` while the integer is coerced to `int`, covering the `int(total) if float(total).is_integer() else total` branch used for averaged decks.

## Verification

- `python -m ruff check tests/test_deck_utils.py` — passed.
- `python -m black --check tests/test_deck_utils.py` — passed (file unchanged).
- `python -m pytest tests/test_deck_utils.py` could NOT run in WSL: importing `services.deck_service.DeckService` transitively imports `wx` (via `utils.constants.keyboard`), which is not installable off-Windows. The same is true of every test already in this file.
- To verify the new assertions, I loaded `services/deck_service/parser.py` in isolation (bypassing the wx-importing package `__init__`) and ran `DeckParser` — which uses the identical `DeckParserMixin` as `DeckService` — against all four fixtures. Output matched every assertion exactly: malformed lines were skipped, and fractional/whole counts were preserved as `float`/`int` respectively.
- Full pytest execution under Windows CI is the source of truth for the wx-importing collection path.

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)