### PR TITLE
test: harden tests/test_image_service.py (#591)

### DIFF
--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -1,21 +1,53 @@
 """Tests for ImageService business logic."""
 
+import pytest
+
 import services.image_service as image_service
 from services.image_service import CardImageDownloadQueue, CardImageRequest, ImageService
+from utils.constants.timing import IMAGE_DOWNLOAD_SLOW_THRESHOLD_SECONDS
 
 
-def test_image_service_initialization():
-    """Test ImageService initializes with correct default state."""
+@pytest.fixture(autouse=True)
+def reset_not_found_keys():
+    """Clear the class-level not-found cache around each test.
+
+    ``CardImageDownloadQueue._NOT_FOUND_KEYS`` is shared by every instance, so
+    a test that marks a key not-found would otherwise leak that state into
+    sibling tests and silently change enqueue()/selected-priority behaviour.
+    """
+    CardImageDownloadQueue._NOT_FOUND_KEYS.clear()
+    yield
+    CardImageDownloadQueue._NOT_FOUND_KEYS.clear()
+
+
+@pytest.fixture
+def image_service_instance():
+    """Provide an ImageService and guarantee its background thread is stopped.
+
+    ``ImageService.__init__`` spins up a daemon thread and a ThreadPoolExecutor
+    via ``CardImageDownloadQueue``. Without an explicit ``shutdown()`` those
+    leak across the suite (the exact leaked-daemon-thread scenario that has
+    crashed CI at interpreter shutdown).
+    """
     service = ImageService()
+    try:
+        yield service
+    finally:
+        service.shutdown()
+
+
+def test_image_service_initialization(image_service_instance):
+    """Test ImageService initializes with correct default state."""
+    service = image_service_instance
 
     assert service.bulk_data_by_name is None
     assert service.printing_index_loading is False
     assert service.image_downloader is None
 
 
-def test_set_bulk_data():
+def test_set_bulk_data(image_service_instance):
     """Test setting bulk data."""
-    service = ImageService()
+    service = image_service_instance
     test_data = {
         "Lightning Bolt": [{"name": "Lightning Bolt", "set": "LEA"}],
         "Island": [{"name": "Island", "set": "LEA"}],
@@ -26,16 +58,16 @@ def test_set_bulk_data():
     assert service.get_bulk_data() == test_data
 
 
-def test_get_bulk_data_initially_none():
+def test_get_bulk_data_initially_none(image_service_instance):
     """Test that bulk data is initially None."""
-    service = ImageService()
+    service = image_service_instance
 
     assert service.get_bulk_data() is None
 
 
-def test_clear_printing_index_loading():
+def test_clear_printing_index_loading(image_service_instance):
     """Test clearing the printing index loading flag."""
-    service = ImageService()
+    service = image_service_instance
     service.printing_index_loading = True
 
     service.clear_printing_index_loading()
@@ -43,26 +75,35 @@ def test_clear_printing_index_loading():
     assert service.printing_index_loading is False
 
 
-def test_is_loading_initially_false():
+def test_is_loading_initially_false(image_service_instance):
     """Test that loading flag is initially false."""
-    service = ImageService()
+    service = image_service_instance
 
     assert service.is_loading() is False
 
 
-def test_is_loading_when_loading():
+def test_is_loading_when_loading(image_service_instance):
     """Test that is_loading returns True when loading."""
-    service = ImageService()
+    service = image_service_instance
     service.printing_index_loading = True
 
     assert service.is_loading() is True
 
 
 class _FakeCache:
+    def __init__(self, cached_keys=None):
+        # Set of (card_name, set_code, size) / (card_name, size) tuples to
+        # report as already cached.
+        self._cached_keys = set(cached_keys or ())
+
     def get_image_path_for_printing(self, card_name, set_code, size):
+        if (card_name, set_code, size) in self._cached_keys:
+            return "path"
         return None
 
     def get_image_path(self, card_name, size):
+        if (card_name, size) in self._cached_keys:
+            return "path"
         return None
 
 
@@ -79,10 +120,23 @@ class _FakeDownloader:
         return response
 
 
-def _build_queue(downloader, *, on_failed=None):
-    queue = CardImageDownloadQueue(_FakeCache(), on_failed=on_failed)
-    queue._downloader = downloader
+def _build_queue(downloader=None, *, on_failed=None, cache=None):
+    queue = CardImageDownloadQueue(cache or _FakeCache(), on_failed=on_failed)
+    if downloader is not None:
+        queue._downloader = downloader
     return queue
+
+
+def _request(**overrides):
+    params = {
+        "card_name": "Mirrorpool",
+        "uuid": None,
+        "set_code": "aeoe",
+        "collector_number": None,
+        "size": "normal",
+    }
+    params.update(overrides)
+    return CardImageRequest(**params)
 
 
 def test_download_request_retries_with_backoff(monkeypatch):
@@ -94,14 +148,7 @@ def test_download_request_retries_with_backoff(monkeypatch):
     # the stop event's wait() so it can be interrupted on shutdown.
     monkeypatch.setattr(queue._stop_event, "wait", lambda seconds: sleeps.append(seconds) or False)
     try:
-        request = CardImageRequest(
-            card_name="Mirrorpool",
-            uuid=None,
-            set_code="aeoe",
-            collector_number=None,
-            size="normal",
-        )
-        assert queue._download_request(request) is True
+        assert queue._download_request(_request()) is True
     finally:
         queue.stop()
 
@@ -124,16 +171,9 @@ def test_download_request_stop_event_interrupts_backoff(monkeypatch):
 
     monkeypatch.setattr(queue._stop_event, "wait", fake_wait)
     try:
-        request = CardImageRequest(
-            card_name="Mirrorpool",
-            uuid=None,
-            set_code="aeoe",
-            collector_number=None,
-            size="normal",
-        )
         # Should return False (giving up) instead of retrying after the wait
         # was interrupted by the stop event.
-        assert queue._download_request(request) is False
+        assert queue._download_request(_request()) is False
     finally:
         queue.stop()
 
@@ -149,72 +189,208 @@ def test_download_request_stop_event_skips_first_attempt():
     queue = _build_queue(downloader)
     queue._stop_event.set()
     try:
-        request = CardImageRequest(
-            card_name="Mirrorpool",
-            uuid=None,
-            set_code="aeoe",
-            collector_number=None,
-            size="normal",
-        )
-        assert queue._download_request(request) is False
+        assert queue._download_request(_request()) is False
     finally:
         queue.stop()
     assert downloader.calls == 0
 
 
 def test_download_request_404_no_retry(monkeypatch):
-    sleeps = []
-    monkeypatch.setattr(image_service.time, "sleep", lambda seconds: sleeps.append(seconds))
     monkeypatch.setattr(image_service.time, "monotonic", lambda: 0.0)
     failed = []
     downloader = _FakeDownloader(
         [Exception("404 Client Error: Not Found for url: https://api.scryfall.com/cards")]
     )
     queue = _build_queue(downloader, on_failed=lambda request, msg: failed.append((request, msg)))
+    waits = []
+    # A permanent failure must skip the retry/backoff path entirely. The retry
+    # path waits on the stop event, so prove no backoff occurred by asserting
+    # _stop_event.wait() is never invoked (mirroring the retry tests).
+    monkeypatch.setattr(queue._stop_event, "wait", lambda seconds: waits.append(seconds) or False)
     try:
-        request = CardImageRequest(
-            card_name="Mirrorpool",
-            uuid=None,
-            set_code="aeoe",
-            collector_number=None,
-            size="normal",
-        )
+        request = _request()
         assert queue._download_request(request) is False
+        # The not-found key is now recorded, so further enqueues are skipped.
         assert queue.enqueue(request) is False
-        other_size = CardImageRequest(
-            card_name="Mirrorpool",
-            uuid=None,
-            set_code="aeoe",
-            collector_number=None,
-            size="large",
-        )
-        assert queue.enqueue(other_size) is False
-        other_collector = CardImageRequest(
-            card_name="Mirrorpool",
-            uuid=None,
-            set_code="aeoe",
-            collector_number="42",
-            size="normal",
-        )
-        assert queue.enqueue(other_collector) is False
+        assert queue.enqueue(_request(size="large")) is False
+        assert queue.enqueue(_request(collector_number="42")) is False
     finally:
         queue.stop()
 
     assert downloader.calls == 1
-    assert sleeps == []
+    assert waits == []
     assert len(failed) == 1
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "404 Client Error: Not Found for url: x",
+        "No uuid for Mirrorpool",
+        "missing uuid for multi-face card",
+        "no downloadable faces",
+        "no normal image for Mirrorpool",
+        "no small image for Mirrorpool",
+        "no large image for Mirrorpool",
+        "no png image for Mirrorpool",
+        "no border_crop image for Mirrorpool",
+        "no art_crop image for Mirrorpool",
+    ],
+)
+def test_is_permanent_failure_message_true(message):
+    assert CardImageDownloadQueue._is_permanent_failure_message(message) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "",
+        "429 Too Many Requests",
+        "Connection reset by peer",
+        "404 but the body says ok",  # 404 without "not found" is transient
+    ],
+)
+def test_is_permanent_failure_message_false(message):
+    assert CardImageDownloadQueue._is_permanent_failure_message(message) is False
+
+
+def test_download_request_permanent_marker_bails_without_retry(monkeypatch):
+    """A non-404 permanent marker should fail immediately without backoff."""
+    monkeypatch.setattr(image_service.time, "monotonic", lambda: 0.0)
+    failed = []
+    downloader = _FakeDownloader([(False, "no normal image for Mirrorpool")])
+    queue = _build_queue(downloader, on_failed=lambda request, msg: failed.append((request, msg)))
+    waits = []
+    monkeypatch.setattr(queue._stop_event, "wait", lambda seconds: waits.append(seconds) or False)
+    try:
+        request = _request()
+        assert queue._download_request(request) is False
+        # The permanent failure was recorded as not-found, blocking re-enqueue.
+        assert queue.enqueue(request) is False
+    finally:
+        queue.stop()
+
+    assert downloader.calls == 1
+    assert waits == []
+    assert len(failed) == 1
+
+
+def test_download_request_slow_success_treated_as_failure(monkeypatch):
+    """A 'success' that is too slow and never landed on disk is rejected."""
+    # monotonic advances past the slow threshold between the two reads.
+    times = iter([0.0, IMAGE_DOWNLOAD_SLOW_THRESHOLD_SECONDS + 1.0])
+    monkeypatch.setattr(image_service.time, "monotonic", lambda: next(times))
+    downloader = _FakeDownloader([(True, "ok")])
+    # _FakeCache reports nothing cached, so the slow success cannot be verified.
+    queue = _build_queue(downloader)
+    try:
+        assert queue._download_request(_request()) is False
+    finally:
+        queue.stop()
+    assert downloader.calls == 1
+
+
+def test_enqueue_fresh_request_returns_true():
+    queue = _build_queue()
+    try:
+        request = _request()
+        assert queue.enqueue(request) is True
+        with queue._condition:
+            assert request.queue_key() in queue._pending_keys
+            assert request in queue._queue
+    finally:
+        queue.stop()
+
+
+def test_enqueue_duplicate_returns_false():
+    queue = _build_queue()
+    try:
+        request = _request()
+        assert queue.enqueue(request) is True
+        assert queue.enqueue(_request()) is False
+        with queue._condition:
+            # Still exactly one copy queued.
+            assert list(queue._queue).count(request) == 1
+    finally:
+        queue.stop()
+
+
+def test_enqueue_not_fetchable_returns_false():
+    queue = _build_queue()
+    try:
+        assert queue.enqueue(_request(card_name="   ")) is False
+    finally:
+        queue.stop()
+
+
+def test_enqueue_already_cached_returns_false():
+    cache = _FakeCache(cached_keys={("Mirrorpool", "aeoe", "normal")})
+    queue = _build_queue(cache=cache)
+    try:
+        assert queue.enqueue(_request()) is False
+        with queue._condition:
+            assert len(queue._queue) == 0
+    finally:
+        queue.stop()
+
+
+def test_enqueue_prioritize_front_loads_and_dedups():
+    queue = _build_queue()
+    try:
+        first = _request(set_code="aaa")
+        second = _request(set_code="bbb")
+        assert queue.enqueue(first) is True
+        assert queue.enqueue(second) is True
+        # Re-enqueueing `first` with prioritize=True should move it to the
+        # front without leaving a duplicate behind.
+        assert queue.enqueue(_request(set_code="aaa"), prioritize=True) is True
+        with queue._condition:
+            assert queue._queue[0].queue_key() == first.queue_key()
+            assert list(queue._queue).count(first) == 1
+            assert len(queue._queue) == 2
+    finally:
+        queue.stop()
+
+
+def test_set_selected_request_promotes_to_front():
+    """A fresh selected request is promoted to the front of the queue."""
+    queue = _build_queue()
+    try:
+        # Stop the worker thread so it cannot drain the queue mid-assert.
+        queue.stop()
+        other = _request(set_code="aaa")
+        queue.enqueue(other)
+        selected = _request(set_code="bbb")
+        queue.set_selected_request(selected)
+        with queue._condition:
+            assert queue._queue[0].queue_key() == selected.queue_key()
+            assert selected.queue_key() in queue._pending_keys
+    finally:
+        queue.stop()
+
+
+def test_set_selected_request_moves_pending_to_front():
+    """A selected request already pending is moved to the front (no dup)."""
+    queue = _build_queue()
+    try:
+        queue.stop()
+        first = _request(set_code="aaa")
+        selected = _request(set_code="bbb")
+        queue.enqueue(first)
+        queue.enqueue(selected)
+        queue.set_selected_request(selected)
+        with queue._condition:
+            assert queue._queue[0].queue_key() == selected.queue_key()
+            assert list(queue._queue).count(selected) == 1
+            assert len(queue._queue) == 2
+    finally:
+        queue.stop()
 
 
 def test_selected_request_skips_not_found():
     downloader = _FakeDownloader([(False, "nope")])
     queue = _build_queue(downloader)
