### PR TITLE
test: cover configure_logging return path and file-failure fallback

### DIFF
--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 from loguru import logger
 
 from utils.logging_config import _warmup_filter, configure_logging
@@ -59,3 +62,37 @@ def test_debug_level_via_env(tmp_path, monkeypatch):
 def test_env_level_is_case_insensitive(tmp_path, monkeypatch):
     debug_no = logger.level("DEBUG").no
     assert all(no == debug_no for no in _captured_levels(tmp_path, monkeypatch, "debug"))
+
+
+def test_returns_log_file_path_under_logs_dir(tmp_path, monkeypatch):
+    # A writable logs_dir yields a timestamped Path under that dir, and the
+    # directory is created so the file sink can be written to.
+    monkeypatch.delenv("MTGO_LOG_LEVEL", raising=False)
+    try:
+        log_file = configure_logging(tmp_path)
+    finally:
+        logger.remove()
+
+    assert isinstance(log_file, Path)
+    assert log_file.parent == tmp_path
+    assert re.fullmatch(r"mtgo_tools_\d{8}_\d{6}\.log", log_file.name)
+    assert tmp_path.is_dir()
+
+
+def test_file_logging_failure_returns_none_but_keeps_stream_sink(tmp_path, monkeypatch):
+    # When the logs_dir cannot be created/written, file logging is disabled:
+    # configure_logging returns None but the stderr/stdout sink(s) survive so
+    # console logging still works.
+    monkeypatch.delenv("MTGO_LOG_LEVEL", raising=False)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("logs dir is not writable")
+
+    monkeypatch.setattr(Path, "mkdir", _boom)
+    try:
+        log_file = configure_logging(tmp_path)
+        assert log_file is None
+        # The stream sink was registered before the file sink failed.
+        assert len(logger._core.handlers) >= 1
+    finally:
+        logger.remove()


### PR DESCRIPTION
Adds two tests to `tests/test_logging_config.py` closing the two medium-severity coverage gaps reported for `utils/logging_config.py`: the documented return-value contract of `configure_logging` (a timestamped `Path` under the given `logs_dir`, with the directory created) was never asserted, and the file-logging exception/fallback branch (returns `None`, keeps console sink) had no coverage. One test now captures the return value and verifies it is a `Path` under `tmp_path` matching the `mtgo_tools_*.log` naming pattern; the other monkeypatches `Path.mkdir` to raise, then asserts `configure_logging` returns `None` while a stream sink remains registered.

## Verification
- `python -m pytest tests/test_logging_config.py -q` — 7 passed.
- `python -m ruff check tests/test_logging_config.py` — passed.
- `python -m black --check tests/test_logging_config.py` — clean.
- Not checked in WSL: no wx/UI behavior is involved here; this is a pure non-wx unit-test change. The full Windows UI suite was not run.

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)
