### PR TITLE
test: make broken test-isolation reset fallback loud (#588)

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,6 +5,7 @@ instances to ensure test isolation and prevent state leakage between tests.
 """
 
 import sys
+import warnings
 from pathlib import Path
 
 # Add parent directory to sys.path to enable imports from repositories and services
@@ -14,16 +15,45 @@ if str(parent_dir) not in sys.path:
 
 
 # ruff: noqa: E402
+def _noop(*_args, **_kwargs):
+    return None
+
+
 def _optional_reset(module_path: str, attr_name: str):
-    """Dynamically import a reset function, falling back to a no-op."""
+    """Dynamically import a reset function, falling back to a no-op.
+
+    The fallback exists so the test suite still collects in environments where
+    an optional dependency (e.g. ``wx``) is unavailable and the target module
+    cannot be imported. To avoid masking real regressions, only the expected
+    import/attribute failures are tolerated, and any fallback that is *not*
+    caused by a genuinely missing optional dependency is surfaced as a warning
+    so that a renamed/removed/relocated reset function is loud rather than a
+    silently broken test-isolation no-op.
+    """
     try:
         module = __import__(module_path, fromlist=[attr_name])
+    except ImportError as exc:  # pragma: no cover - depends on installed deps
+        # A missing optional dependency (the module that failed to import is
+        # not the target module itself) is the expected, benign fallback case.
+        missing = getattr(exc, "name", None)
+        if missing is not None and missing != module_path:
+            return _noop
+        warnings.warn(
+            f"Could not import reset module {module_path!r}; test isolation for "
+            f"{attr_name!r} is disabled (using a no-op).",
+            stacklevel=2,
+        )
+        return _noop
+
+    try:
         return getattr(module, attr_name)
-    except Exception:  # pragma: no cover - used in CI without optional deps
-
-        def _noop(*_args, **_kwargs):
-            return None
-
+    except AttributeError:
+        warnings.warn(
+            f"{module_path!r} has no attribute {attr_name!r}; test isolation for "
+            f"this singleton is disabled (using a no-op). It may have been "
+            f"renamed or removed.",
+            stacklevel=2,
+        )
         return _noop
 
 

--- a/tests/test_reset_helpers.py
+++ b/tests/test_reset_helpers.py
@@ -1,0 +1,95 @@
+"""Unit tests for the reset-function resolution in ``tests/test_helpers.py``.
+
+These cover the fallback behaviour of ``_optional_reset`` so that a renamed,
+removed, or relocated ``reset_*`` function produces a loud warning instead of a
+silently broken (no-op) test-isolation hook, while a genuinely missing optional
+dependency (e.g. ``wx``) stays silent.
+"""
+
+import sys
+import types
+import warnings
+
+import pytest
+import test_helpers
+
+
+@pytest.fixture
+def fake_module():
+    """Register a throwaway module in ``sys.modules`` and clean it up."""
+    created = []
+
+    def _make(name):
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+        created.append(name)
+        return mod
+
+    yield _make
+
+    for name in created:
+        sys.modules.pop(name, None)
+
+
+def test_resolves_existing_attribute(fake_module):
+    mod = fake_module("fake_reset_mod_exists")
+
+    def reset_thing():
+        return "called"
+
+    mod.reset_thing = reset_thing
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would fail the test
+        fn = test_helpers._optional_reset("fake_reset_mod_exists", "reset_thing")
+
+    assert fn is reset_thing
+    assert fn() == "called"
+
+
+def test_missing_attribute_warns(fake_module):
+    """A renamed/removed reset function must surface a warning, not silence."""
+    fake_module("fake_reset_mod_no_attr")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn = test_helpers._optional_reset("fake_reset_mod_no_attr", "reset_renamed")
+
+    assert fn() is None  # no-op fallback
+    assert any("reset_renamed" in str(c.message) for c in caught)
+
+
+def test_missing_target_module_warns():
+    """An unimportable target module (its own name) must warn."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn = test_helpers._optional_reset("definitely_not_a_real_module_xyz", "reset_y")
+
+    assert fn() is None
+    assert any("definitely_not_a_real_module_xyz" in str(c.message) for c in caught)
+
+
+def test_transitive_missing_optional_dependency_is_silent(monkeypatch):
+    """ImportError whose ``.name`` differs from the target module is benign.
+
+    This is the expected CI fallback (e.g. the module imports ``wx`` which is
+    not installed): the resolution should fall back to a no-op *silently*.
+    """
+    module_path = "pkg.target_mod"
+
+    def fake_import(name, *args, **kwargs):
+        # Simulate the target module importing an absent optional dependency.
+        raise ImportError("No module named 'wx'", name="wx")
+
+    monkeypatch.setattr(test_helpers, "__import__", fake_import, raising=False)
+    # ``__import__`` is looked up as a builtin; patch builtins to be safe.
+    import builtins
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn = test_helpers._optional_reset(module_path, "reset_x")
+
+    assert fn() is None
+    assert not caught, [str(c.message) for c in caught]


### PR DESCRIPTION
## Summary

`tests/test_helpers._optional_reset` resolved the 12 `reset_*` singleton-clearing functions (used by the autouse `reset_global_state` fixture in `tests/conftest.py`) inside a bare `except Exception` that returned a silent no-op on ANY failure. That meant a renamed, moved, or deleted reset would silently downgrade to a no-op, letting global service/repository state leak across tests with zero signal — the false-confidence failure flagged in the issue. This narrows the catch to `ImportError`/`AttributeError` and emits a `warnings.warn` when falling back, so a renamed/removed/relocated reset is loud rather than silent. The genuinely benign case — a target module failing to import only because an optional dependency (`wx`, absent in WSL/CI) is missing — stays silent by checking that the failing `ImportError.name` is a *different* module than the target. Imports are intentionally kept optional rather than made mandatory (the issue's "better" suggestion): every one of the 12 target modules transitively imports `wx`, which is not installed off-Windows, so mandatory top-level imports would break test collection entirely there.

## Verification

Run from WSL (wx not importable here; Windows-only UI behavior not exercised):
- `python -m ruff check tests/test_helpers.py tests/test_reset_helpers.py` — passes.
- `python -m black --check tests/test_helpers.py tests/test_reset_helpers.py` — passes.
- `python -m pytest tests/test_reset_helpers.py -q` — 4 passed. Covers: resolving an existing attribute (no warning), missing attribute warns, missing target module warns, and benign transitive missing-dependency stays silent.
- `python -m pytest tests/test_reset_helpers.py -q -W error::UserWarning` — 4 passed, confirming the autouse `reset_all_globals` teardown (which resolves all 12 real bindings at import time, where `wx` is missing) emits no warnings on the benign path.
- Confirmed all 12 referenced `reset_*` functions still exist at their declared module paths.

Not verified in WSL: the full wx/UI test suite (requires Windows + wx). No app/GUI code was touched — this change is confined to test-support helpers.

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)