-    request = CardImageRequest(
-        card_name="Mirrorpool",
-        uuid=None,
-        set_code="aeoe",
-        collector_number=None,
-        size="normal",
-    )
+    request = _request()
     not_found_key = queue._not_found_key(request)
     try:
         queue.stop()


### PR DESCRIPTION
## Summary

Addresses the test-suite review findings for `tests/test_image_service.py` (2 high, 5 medium). The vacuous 404 assertion (which monkeypatched `time.sleep`, a function the retry path never calls) is replaced with a real assertion that `_stop_event.wait` is never invoked on a permanent failure. The shared class-level `_NOT_FOUND_KEYS` set is now cleared by an autouse fixture so it no longer leaks across tests, and directly-constructed `ImageService` instances are torn down via an `image_service_instance` fixture that calls `shutdown()`, stopping the leaked daemon thread + executor. New coverage was added for `_is_permanent_failure_message` (every permanent marker plus transient/empty inputs), the slow-success-but-not-cached branch of `_download_request`, the `enqueue` happy/dedup/not-fetchable/cached/prioritize paths, and `_ensure_selected_priority_locked` promotion.

## Verification

- `python -m ruff check tests/test_image_service.py` — passed.
- `python -m black --check tests/test_image_service.py` — passed (unchanged).
- The test module transitively imports `wx` (via `utils.constants`), so it cannot be collected in WSL directly. To exercise the logic I ran the file under pytest with a dynamic stub `wx` module injected into `sys.modules`: all 34 tests pass. This is a best-effort local check; the real wx-backed run happens on Windows CI, which is the source of truth.
- No production code was changed — this is a test-only change. No GUI/wx behavior was launched or verified in WSL.

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)