### PR TITLE
fix: correct unknown-username perspective fallback in match history

### DIFF
--- a/tests/test_match_history_metrics.py
+++ b/tests/test_match_history_metrics.py
@@ -73,6 +73,7 @@ def test_resolve_perspective_player2_is_us() -> None:
     assert out["our_name"] == "me"
     assert out["opp_name"] == "them"
     assert out["our_archetype"] == "Burn"
+    assert out["opp_archetype"] == "Control"
     assert out["our_mulligans"] == [1, 1]
     assert out["our_score"] == 0
     assert out["opp_score"] == 2
@@ -93,6 +94,37 @@ def test_resolve_perspective_bad_score_falls_back_to_zero() -> None:
     out = resolve_match_perspective({"players": ["a", "b"], "match_score": "??"}, None)
     assert out["our_score"] == 0
     assert out["opp_score"] == 0
+
+
+def test_resolve_perspective_unknown_username_defaults_to_player1() -> None:
+    # A username present but matching neither player must fall back to player1
+    # being "us", as documented. (Regression: player2 was wrongly treated as us.)
+    match = {
+        "players": ["a", "b"],
+        "winner": "a",
+        "match_score": "2-1",
+        "player1_archetype": "Burn",
+        "player2_archetype": "Control",
+    }
+    out = resolve_match_perspective(match, "zzz")
+    assert out["our_name"] == "a"
+    assert out["opp_name"] == "b"
+    assert out["our_archetype"] == "Burn"
+    assert out["opp_archetype"] == "Control"
+    assert out["our_score"] == 2
+    assert out["opp_score"] == 1
+    assert out["we_won"] is True
+
+
+def test_resolve_perspective_missing_players_defaults_to_unknown() -> None:
+    out = resolve_match_perspective({"players": []}, None)
+    assert out["our_name"] == "Unknown"
+    assert out["opp_name"] == "Unknown"
+
+
+def test_resolve_perspective_missing_winner_we_won_false() -> None:
+    out = resolve_match_perspective({"players": ["a", "b"], "match_score": "2-0"}, None)
+    assert out["we_won"] is False
 
 
 # -------------------------------------------------------------------- compute_history_metrics
@@ -144,6 +176,9 @@ def test_compute_history_metrics_zero_games_no_div_by_zero() -> None:
     assert out["game_rate"] == 0.0
     assert out["mulligan_rate"] == 0.0
     assert out["games_with_data"] == 0
+    # Lock in the filtered-branch zero-division guard.
+    assert out["filtered"] is not None
+    assert out["filtered"]["game_rate"] == 0.0
 
 
 # --------------------------------------------------------------------- compute_opponent_stats

--- a/widgets/frames/match_history/properties.py
+++ b/widgets/frames/match_history/properties.py
@@ -43,7 +43,11 @@ def resolve_match_perspective(
         player1_score = 0
         player2_score = 0
 
-    use_player2 = bool(current_username and player1_name.lower() != current_username.lower())
+    use_player2 = bool(
+        current_username
+        and player1_name.lower() != current_username.lower()
+        and player2_name.lower() == current_username.lower()
+    )
     if use_player2:
         our_name = player2_name
         opp_name = player1_name


### PR DESCRIPTION
Fixes a correctness bug in `widgets/frames/match_history/properties.py::resolve_match_perspective` surfaced by the test-quality review in #594. The docstring states that an unknown username (or one matching neither player) should fall back to player 1 being treated as "us", but the code computed `use_player2 = bool(current_username and player1_name.lower() != current_username.lower())`, so any unrecognized-but-present username (where player 1 simply isn't us) wrongly flipped the perspective to player 2. The guard now additionally requires player 2 to actually match the username, matching both the docstring and the analogous logic in `_iter_matches`. The previously-untested branches called out in the review are now covered.

## Verification
- `python -m ruff check widgets/frames/match_history/properties.py tests/test_match_history_metrics.py` — passed.
- `python -m black --check ...` — passed (no changes).
- `python -m pytest tests/test_match_history_metrics.py -q` — 13 passed (added: unknown-username fallback, missing-players defaults, missing-winner `we_won=False`, player2 `opp_archetype`, and the filtered zero-division `game_rate` guard).
- Not checked in WSL: any wx/UI behavior. These pure kernels are wx-free; `wx` is not importable here and the full UI suite requires Windows. The change is confined to the wx-free function and its tests.

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)