### PR TITLE
test: cover strict hypergeometric impossible-draw branch (#595)

### DIFF
--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -78,6 +78,17 @@ class TestHypergeometricProbability:
         prob = hypergeometric_probability(60, 0, 7, 0)
         assert prob == 1.0
 
+    def test_not_enough_failures_returns_zero(self) -> None:
+        """Combinatorially impossible draw returns 0.0 from the strict function.
+
+        Directly exercises the 'not enough non-target cards' branch: every
+        validation guard passes (successes_in_sample=0 is in range), yet the
+        sample cannot be filled because only 2 non-target cards exist for a
+        7-card draw, so failures_in_sample (7) > failures_in_pop (2).
+        """
+        assert hypergeometric_probability(60, 58, 7, 0) == 0.0
+        assert hypergeometric_probability(10, 8, 5, 0) == 0.0
+
 
 class TestHypergeometricAtLeast:
     """Tests for hypergeometric_at_least function."""


### PR DESCRIPTION
Adds a unit test directly exercising the strict `hypergeometric_probability`'s "not enough non-target cards" branch (`utils/math_utils.py:59-61`), which returns `0.0` for combinatorially impossible draws that still pass every validation guard (e.g. `(60, 58, 7, 0)` and `(10, 8, 5, 0)`). Previously this branch was only covered indirectly through the separate lenient `hypergeometric_exactly` code path, so a regression in the strict function's impossible-draw handling would have gone undetected. This is a test-only change addressing the single medium-severity finding in issue #595; no production code is modified.

## Verification
Ran from WSL:
- `python -m ruff check tests/test_math_utils.py` — passed
- `python -m black --check tests/test_math_utils.py` — passed (no changes)
- `python -m pytest tests/test_math_utils.py -q` — 31 passed

These tests are pure-Python and do not import `wx`, so they run fully in WSL. No wx/UI behavior is involved in this change, so nothing UI-related needed Windows verification.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)