### PR TITLE
test: cover diagnostics app-version fallback and rotated event files

### DIFF
--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from utils.diagnostics import EventLogger, export_diagnostics_bundle
+from utils.diagnostics import EventLogger, _get_app_version, export_diagnostics_bundle
 
 # ---------------------------------------------------------------------------
 # EventLogger
@@ -111,7 +111,28 @@ class TestExportDiagnosticsBundle:
             assert "system_info.json" in zf.namelist()
             info = json.loads(zf.read("system_info.json"))
             assert "platform" in info
+            assert "platform_release" in info
             assert "python_version" in info
+            # app_version must always be present and non-empty for support triage
+            assert "app_version" in info
+            assert info["app_version"]
+
+    def test_event_log_rotated_files_included(self, tmp_path: Path) -> None:
+        """Rotated event files (events.jsonl.1) must also land in the bundle."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        el = EventLogger(logs_dir, enabled=True)
+        # Force rotation: first write creates the file, second sees size >= 1
+        el._MAX_BYTES = 1
+        el.log("first_event")
+        el.log("second_event")
+        assert (logs_dir / "events.jsonl.1").exists()
+
+        out = export_diagnostics_bundle(tmp_path / "bundle.zip", logs_dir=logs_dir)
+        with zipfile.ZipFile(out) as zf:
+            names = zf.namelist()
+        assert "logs/events.jsonl" in names
+        assert "logs/events.jsonl.1" in names
 
     def test_log_files_included(self, tmp_path: Path) -> None:
         logs_dir = tmp_path / "logs"
@@ -210,3 +231,35 @@ class TestExportDiagnosticsBundle:
         # Should not raise
         export_diagnostics_bundle(tmp_path / "bundle.zip", logs_dir=logs_dir)
         monkeypatch.setattr(socket.socket, "connect", original_connect)
+
+
+# ---------------------------------------------------------------------------
+# _get_app_version fallback chain
+# ---------------------------------------------------------------------------
+
+
+class TestGetAppVersion:
+    def test_returns_non_empty_string(self) -> None:
+        assert isinstance(_get_app_version(), str)
+        assert _get_app_version()
+
+    def test_falls_through_to_unknown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If both metadata and constants lookups fail, fall back to 'unknown'."""
+        import importlib.metadata
+
+        def raise_metadata(*args, **kwargs):  # type: ignore[no-untyped-def]
+            raise importlib.metadata.PackageNotFoundError("mtgo_tools")
+
+        monkeypatch.setattr(importlib.metadata, "version", raise_metadata)
+        # Block the utils.constants fallback so we reach the final "unknown".
+        import builtins
+
+        original_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if name == "utils.constants":
+                raise ImportError("blocked for test")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        assert _get_app_version() == "unknown"


### PR DESCRIPTION
Closes #584

Adds the two missing test coverage paths in `tests/test_diagnostics.py` flagged by the test-file-review workflow. The first medium finding is addressed by extending `test_zip_contains_system_info` to assert `system_info.json` carries a non-empty `app_version` plus `platform_release`, and by adding a `TestGetAppVersion` class that forces both the `importlib.metadata.version("mtgo_tools")` and `utils.constants.APP_VERSION` lookups to fail so the `"unknown"` fallback branch is exercised. The second finding is addressed by a new `test_event_log_rotated_files_included` test that triggers `EventLogger` rotation (so both `events.jsonl` and `events.jsonl.1` exist) and asserts both files appear in the exported bundle, guarding the `events.jsonl*` glob against being narrowed. This is a test-only change; no production code was modified.

## Verification
- `python -m pytest tests/test_diagnostics.py -q` -> 24 passed (was 21; 3 new test cases).
- `python -m ruff check tests/test_diagnostics.py` -> All checks passed.
- `python -m black --check tests/test_diagnostics.py` -> would be left unchanged.
- These tests are pure-Python and do not import `wx`, so they run fully in WSL. No GUI/wx behavior is involved, so there is nothing wx-specific that could not be checked here. Note: in this WSL environment `mtgo_tools` is not pip-installed and `utils.constants` has no `APP_VERSION`, so `_get_app_version()` resolves to `"unknown"`; the assertions are written to remain valid regardless of which fallback tier resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)