### PR TITLE
test: cover all help manifest files and TOC topics (#587)

### DIFF
--- a/tests/test_help_assets.py
+++ b/tests/test_help_assets.py
@@ -1,31 +1,81 @@
 """Smoke checks for the bundled help assets.
 
 These guard against regressions where the help viewer can't find its docs
-(see issue #464): the path helper must resolve to the real ``help/`` tree
-and the manifest's default topic must exist on disk.
+(see issue #464): the path helper must resolve to the real ``help/`` tree,
+the manifest's default topic and every file it references must exist on disk,
+and every topic linked from the table of contents must exist as well.
 """
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 from utils.constants.paths import resource_path
 
 
-def test_help_index_is_loadable():
+def _read_hhp() -> tuple[Path, str]:
     hhp = resource_path("help", "mtgo_tools.hhp")
     assert hhp.is_file(), f"expected help project file at {hhp}"
+    return hhp, hhp.read_text(encoding="utf-8")
 
-    text = hhp.read_text(encoding="utf-8")
-    assert "Default topic=" in text
 
-    default_topic = next(
-        (
-            line.split("=", 1)[1].strip()
-            for line in text.splitlines()
-            if line.startswith("Default topic=")
-        ),
+def _option(text: str, key: str) -> str | None:
+    return next(
+        (line.split("=", 1)[1].strip() for line in text.splitlines() if line.startswith(f"{key}=")),
         None,
     )
+
+
+def test_help_index_is_loadable():
+    hhp, text = _read_hhp()
+
+    default_topic = _option(text, "Default topic")
     assert default_topic, "help project file missing Default topic"
 
     topic_path = hhp.parent / default_topic
     assert topic_path.is_file(), f"default help topic missing: {topic_path}"
+
+
+def test_help_contents_and_index_files_exist():
+    hhp, text = _read_hhp()
+
+    for key in ("Contents file", "Index file"):
+        value = _option(text, key)
+        assert value, f"help project file missing {key}"
+        path = hhp.parent / value
+        assert path.is_file(), f"{key} missing: {path}"
+
+
+def test_help_manifest_files_all_exist():
+    hhp, text = _read_hhp()
+
+    files_section = text.split("[FILES]", 1)
+    assert len(files_section) == 2, "help project file missing [FILES] section"
+
+    listed = [line.strip() for line in files_section[1].splitlines() if line.strip()]
+    # Stop at the next bracketed section, if any follows [FILES].
+    files = []
+    for entry in listed:
+        if entry.startswith("["):
+            break
+        files.append(entry)
+    assert files, "help project file [FILES] section is empty"
+
+    for entry in files:
+        path = hhp.parent / entry
+        assert path.is_file(), f"manifest file missing: {path}"
+
+
+def test_help_contents_topics_all_exist():
+    hhp = resource_path("help", "mtgo_tools.hhp")
+    hhc = hhp.parent / "contents.hhc"
+    assert hhc.is_file(), f"contents file missing: {hhc}"
+
+    text = hhc.read_text(encoding="utf-8")
+    locals_ = re.findall(r'<param\s+name="Local"\s+value="([^"]+)"', text, flags=re.IGNORECASE)
+    assert locals_, "contents.hhc references no topics"
+
+    for topic in locals_:
+        path = hhp.parent / topic
+        assert path.is_file(), f"contents topic missing: {path}"


### PR DESCRIPTION
## Summary

Strengthens `tests/test_help_assets.py`, which previously only asserted that the manifest's Default topic existed. The `.hhp` `[FILES]` section lists 13 HTML files, the `OPTIONS` section declares a Contents file and Index file, and `contents.hhc` references 13 topics via `param name="Local"` — none of which were checked. Any of them could be renamed or deleted and the suite would still pass while the help viewer 404s on that page (the exact regression class this file claims to guard against). This PR adds focused assertions that every `[FILES]` entry, the Contents/Index files, and every `contents.hhc` topic resolve to a real file under the `help/` tree, and factors the shared manifest reading/option parsing into small helpers. No application code changes.

## Verification

- `python -m ruff check tests/test_help_assets.py` — passed.
- `python -m black --check tests/test_help_assets.py` — passed (formatted with black).
- Could NOT run `pytest tests/test_help_assets.py` in WSL: importing `utils.constants.paths` pulls in `utils/constants/__init__.py`, which imports `wx` (not installable off-Windows). This is a pre-existing condition — the original test had the identical import and likewise only runs on Windows CI.
- To validate the new logic in WSL, I loaded `utils/constants/paths.py` directly (bypassing the wx-importing package `__init__`) and ran every new assertion against the real help assets: Default topic, Contents file (`contents.hhc`), Index file (`index.hhk`), all 13 `[FILES]` entries, and all 13 `contents.hhc` topics resolved to existing files. All assertions passed.
- The test will run for real on Windows CI where `wx` is importable.

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)