### PR TITLE
test: offline unit tests for mtggoldfish visual parser (#598)

### DIFF
--- a/tests/test_mtggoldfish_visual.py
+++ b/tests/test_mtggoldfish_visual.py
@@ -1,17 +1,83 @@
-"""Integration test for services/scrapers/mtggoldfish_visual.py against live MTGGoldfish.
+"""Tests for repositories/scrapers/mtggoldfish_visual.py.
 
-This intentionally hits the real /deck/visual/ endpoint — the whole point of
-the fallback is to exercise an unprotected URL, so mocking it would tell us
-nothing about whether it still works.
+Two layers of coverage:
+
+* Offline unit tests feed fixed ``/deck/visual/`` HTML straight to
+  :func:`parse_visual_page` so the deterministic parsing contract (alt-text
+  counting, sideboard formatting, the empty-page error path) is verified on
+  every CI run, independent of MTGGoldfish availability.
+* A network-gated smoke test still hits the real ``/deck/visual/`` endpoint —
+  the whole point of the fallback is to exercise an unprotected URL — to catch
+  upstream page-structure changes.
 """
 
 import pytest
 
-from repositories.scrapers.mtggoldfish_visual import fetch_deck_text_from_visual_page
+from repositories.scrapers.mtggoldfish_visual import (
+    fetch_deck_text_from_visual_page,
+    parse_visual_page,
+)
 
 # Modern Affinity decklist sourced from a real MTGO Challenge result. Picked
 # because it exercises both mainboard and sideboard parsing.
 LIVE_DECK_NUM = "7750657"
+
+
+def _pile(selector_class: str, alts: list[str]) -> str:
+    """Render a ``.deck-visual-playmat-*`` container with one card img per alt."""
+    imgs = "".join(f'<img class="deck-visual-pile-card" alt="{alt}">' for alt in alts)
+    return f'<div class="{selector_class}">{imgs}</div>'
+
+
+def _visual_html(main_alts: list[str], side_alts: list[str] | None = None) -> str:
+    main = _pile("deck-visual-playmat-maindeck", main_alts)
+    side = _pile("deck-visual-playmat-sideboard", side_alts) if side_alts is not None else ""
+    return f"<html><body>{main}{side}</body></html>"
+
+
+def test_parse_visual_page_counts_alt_text_with_sideboard():
+    html = _visual_html(
+        main_alts=["Mox Opal", "Mox Opal", "Ornithopter"],
+        side_alts=["Galvanic Blast", "Galvanic Blast"],
+    )
+
+    text = parse_visual_page(html)
+
+    main_block, sep, side_block = text.partition("\n\n")
+    assert sep == "\n\n"
+    # Insertion order is preserved; duplicate alts are tallied.
+    assert main_block == "2 Mox Opal\n1 Ornithopter"
+    assert side_block == "2 Galvanic Blast"
+
+
+def test_parse_visual_page_mainboard_only_has_no_separator():
+    html = _visual_html(main_alts=["Mox Opal", "Ornithopter"])
+
+    text = parse_visual_page(html)
+
+    assert text == "1 Mox Opal\n1 Ornithopter"
+    assert "\n\n" not in text
+
+
+def test_parse_visual_page_skips_blank_alt_text():
+    html = _visual_html(main_alts=["Mox Opal", "", "   ", "Ornithopter"])
+
+    text = parse_visual_page(html)
+
+    assert text == "1 Mox Opal\n1 Ornithopter"
+
+
+def test_parse_visual_page_raises_when_no_card_piles():
+    # Containers present but empty -> no cards counted -> explicit error.
+    html = _visual_html(main_alts=[], side_alts=[])
+
+    with pytest.raises(ValueError):
+        parse_visual_page(html)
+
+
+def test_parse_visual_page_raises_when_containers_missing():
+    with pytest.raises(ValueError):
+        parse_visual_page("<html><body><p>no piles here</p></body></html>")
 
 
 @pytest.mark.network


### PR DESCRIPTION
## Summary

`tests/test_mtggoldfish_visual.py` previously contained only a single `@pytest.mark.network` integration test, which is excluded by `addopts = "-m 'not network'"` and so never runs in default/CI sweeps — leaving the deterministic parsing logic in `repositories/scrapers/mtggoldfish_visual.py` (`parse_visual_page` and its helpers) with zero exercised coverage. This PR adds offline unit tests that feed fixed `/deck/visual/` HTML straight to `parse_visual_page()`, validating alt-text counting, sideboard formatting, the mainboard-only (no-separator) branch, blank-alt skipping, and both empty-pile / missing-container `ValueError` paths. The live network smoke test is retained and documented alongside the new offline coverage. No production code was changed.

## Verification

Run from WSL (where `wx` is not importable, so the test module cannot be collected by plain pytest because the module under test transitively imports `wx` via `utils.constants`):

- Ran the new offline tests with a minimal `wx` stub injected: `5 passed, 1 deselected` (the network test is correctly deselected).
- `python -m ruff check tests/test_mtggoldfish_visual.py` — All checks passed.
- `python -m black --check tests/test_mtggoldfish_visual.py` — would be left unchanged.

Not verified in WSL: the network-gated live smoke test (requires network + stable upstream deck) and a clean collection/run without the `wx` stub. Those run on Windows CI where `wx` is importable. No wx/UI behavior is involved in this change.

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)
