### PR TITLE
test: cover write-path guards and bulk_replace contract for format card pool repo

### DIFF
--- a/tests/test_format_card_pool_repository.py
+++ b/tests/test_format_card_pool_repository.py
@@ -113,3 +113,62 @@ def test_bulk_replace_invalidates(repo):
         ]
     )
     assert repo.get_card_total("modern", "Lightning Bolt") == 3
+
+
+def test_bulk_replace_returns_count_and_persists_all(repo):
+    # Multiple distinct formats: the return value is the number of entries
+    # successfully replaced, and each snapshot must be persisted.
+    replaced = repo.bulk_replace([_entry(), _entry("legacy")])
+    assert replaced == 2
+    assert repo.get_card_total("modern", "Lightning Bolt") == 40
+    assert repo.get_card_total("legacy", "Lightning Bolt") == 40
+
+
+def test_bulk_replace_skips_invalid_entries(repo):
+    # A bad entry (missing format / non-list cards) is rejected by
+    # replace_format_pool (returns False), so it is not counted and valid
+    # entries still persist.
+    replaced = repo.bulk_replace(
+        [
+            {},
+            _entry(),
+            {"format": "legacy", "cards": "notalist"},
+        ]
+    )
+    assert replaced == 1
+    assert repo.get_card_total("modern", "Lightning Bolt") == 40
+    assert repo.get_summary("legacy") is None
+
+
+def test_replace_format_pool_rejects_invalid_entries(repo):
+    # Missing format, blank/whitespace format, and non-list cards are all
+    # data-integrity guards on the write path and must return False without
+    # persisting anything.
+    assert repo.replace_format_pool({}) is False
+    assert repo.replace_format_pool({"format": "   "}) is False
+    assert repo.replace_format_pool({"format": "modern", "cards": "notalist"}) is False
+
+    assert repo.get_summary("modern") is None
+    assert repo.get_card_total("modern", "Lightning Bolt") is None
+
+
+def test_copies_played_coercion_falls_back_to_zero(repo):
+    # Non-numeric, None, and missing copies_played must coerce to 0 rather than
+    # corrupting the stored total or raising.
+    assert (
+        repo.replace_format_pool(
+            _entry(
+                cards=["Lightning Bolt", "Brainstorm", "Counterspell"],
+                copy_totals=[
+                    {"card_name": "Lightning Bolt", "copies_played": "oops"},
+                    {"card_name": "Brainstorm", "copies_played": None},
+                    {"card_name": "Counterspell"},
+                ],
+            )
+        )
+        is True
+    )
+
+    assert repo.get_card_total("modern", "Lightning Bolt") == 0
+    assert repo.get_card_total("modern", "Brainstorm") == 0
+    assert repo.get_card_total("modern", "Counterspell") == 0


### PR DESCRIPTION
## Summary

Addresses the three medium-severity test-quality findings in issue #585 for `tests/test_format_card_pool_repository.py`. The existing tests covered the read-caching/connection-reuse mechanics well but only exercised the write path's happy cases. This adds coverage for: `bulk_replace`'s return-count contract (number of successfully replaced entries) plus its skip-and-continue behavior on invalid entries; `replace_format_pool`'s false-return data-integrity guards (missing/blank format, non-list `cards`); and the `copies_played` coercion fallback to `0` for non-numeric, `None`, and missing values. No production code changed — these are test-only additions matching the existing file style and helpers.

## Verification

- `python -m ruff check tests/test_format_card_pool_repository.py` — passed.
- `python -m black --check tests/test_format_card_pool_repository.py` — passed (unchanged).
- Could NOT run pytest in WSL: collecting this test transitively imports `utils.constants` -> `utils.constants.keyboard` -> `wx`, which is not importable off-Windows (the same import the pre-existing tests in this file already rely on). The new assertions were derived directly from `repositories/format_card_pool_repository/writes.py` (`replace_format_pool` guards at lines 22-26, `copies_played` coercion at lines 40-44, `bulk_replace` count/skip at lines 84-91) and `reads.py` (`get_card_total`/`get_summary` semantics). Full execution must be validated by Windows CI.

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)