### PR TITLE
test(i18n): cover per-key fallback, format edge cases, and fix empty-string trap

### DIFF
--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,3 +1,5 @@
+import pytest
+
 from utils.i18n import DEFAULT_LOCALE, MESSAGES, SUPPORTED_LOCALES, normalize_locale, translate
 
 
@@ -13,8 +15,40 @@ def test_translate_returns_locale_string_and_falls_back_to_default() -> None:
     assert translate("es-ES", "app.status.ready") == "Ready"
 
 
+def test_translate_falls_back_to_default_locale_for_missing_key(monkeypatch) -> None:
+    # A supported, non-default locale that is missing a specific key should fall
+    # back to the default locale's string for that key (the right-hand side of the
+    # per-key fallback in translate). Drop a key from the pt-BR table to exercise it.
+    pt_br = dict(MESSAGES["pt-BR"])
+    pt_br.pop("app.status.ready")
+    monkeypatch.setitem(MESSAGES, "pt-BR", pt_br)
+    assert translate("pt-BR", "app.status.ready") == MESSAGES[DEFAULT_LOCALE]["app.status.ready"]
+
+
+def test_translate_preserves_empty_string_for_supported_locale(monkeypatch) -> None:
+    # An empty-string translation in a supported locale must be returned as-is and
+    # must not silently fall through to the default locale's value.
+    pt_br = dict(MESSAGES["pt-BR"])
+    pt_br["app.status.ready"] = ""
+    monkeypatch.setitem(MESSAGES, "pt-BR", pt_br)
+    assert translate("pt-BR", "app.status.ready") == ""
+
+
 def test_translate_returns_key_when_missing() -> None:
     assert translate("pt-BR", "missing.translation.key") == "missing.translation.key"
+
+
+def test_translate_raises_when_required_placeholder_kwarg_missing() -> None:
+    # app.status.selected_language expects a `language` placeholder.
+    with pytest.raises(KeyError):
+        translate("en-US", "app.status.selected_language", wrong_kwarg="x")
+
+
+def test_translate_ignores_extra_kwargs_for_template_without_placeholders() -> None:
+    # app.status.ready has no placeholders; extra kwargs should be ignored.
+    assert (
+        translate("en-US", "app.status.ready", unused="x") == MESSAGES["en-US"]["app.status.ready"]
+    )
 
 
 def test_translate_formats_params_when_present() -> None:

--- a/utils/i18n/__init__.py
+++ b/utils/i18n/__init__.py
@@ -33,7 +33,9 @@ def normalize_locale(locale: str | None) -> LocaleCode:
 def translate(locale: str | None, key: str, **kwargs: object) -> str:
     """Return a translated string with fallback to default locale and key text."""
     normalized = normalize_locale(locale)
-    template = MESSAGES.get(normalized, {}).get(key) or MESSAGES[DEFAULT_LOCALE].get(key)
+    template = MESSAGES.get(normalized, {}).get(key)
+    if template is None:
+        template = MESSAGES[DEFAULT_LOCALE].get(key)
     if template is None:
         return key
     if not kwargs:


### PR DESCRIPTION
This PR closes the test-quality gaps flagged for `tests/test_i18n.py` and fixes the latent correctness trap behind one of them. The High finding (per-key fallback to `DEFAULT_LOCALE` was never exercised) is now covered by a test that drops a key from the pt-BR table and asserts `translate("pt-BR", key)` returns the en-US string. The two Medium findings are addressed by tests for the `.format()` error paths (missing placeholder kwarg raises `KeyError`; extra kwargs on a placeholder-free template are ignored) and by fixing the empty-string truthiness edge case: `translate()` previously used `get(key) or MESSAGES[DEFAULT_LOCALE].get(key)`, which treated a legitimate `""` translation as falsy and silently fell through to the default locale. It now uses an explicit `is None` check so empty-string translations are preserved, with a regression test pinning that behavior.

## Verification
- `python -m ruff check utils/i18n/__init__.py tests/test_i18n.py` — passed.
- `python -m black --check utils/i18n/__init__.py tests/test_i18n.py` — passed (test file reformatted by black, then re-checked clean).
- `python -m pytest tests/test_i18n.py -q` — 10 passed.
- Not verified in WSL: nothing wx/UI-related is touched here; `utils/i18n` is a pure-Python string module with no wx imports, so these checks fully cover the change. CI remains the source of truth for the broader suite and Windows build.

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
