### PR TITLE
fix: skip blank opponent names from window-title parsing

### DIFF
--- a/tests/test_opponent_detection.py
+++ b/tests/test_opponent_detection.py
@@ -41,3 +41,23 @@ def test_find_opponent_names_ignores_non_match_titles(monkeypatch: pytest.Monkey
         lambda: ["MTGO Lobby", "Deck building", ""],
     )
     assert find_opponent_names() == []
+
+
+@pytest.mark.parametrize(
+    "titles",
+    [
+        ["Champion vs."],
+        ["vs."],
+        ["Champion vs. "],
+        ["Champion vs. Rival", "Lobby vs."],
+    ],
+)
+def test_find_opponent_names_skips_blank_opponents(
+    monkeypatch: pytest.MonkeyPatch, titles: Iterable[str]
+) -> None:
+    """A trailing 'vs.' yields an empty name that must not be emitted as an opponent."""
+    monkeypatch.setattr(
+        "utils.find_opponent_names.pygetwindow.getAllTitles",
+        lambda: list(titles),
+    )
+    assert "" not in find_opponent_names()

--- a/utils/find_opponent_names.py
+++ b/utils/find_opponent_names.py
@@ -14,5 +14,7 @@ def find_opponent_names():
     opponents = []
     for name in window_names:
         if "vs." in name:
-            opponents.append(name.split("vs.")[-1].strip())
+            opponent = name.split("vs.")[-1].strip()
+            if opponent:
+                opponents.append(opponent)
     return opponents


### PR DESCRIPTION
## Summary

`find_opponent_names()` parsed window titles with `name.split("vs.")[-1].strip()` and unconditionally appended the result whenever `"vs."` was present. A title ending in `vs.` (e.g. `"Champion vs."`) or `"vs."` alone produced an empty string that was still added to the opponents list. The identify-opponent poller (`widgets/frames/identify_opponent/handlers/polling.py`) consumes `opponents[0]` directly and would treat that blank value as a real opponent, mis-triggering a deck lookup for an empty name. This change skips empty results in the source and pins the behavior with a parametrized test, per the issue recommendation.

## Verification

Ran from WSL (wx not importable here):
- `python -m ruff check utils/find_opponent_names.py tests/test_opponent_detection.py` — passed
- `python -m black --check ...` — passed (no changes)
- `python -m pytest tests/test_opponent_detection.py -q` — 7 passed

The changed code (`utils/find_opponent_names.py`) and its test are pure-Python and have no wx dependency, so they were fully exercised here. The downstream consumer in `widgets/frames/identify_opponent/handlers/polling.py` was read but not modified; its wx/UI behavior could not be exercised from WSL.

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)