### PR TITLE
test: exercise real radar code in tests/test_identify_opponent_radar.py (#590)

### DIFF
--- a/tests/test_identify_opponent_radar.py
+++ b/tests/test_identify_opponent_radar.py
@@ -14,9 +14,16 @@ These exercise the real production code paths:
   partial matches, the no-match ``None`` path, and the repo-error path).
 
 ``wx`` is not importable in the WSL dev environment, so a permissive stub
-module is injected before the handler modules are imported by file path. The
-stub's ``CallAfter`` runs synchronously so the marshalled UI calls can be
-asserted directly.
+module is injected before the handler modules are imported by file path. So the
+marshalled UI calls can be asserted directly, the handler modules loaded under
+test get their module-global ``wx`` rebound to a proxy whose ``CallAfter`` runs
+synchronously. Crucially this rebind is scoped to *these* modules only -- the
+shared ``wx`` module in ``sys.modules`` is left untouched, because other test
+files (e.g. the wxPython UI tests) rely on the real, asynchronous
+``wx.CallAfter`` to defer work off the construction path. Globally forcing
+``CallAfter`` synchronous makes deferred callbacks such as the opponent
+tracker's tutorial dialog fire mid-construction and block the whole suite on a
+modal ``ShowModal()``.
 """
 
 from __future__ import annotations
@@ -49,40 +56,68 @@ class _WxStub(types.ModuleType):
         return func(*args, **kwargs)
 
 
-def _install_wx_stub() -> types.ModuleType:
-    """Make ``wx.CallAfter`` synchronous so marshalled UI calls can be observed.
+class _SyncCallAfterWx(types.ModuleType):
+    """Proxy around the resolved ``wx`` whose ``CallAfter`` runs synchronously.
 
-    When the real ``wx`` is importable (the headless Windows CI runner) there is
-    no ``wx.App``, so the real ``wx.CallAfter`` raises "No wx.App created yet".
-    We override ``CallAfter`` to run synchronously instead of returning the
-    module untouched. When ``wx`` is absent (WSL dev) we inject a permissive
-    stub whose ``CallAfter`` is already synchronous.
+    Bound as the *loaded-under-test* handler modules' ``wx`` global so the
+    worker's marshalled UI calls execute inline (and can be asserted) without
+    a ``wx.App``. Every other attribute delegates to the real/stub ``wx``. This
+    proxy is NEVER placed in ``sys.modules``: mutating the shared ``wx`` module
+    would make ``CallAfter`` synchronous for the whole test session and hang the
+    wxPython UI tests, whose harness depends on deferred callbacks.
+    """
+
+    def __init__(self, base: types.ModuleType) -> None:
+        super().__init__("wx")
+        self.__dict__["_base"] = base
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.__dict__["_base"], name)
+
+    @staticmethod
+    def CallAfter(func: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: N802
+        return func(*args, **kwargs)
+
+
+def _ensure_wx_importable() -> types.ModuleType:
+    """Return the ``wx`` module the handlers should import, leaving it untouched.
+
+    On the Windows CI runner the real ``wx`` is importable and is returned as-is
+    (no global mutation). On the WSL dev box ``wx`` is absent, so a permissive
+    stub is injected into ``sys.modules`` -- required because importing the
+    handler modules transitively imports ``wx`` (e.g. ``services.radar_service``
+    pulls in ``utils.constants.keyboard``).
     """
     try:
         import wx as real_wx
 
-        real_wx.CallAfter = lambda func, *args, **kwargs: func(*args, **kwargs)
         return real_wx
     except Exception:
-        pass
-    stub = _WxStub("wx")
-    sys.modules["wx"] = stub
-    return stub
+        stub = _WxStub("wx")
+        sys.modules["wx"] = stub
+        return stub
 
 
 def _load_module(name: str, *parts: str) -> types.ModuleType:
-    """Import a module directly by file path, bypassing package side effects."""
+    """Import a module by file path and give it a synchronous ``wx.CallAfter``.
+
+    The module's own ``import wx`` binds the shared ``wx`` object; we rebind the
+    module global to a per-module proxy so its marshalled UI calls run inline
+    without affecting any other module's ``wx``.
+    """
     path = Path(__file__).resolve().parent.parent.joinpath(*parts)
     spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    if hasattr(module, "wx"):
+        module.wx = _SyncCallAfterWx(module.wx)
     return module
 
 
-# wx must be stubbed before importing anything that transitively imports it
+# wx must be importable before loading anything that transitively imports it
 # (services.radar_service pulls in utils.constants.keyboard, which imports wx).
-_install_wx_stub()
+_ensure_wx_importable()
 
 from services.radar_service import CardFrequency, RadarData  # noqa: E402
 

--- a/tests/test_identify_opponent_radar.py
+++ b/tests/test_identify_opponent_radar.py
@@ -50,11 +50,19 @@ class _WxStub(types.ModuleType):
 
 
 def _install_wx_stub() -> types.ModuleType:
-    """Install a ``wx`` stub only when the real module is unavailable."""
-    try:
-        import wx as real_wx  # noqa: F401
+    """Make ``wx.CallAfter`` synchronous so marshalled UI calls can be observed.
 
-        return sys.modules["wx"]
+    When the real ``wx`` is importable (the headless Windows CI runner) there is
+    no ``wx.App``, so the real ``wx.CallAfter`` raises "No wx.App created yet".
+    We override ``CallAfter`` to run synchronously instead of returning the
+    module untouched. When ``wx`` is absent (WSL dev) we inject a permissive
+    stub whose ``CallAfter`` is already synchronous.
+    """
+    try:
+        import wx as real_wx
+
+        real_wx.CallAfter = lambda func, *args, **kwargs: func(*args, **kwargs)
+        return real_wx
     except Exception:
         pass
     stub = _WxStub("wx")

--- a/tests/test_identify_opponent_radar.py
+++ b/tests/test_identify_opponent_radar.py
@@ -1,268 +1,579 @@
-"""Tests for opponent tracker radar integration."""
+"""Tests for opponent tracker radar integration.
 
-from unittest.mock import MagicMock, patch
+These exercise the real production code paths:
 
-import pytest
+* :class:`RadarMixin` worker orchestration in
+  ``widgets/frames/identify_opponent/handlers/radar.py`` (archetype guards,
+  dedup, in-progress guard, error/cancel handling, thread lifecycle).
+* :class:`CompactRadarHandlersMixin` public setters and list populators in
+  ``widgets/panels/compact_radar_panel/handlers.py`` (clear/loading/error
+  side effects and the actual card-line formatting incl. ``max(1, round(...))``
+  clamping).
+* :func:`find_archetype_by_name` / :func:`normalize_archetype_name` in
+  ``services/archetype_resolver.py`` (exact, forward- and reverse-containment
+  partial matches, the no-match ``None`` path, and the repo-error path).
 
-from services.radar_service import RadarData
+``wx`` is not importable in the WSL dev environment, so a permissive stub
+module is injected before the handler modules are imported by file path. The
+stub's ``CallAfter`` runs synchronously so the marshalled UI calls can be
+asserted directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import threading
+import types
+from pathlib import Path
+from typing import Any
 
 
-@pytest.fixture
-def mock_wx():
-    """Mock wx module to avoid GUI dependencies."""
-    with patch("widgets.frames.identify_opponent.wx") as mock:
-        # Mock common wx classes
-        mock.Frame = MagicMock
-        mock.Panel = MagicMock
-        mock.StaticText = MagicMock
-        mock.Button = MagicMock
-        mock.Timer = MagicMock
-        mock.BoxSizer = MagicMock
-        mock.VERTICAL = 0
-        mock.HORIZONTAL = 1
-        mock.EXPAND = 1
-        mock.ALL = 1
-        mock.CallAfter = lambda func, *args, **kwargs: func(*args, **kwargs)
-        yield mock
+# --------------------------------------------------------------------------- #
+# wx stub + module loading                                                    #
+# --------------------------------------------------------------------------- #
+class _WxStub(types.ModuleType):
+    """A permissive ``wx`` stand-in fabricating attributes on demand.
+
+    ``CallAfter`` is overridden to run synchronously so that the UI calls the
+    worker marshals via ``wx.CallAfter`` can be observed in the test thread.
+    """
+
+    def __getattr__(self, name: str) -> Any:  # noqa: D401 - simple stub
+        value: Any = type(name, (), {})
+        setattr(self, name, value)
+        return value
+
+    @staticmethod
+    def CallAfter(func: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: N802
+        return func(*args, **kwargs)
 
 
-@pytest.fixture
-def mock_radar_service():
-    """Mock radar service."""
-    service = MagicMock()
-    service.calculate_radar.return_value = RadarData(
+def _install_wx_stub() -> types.ModuleType:
+    """Install a ``wx`` stub only when the real module is unavailable."""
+    try:
+        import wx as real_wx  # noqa: F401
+
+        return sys.modules["wx"]
+    except Exception:
+        pass
+    stub = _WxStub("wx")
+    sys.modules["wx"] = stub
+    return stub
+
+
+def _load_module(name: str, *parts: str) -> types.ModuleType:
+    """Import a module directly by file path, bypassing package side effects."""
+    path = Path(__file__).resolve().parent.parent.joinpath(*parts)
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# wx must be stubbed before importing anything that transitively imports it
+# (services.radar_service pulls in utils.constants.keyboard, which imports wx).
+_install_wx_stub()
+
+from services.radar_service import CardFrequency, RadarData  # noqa: E402
+
+RadarMixin = _load_module(
+    "_radar_handler_under_test",
+    "widgets",
+    "frames",
+    "identify_opponent",
+    "handlers",
+    "radar.py",
+).RadarMixin
+CompactRadarHandlersMixin = _load_module(
+    "_compact_radar_handlers_under_test",
+    "widgets",
+    "panels",
+    "compact_radar_panel",
+    "handlers.py",
+).CompactRadarHandlersMixin
+
+
+# --------------------------------------------------------------------------- #
+# helpers                                                                      #
+# --------------------------------------------------------------------------- #
+def _card(name: str, avg_copies: float, inclusion_rate: float = 100.0) -> CardFrequency:
+    return CardFrequency(
+        card_name=name,
+        appearances=10,
+        total_copies=int(avg_copies * 10),
+        max_copies=4,
+        avg_copies=avg_copies,
+        inclusion_rate=inclusion_rate,
+        expected_copies=avg_copies,
+        copy_distribution={},
+    )
+
+
+def _radar(mainboard=None, sideboard=None, total: int = 10) -> RadarData:
+    return RadarData(
         archetype_name="UR Murktide",
         format_name="Modern",
-        mainboard_cards=[],
-        sideboard_cards=[],
-        total_decks_analyzed=10,
+        mainboard_cards=list(mainboard or []),
+        sideboard_cards=list(sideboard or []),
+        total_decks_analyzed=total,
         decks_failed=0,
     )
-    return service
 
 
-@pytest.fixture
-def mock_metagame_repo():
-    """Mock metagame repository."""
-    repo = MagicMock()
-    repo.get_archetypes_for_format.return_value = [
-        {"name": "UR Murktide", "href": "/archetype/ur-murktide"},
-        {"name": "Azorius Control", "href": "/archetype/azorius-control"},
-    ]
-    return repo
+class _FakePanel:
+    """Records the radar-panel setter/clear calls the worker marshals."""
+
+    def __init__(self) -> None:
+        self.set_error_calls: list[str] = []
+        self.set_loading_calls: list[str] = []
+        self.display_radar_calls: list[RadarData] = []
+        self.clear_calls = 0
+
+    def set_error(self, message: str) -> None:
+        self.set_error_calls.append(message)
+
+    def set_loading(self, message: str) -> None:
+        self.set_loading_calls.append(message)
+
+    def display_radar(self, radar: RadarData) -> None:
+        self.display_radar_calls.append(radar)
+
+    def clear(self) -> None:
+        self.clear_calls += 1
 
 
-class TestRadarIntegration:
-    """Test radar integration in opponent tracker."""
+class _FakeController:
+    def __init__(self, resolved: dict[str, Any] | None) -> None:
+        self._resolved = resolved
+        self.resolve_calls: list[tuple] = []
 
-    def test_trigger_radar_load_with_valid_archetype(
-        self, mock_wx, mock_radar_service, mock_metagame_repo
-    ):
-        """Test that radar loading is triggered when opponent has known deck."""
-        with patch("services.archetype_resolver.find_archetype_by_name") as mock_find:
-            mock_find.return_value = {
-                "name": "UR Murktide",
-                "href": "/archetype/ur-murktide",
-            }
+    def find_archetype_by_name(self, archetype_name, format_name, repo):
+        self.resolve_calls.append((archetype_name, format_name, repo))
+        return self._resolved
 
-            # This would normally create the GUI, but we're mocking wx
-            # So we can't fully instantiate it without GUI dependencies
-            # Instead, test the logic directly
 
-            # Verify find_archetype_by_name would be called with correct args
-            archetype_dict = mock_find("UR Murktide", "Modern", mock_metagame_repo)
-            assert archetype_dict is not None
-            assert archetype_dict["name"] == "UR Murktide"
+class _FakeHost(RadarMixin):
+    """Concrete :class:`RadarMixin` host with the collaborators it touches."""
 
-    def test_clear_radar_on_opponent_change(self, mock_wx):
-        """Test that radar clears when opponent changes."""
-        # Test the clear logic
-        mock_panel = MagicMock()
-        mock_panel.clear = MagicMock()
+    def __init__(self, last_seen_decks, resolved):
+        self.last_seen_decks = last_seen_decks
+        self._last_radar_archetype = ""
+        self._radar_worker_thread = None
+        self._radar_cancel_requested = False
+        self.current_radar = None
+        self._last_guide_archetype = "stale"
+        self.radar_panel = _FakePanel()
+        self.sideboard_panel = _FakePanel()
+        self.controller = _FakeController(resolved)
+        self.metagame_service = types.SimpleNamespace(metagame_repo=object())
+        self.radar_service = types.SimpleNamespace(calculate_radar=None)
 
-        # Simulate clearing
-        mock_panel.clear()
-        mock_panel.clear.assert_called_once()
 
-    def test_skip_duplicate_radar_requests(self):
-        """Test that duplicate radar requests for same archetype are skipped."""
-        last_archetype = "UR Murktide"
-        new_archetype = "UR Murktide"
+def _join_worker(host: _FakeHost) -> None:
+    """Wait for the (already started) worker thread to finish, if any."""
+    thread = host._radar_worker_thread
+    if isinstance(thread, threading.Thread):
+        thread.join(timeout=5)
 
-        # Should skip if archetypes match
-        should_skip = last_archetype == new_archetype
-        assert should_skip is True
 
-        # Should not skip if different
-        different_archetype = "Azorius Control"
-        should_skip = last_archetype == different_archetype
-        assert should_skip is False
+# --------------------------------------------------------------------------- #
+# RadarMixin._trigger_radar_load                                              #
+# --------------------------------------------------------------------------- #
+class TestTriggerRadarLoad:
+    def test_no_decks_is_noop(self):
+        host = _FakeHost({}, resolved={"name": "UR Murktide"})
+        host._trigger_radar_load()
+        assert host.controller.resolve_calls == []
+        assert host._radar_worker_thread is None
 
-    def test_radar_worker_handles_cancellation(self, mock_radar_service):
-        """Test that radar worker respects cancellation flag."""
-        cancel_requested = False
+    def test_unknown_archetype_skipped(self):
+        host = _FakeHost({"Modern": "Unknown"}, resolved={"name": "x"})
+        host._trigger_radar_load()
+        assert host.controller.resolve_calls == []
+        assert host._last_radar_archetype == ""
 
-        def mock_progress_callback(current, total, deck_name):
-            if cancel_requested:
-                raise InterruptedError("Cancelled")
+    def test_unresolved_archetype_sets_error(self):
+        host = _FakeHost({"Modern": "UR Murktide"}, resolved=None)
+        host._trigger_radar_load()
+        assert host.controller.resolve_calls  # production resolver was invoked
+        assert host.radar_panel.set_error_calls == ["Archetype 'UR Murktide' not found"]
+        assert host._radar_worker_thread is None
+        assert host._last_radar_archetype == ""
 
-        # Simulate cancellation
-        cancel_requested = True
-        with pytest.raises(InterruptedError):
-            mock_progress_callback(1, 10, "Test Deck")
+    def test_valid_archetype_starts_worker_and_sets_loading(self):
+        resolved = {"name": "UR Murktide", "href": "/archetype/ur-murktide"}
+        host = _FakeHost({"Modern": "UR Murktide"}, resolved=resolved)
 
-    def test_radar_worker_handles_network_failure(self, mock_radar_service):
-        """Test that radar worker handles network failures gracefully."""
-        mock_radar_service.calculate_radar.side_effect = Exception("Network error")
+        captured: dict[str, Any] = {}
 
-        with pytest.raises(Exception) as exc_info:
-            mock_radar_service.calculate_radar(
-                {"name": "UR Murktide", "href": "/archetype/ur-murktide"},
-                "Modern",
-            )
+        def calculate_radar(archetype_dict, format_name, max_decks, progress_callback):
+            captured["args"] = (archetype_dict, format_name, max_decks)
+            return _radar(mainboard=[_card("Murktide Regent", 4.0)])
 
-        assert "Network error" in str(exc_info.value)
+        host.radar_service.calculate_radar = calculate_radar
+        host._trigger_radar_load()
+        _join_worker(host)
 
-    def test_archetype_resolver_exact_match(self):
-        """Test archetype name resolution with exact match."""
-        from services.archetype_resolver import normalize_archetype_name
+        assert host._last_radar_archetype == "UR Murktide"
+        assert any("Loading radar" in m for m in host.radar_panel.set_loading_calls)
+        assert captured["args"][0] is resolved
+        assert captured["args"][1] == "Modern"
+        # On success the worker marshals the radar to _display_radar.
+        assert host.current_radar is not None
+        assert host.radar_panel.display_radar_calls
 
-        result = normalize_archetype_name("UR Murktide")
-        assert result == "ur murktide"
+    def test_duplicate_archetype_skipped(self):
+        host = _FakeHost({"Modern": "UR Murktide"}, resolved={"name": "UR Murktide"})
+        host._last_radar_archetype = "UR Murktide"
+        host._trigger_radar_load()
+        # Early-return before resolving / starting a worker.
+        assert host.controller.resolve_calls == []
+        assert host.radar_panel.set_loading_calls == []
 
-        # Case insensitive
-        result2 = normalize_archetype_name("ur murktide")
-        assert result2 == "ur murktide"
+    def test_in_progress_thread_skipped(self):
+        host = _FakeHost({"Modern": "UR Murktide"}, resolved={"name": "UR Murktide"})
 
-        # Should match
-        assert result == result2
+        started = threading.Event()
+        release = threading.Event()
 
-    def test_archetype_resolver_partial_match(self, mock_metagame_repo):
-        """Test archetype name resolution with partial match."""
-        from services.archetype_resolver import find_archetype_by_name
+        def _busy() -> None:
+            started.set()
+            release.wait(timeout=5)
 
-        result = find_archetype_by_name("Murktide", "Modern", mock_metagame_repo)
-        assert result is not None
-        assert "Murktide" in result["name"]
+        live = threading.Thread(target=_busy, daemon=True)
+        live.start()
+        started.wait(timeout=5)
+        host._radar_worker_thread = live
 
-    def test_radar_config_persistence(self):
-        """Test that radar visibility state is saved to config."""
-        config = {
-            "screen_pos": [100, 100],
-            "calculator_visible": False,
-            "radar_visible": True,
-        }
+        host._trigger_radar_load()
+        try:
+            assert host.controller.resolve_calls == []
+            assert host.radar_panel.set_loading_calls == []
+        finally:
+            release.set()
+            live.join(timeout=5)
 
-        # Verify config structure
-        assert "radar_visible" in config
-        assert config["radar_visible"] is True
 
-    def test_radar_panel_display(self):
-        """Test that radar panel displays data correctly."""
-        from services.radar_service import CardFrequency, RadarData
+# --------------------------------------------------------------------------- #
+# RadarMixin._generate_radar_worker                                           #
+# --------------------------------------------------------------------------- #
+class TestGenerateRadarWorker:
+    def test_network_failure_sets_error_and_resets_thread(self):
+        host = _FakeHost({"Modern": "UR Murktide"}, resolved={"name": "x"})
+        host._radar_worker_thread = "sentinel"
 
-        radar = RadarData(
-            archetype_name="UR Murktide",
-            format_name="Modern",
-            mainboard_cards=[
-                CardFrequency(
-                    card_name="Murktide Regent",
-                    appearances=10,
-                    total_copies=40,
-                    max_copies=4,
-                    avg_copies=4.0,
-                    inclusion_rate=100.0,
-                    expected_copies=4.0,
-                    copy_distribution={4: 10},
-                ),
+        def calculate_radar(*_a, **_k):
+            raise RuntimeError("Network error")
+
+        host.radar_service.calculate_radar = calculate_radar
+        host._generate_radar_worker({"name": "x"}, "Modern")
+
+        assert host.radar_panel.set_error_calls == ["Failed to load radar"]
+        assert host._radar_worker_thread is None  # finally block ran
+
+    def test_cancellation_clears_panel(self):
+        host = _FakeHost({"Modern": "UR Murktide"}, resolved={"name": "x"})
+        host._radar_cancel_requested = True
+
+        def calculate_radar(archetype_dict, format_name, max_decks, progress_callback):
+            # The production update_progress closure raises InterruptedError
+            # because cancellation was requested.
+            progress_callback(1, 10, "Deck 1")
+            raise AssertionError("calculate_radar should have been interrupted")
+
+        host.radar_service.calculate_radar = calculate_radar
+        host._generate_radar_worker({"name": "x"}, "Modern")
+
+        assert host.radar_panel.clear_calls == 1
+        assert host.radar_panel.set_error_calls == []
+        assert host._radar_worker_thread is None
+
+    def test_success_displays_radar(self):
+        host = _FakeHost({"Modern": "UR Murktide"}, resolved={"name": "x"})
+        radar = _radar(mainboard=[_card("Murktide Regent", 4.0)])
+
+        def calculate_radar(archetype_dict, format_name, max_decks, progress_callback):
+            progress_callback(1, 1, "Deck 1")  # not cancelled -> schedules loading
+            return radar
+
+        host.radar_service.calculate_radar = calculate_radar
+        host._generate_radar_worker({"name": "x"}, "Modern")
+
+        assert host.current_radar is radar
+        assert host.radar_panel.display_radar_calls == [radar]
+        assert any("Analyzing deck" in m for m in host.radar_panel.set_loading_calls)
+        assert host._radar_worker_thread is None
+
+
+# --------------------------------------------------------------------------- #
+# RadarMixin._clear_radar_display                                             #
+# --------------------------------------------------------------------------- #
+class TestClearRadarDisplay:
+    def test_resets_state_and_clears_panels(self):
+        host = _FakeHost({"Modern": "UR Murktide"}, resolved={"name": "x"})
+        host._last_radar_archetype = "UR Murktide"
+        host.current_radar = _radar()
+        host._radar_cancel_requested = False
+
+        host._clear_radar_display()
+
+        assert host._radar_cancel_requested is True
+        assert host.current_radar is None
+        assert host._last_radar_archetype == ""
+        assert host._last_guide_archetype == ""
+        assert host.radar_panel.clear_calls == 1
+        assert host.sideboard_panel.clear_calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# CompactRadarHandlersMixin                                                   #
+# --------------------------------------------------------------------------- #
+class _FakeLabel:
+    def __init__(self) -> None:
+        self.label = ""
+
+    def SetLabel(self, text: str) -> None:
+        self.label = text
+
+
+class _FakeList:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def Append(self, line: str) -> None:
+        self.lines.append(line)
+
+    def Clear(self) -> None:
+        self.lines = []
+
+
+class _FakeButton:
+    def __init__(self) -> None:
+        self.shown = True
+        self.label = ""
+
+    def Show(self) -> None:
+        self.shown = True
+
+    def Hide(self) -> None:
+        self.shown = False
+
+    def SetLabel(self, text: str) -> None:
+        self.label = text
+
+
+class _FakeParent:
+    def __init__(self) -> None:
+        self.layout_calls = 0
+
+    def Layout(self) -> None:
+        self.layout_calls += 1
+
+
+class _FakePanelHost(CompactRadarHandlersMixin):
+    def __init__(self, view_mode):
+        self.current_radar = None
+        self.header_label = _FakeLabel()
+        self.status_label = _FakeLabel()
+        self.card_list = _FakeList()
+        self.view_toggle_btn = _FakeButton()
+        self._view_mode = view_mode
+        self._parent = _FakeParent()
+        self.shown = False
+
+    def Show(self) -> None:
+        self.shown = True
+
+    def GetParent(self) -> _FakeParent:
+        return self._parent
+
+
+def _view_modes():
+    props = _load_module(
+        "_compact_radar_props_under_test",
+        "widgets",
+        "panels",
+        "compact_radar_panel",
+        "properties.py",
+    )
+    return props.RadarViewMode
+
+
+_RadarViewMode = _view_modes()
+
+
+class TestCompactRadarSetters:
+    def test_clear_resets_labels_list_and_button(self):
+        panel = _FakePanelHost(_RadarViewMode.TOP_CARDS)
+        panel.current_radar = _radar()
+        panel.card_list.lines = ["stale"]
+        panel.view_toggle_btn.shown = True
+
+        panel.clear()
+
+        assert panel.current_radar is None
+        assert panel.header_label.label == "Radar: —"
+        assert "Waiting for opponent" in panel.status_label.label
+        assert panel.card_list.lines == []
+        assert panel.view_toggle_btn.shown is False
+        assert panel._parent.layout_calls == 1
+
+    def test_set_error_shows_message(self):
+        panel = _FakePanelHost(_RadarViewMode.TOP_CARDS)
+        panel.set_error("boom")
+        assert panel.header_label.label == "Radar: Error"
+        assert panel.status_label.label == "boom"
+        assert panel.view_toggle_btn.shown is False
+        assert panel.shown is True
+
+    def test_set_loading_shows_message(self):
+        panel = _FakePanelHost(_RadarViewMode.TOP_CARDS)
+        panel.set_loading("Loading radar for UR Murktide...")
+        assert panel.header_label.label == "Radar: Loading..."
+        assert panel.status_label.label == "Loading radar for UR Murktide..."
+        assert panel.view_toggle_btn.shown is False
+        assert panel.shown is True
+
+
+class TestCompactRadarFormatting:
+    def test_top_cards_line_format_and_clamping(self):
+        panel = _FakePanelHost(_RadarViewMode.TOP_CARDS)
+        # 0.3 must clamp up to 1; 95.6% must floor-format to 96 via :.0f rounding.
+        panel.current_radar = _radar(
+            mainboard=[
+                _card("Lightning Bolt", 4.0, inclusion_rate=95.0),
+                _card("Spell Pierce", 0.3, inclusion_rate=40.0),
             ],
-            sideboard_cards=[],
-            total_decks_analyzed=10,
-            decks_failed=0,
+            sideboard=[_card("Mystical Dispute", 2.4, inclusion_rate=60.0)],
         )
 
-        # Verify radar data structure
-        assert radar.archetype_name == "UR Murktide"
-        assert radar.format_name == "Modern"
-        assert len(radar.mainboard_cards) == 1
-        assert radar.mainboard_cards[0].card_name == "Murktide Regent"
-        assert radar.mainboard_cards[0].inclusion_rate == 100.0
+        panel._populate_top_cards()
+
+        assert "4x Lightning Bolt (95%)" in panel.card_list.lines
+        # max(1, int(round(0.3))) == 1
+        assert "1x Spell Pierce (40%)" in panel.card_list.lines
+        # max(1, int(round(2.4))) == 2
+        assert "2x Mystical Dispute (60%)" in panel.card_list.lines
+        assert "─── Mainboard ───" in panel.card_list.lines
+        assert "─── Sideboard ───" in panel.card_list.lines
+
+    def test_top_cards_respects_limits(self):
+        props = _load_module(
+            "_compact_radar_props_limits",
+            "widgets",
+            "panels",
+            "compact_radar_panel",
+            "properties.py",
+        )
+        mainboard = [_card(f"MB {i}", 1.0) for i in range(props._TOP_MAINBOARD_LIMIT + 5)]
+        sideboard = [_card(f"SB {i}", 1.0) for i in range(props._TOP_SIDEBOARD_LIMIT + 5)]
+        panel = _FakePanelHost(_RadarViewMode.TOP_CARDS)
+        panel.current_radar = _radar(mainboard=mainboard, sideboard=sideboard)
+
+        panel._populate_top_cards()
+
+        mb_lines = [line for line in panel.card_list.lines if line.startswith("1x MB ")]
+        sb_lines = [line for line in panel.card_list.lines if line.startswith("1x SB ")]
+        assert len(mb_lines) == props._TOP_MAINBOARD_LIMIT
+        assert len(sb_lines) == props._TOP_SIDEBOARD_LIMIT
+
+    def test_full_decklist_line_format_and_clamping(self):
+        panel = _FakePanelHost(_RadarViewMode.FULL_DECKLIST)
+        panel.current_radar = _radar(
+            mainboard=[_card("Murktide Regent", 4.0), _card("Spell Pierce", 0.3)],
+            sideboard=[_card("Mystical Dispute", 2.4)],
+        )
+
+        panel._populate_full_decklist()
+
+        assert "4 Murktide Regent" in panel.card_list.lines
+        # round(0.3) == 0 -> clamped to 1
+        assert "1 Spell Pierce" in panel.card_list.lines
+        # round(2.4) == 2
+        assert "2 Mystical Dispute" in panel.card_list.lines
+        # Mainboard header carries the clamped total (4 + 1 = 5).
+        assert "─── Mainboard (5) ───" in panel.card_list.lines
+        assert "─── Sideboard (2) ───" in panel.card_list.lines
+
+    def test_display_radar_sets_header_and_shows(self):
+        panel = _FakePanelHost(_RadarViewMode.TOP_CARDS)
+        radar = _radar(mainboard=[_card("Murktide Regent", 4.0)])
+
+        panel.display_radar(radar)
+
+        assert panel.current_radar is radar
+        assert panel.header_label.label == "Radar: UR Murktide"
+        assert panel.view_toggle_btn.shown is True
+        assert panel.shown is True
+        assert any("Murktide Regent" in line for line in panel.card_list.lines)
 
 
-class TestRadarPanelLogic:
-    """Test compact radar panel logic without GUI."""
+# --------------------------------------------------------------------------- #
+# services.archetype_resolver                                                 #
+# --------------------------------------------------------------------------- #
+class _FakeRepo:
+    def __init__(self, archetypes, raises: bool = False) -> None:
+        self._archetypes = archetypes
+        self._raises = raises
 
-    def test_format_top_card_line(self):
-        """Test card line formatting for top cards view."""
-        avg_copies = 4
-        card_name = "Lightning Bolt"
-        inclusion_rate = 95.0
+    def get_archetypes_for_format(self, format_name):
+        if self._raises:
+            raise RuntimeError("scrape failed")
+        return self._archetypes
 
-        line = f"{avg_copies}x {card_name} ({inclusion_rate:.0f}%)"
-        assert line == "4x Lightning Bolt (95%)"
 
-    def test_format_full_decklist_line(self):
-        """Test card line formatting for full decklist view."""
-        count = 4
-        card_name = "Lightning Bolt"
+class TestArchetypeResolver:
+    def test_normalize(self):
+        from services.archetype_resolver import normalize_archetype_name
 
-        line = f"{count} {card_name}"
-        assert line == "4 Lightning Bolt"
+        assert normalize_archetype_name("  UR   Murktide ") == "ur murktide"
+        assert normalize_archetype_name("UR Murktide") == normalize_archetype_name("ur murktide")
 
-    def test_mainboard_card_limit(self):
-        """Test that mainboard cards are limited to 15 in top cards view."""
-        from widgets.panels.compact_radar_panel import _TOP_MAINBOARD_LIMIT
+    def test_exact_match(self):
+        from services.archetype_resolver import find_archetype_by_name
 
-        assert _TOP_MAINBOARD_LIMIT == 15
+        repo = _FakeRepo([{"name": "UR Murktide"}, {"name": "Azorius Control"}])
+        result = find_archetype_by_name("ur murktide", "Modern", repo)
+        assert result == {"name": "UR Murktide"}
 
-        total_cards = 50
-        mainboard_display = min(_TOP_MAINBOARD_LIMIT, total_cards)
-        assert mainboard_display == 15
+    def test_forward_containment_partial_match(self):
+        from services.archetype_resolver import find_archetype_by_name
 
-        total_cards = 10
-        mainboard_display = min(_TOP_MAINBOARD_LIMIT, total_cards)
-        assert mainboard_display == 10
+        # input ("murktide") is contained in a candidate name.
+        repo = _FakeRepo([{"name": "UR Murktide"}])
+        result = find_archetype_by_name("Murktide", "Modern", repo)
+        assert result == {"name": "UR Murktide"}
 
-    def test_sideboard_card_limit(self):
-        """Test that sideboard cards are limited to 8 in top cards view."""
-        from widgets.panels.compact_radar_panel import _TOP_SIDEBOARD_LIMIT
+    def test_reverse_containment_partial_match(self):
+        from services.archetype_resolver import find_archetype_by_name
 
-        assert _TOP_SIDEBOARD_LIMIT == 8
+        # candidate name ("murktide") is contained in the input.
+        repo = _FakeRepo([{"name": "Murktide"}])
+        result = find_archetype_by_name("UR Murktide Tempo", "Modern", repo)
+        assert result == {"name": "Murktide"}
 
-        total_cards = 20
-        sideboard_display = min(_TOP_SIDEBOARD_LIMIT, total_cards)
-        assert sideboard_display == 8
+    def test_no_match_returns_none(self):
+        from services.archetype_resolver import find_archetype_by_name
 
-        total_cards = 5
-        sideboard_display = min(_TOP_SIDEBOARD_LIMIT, total_cards)
-        assert sideboard_display == 5
+        repo = _FakeRepo([{"name": "Azorius Control"}])
+        assert find_archetype_by_name("Burn", "Modern", repo) is None
 
-    def test_view_mode_enum(self):
-        """Test that view mode enum has expected values."""
-        from widgets.panels.compact_radar_panel import RadarViewMode
+    def test_repo_error_returns_none(self):
+        from services.archetype_resolver import find_archetype_by_name
 
-        assert RadarViewMode.TOP_CARDS.value == "top"
-        assert RadarViewMode.FULL_DECKLIST.value == "full"
+        repo = _FakeRepo([], raises=True)
+        assert find_archetype_by_name("Burn", "Modern", repo) is None
 
-    def test_full_decklist_includes_all_cards(self):
-        """Test that full decklist mode counts all cards."""
-        from services.radar_service import CardFrequency
 
-        cards = [
-            CardFrequency("Card A", 10, 40, 4, 4.0, 100.0, 4.0, {4: 10}),
-            CardFrequency("Card B", 5, 10, 2, 2.0, 50.0, 1.0, {2: 5, 0: 5}),
-            CardFrequency("Card C", 3, 3, 1, 1.0, 30.0, 0.3, {1: 3, 0: 7}),
-        ]
-
-        # Full decklist should include all cards
-        total = sum(max(1, round(c.avg_copies)) for c in cards)
-        assert total == 4 + 2 + 1  # 7 total
-
-    def test_full_decklist_min_one_copy(self):
-        """Test that full decklist shows at least 1 copy per card."""
-        from services.radar_service import CardFrequency
-
-        # Card with avg_copies < 0.5 rounds to 0, but we clamp to 1
-        card = CardFrequency("Rare Card", 1, 1, 1, 0.3, 10.0, 0.03, {1: 1, 0: 9})
-        count = max(1, round(card.avg_copies))
-        assert count == 1
+# --------------------------------------------------------------------------- #
+# RadarData / CardFrequency models                                            #
+# --------------------------------------------------------------------------- #
+def test_radar_data_structure():
+    radar = _radar(mainboard=[_card("Murktide Regent", 4.0, inclusion_rate=100.0)])
+    assert radar.archetype_name == "UR Murktide"
+    assert radar.format_name == "Modern"
+    assert len(radar.mainboard_cards) == 1
+    assert radar.mainboard_cards[0].card_name == "Murktide Regent"
+    assert radar.mainboard_cards[0].inclusion_rate == 100.0


### PR DESCRIPTION
## Summary
Rewrites `tests/test_identify_opponent_radar.py` so it drives the real production code instead of asserting against bare `MagicMock`s and locally reimplemented logic. The new tests construct concrete `RadarMixin` / `CompactRadarHandlersMixin` hosts (with lightweight fakes for the wx widgets and collaborators) and call the actual methods: the `_trigger_radar_load` archetype/dedup/in-progress guards, `set_error` on unresolved archetypes, the worker's success/network-failure/cancellation branches plus its `finally` thread reset, `_clear_radar_display` state resets, the compact panel's `clear`/`set_loading`/`set_error` setters, and the real card-line formatting including the `max(1, round(...))` clamping and the top-cards mainboard/sideboard limits. The `find_archetype_by_name` exact, forward- and reverse-containment, no-match, and repo-error branches are now all covered. `test_radar_config_persistence` was dropped because the opponent-tracker persistence handler only serializes `screen_pos` — there is no `radar_visible` production behavior to test.

## Verification
Run from WSL (the repo's dev environment; `wx` is not importable here so the handler modules are imported by file path after a synchronous-`CallAfter` `wx` stub is injected into `sys.modules`):
- `python -m pytest tests/test_identify_opponent_radar.py -q` -> 24 passed.
- `python -m ruff check tests/test_identify_opponent_radar.py` -> All checks passed.
- `python -m black --check tests/test_identify_opponent_radar.py` -> formatted (applied).
- Mutation sanity check: removing the `_trigger_radar_load` dedup early-return and breaking the `max(1, int(round(...)))` clamp each made the relevant new test fail, confirming the tests bind to production behavior. Production files were restored unchanged (only the test file is modified).

Could not be checked in WSL: any actual `wx` UI rendering/event behavior of the radar panel and opponent-tracker frame — those require the real wx runtime on Windows. The tests deliberately stub wx and assert the marshalled side effects only.

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)