### PR TITLE
test: cover bridge command transport, JSON sanitization, and path resolution (#599)

### DIFF
--- a/tests/test_mtgo_bridge_client.py
+++ b/tests/test_mtgo_bridge_client.py
@@ -1,3 +1,4 @@
+import queue as queue_mod
 from pathlib import Path
 
 import pytest
@@ -17,3 +18,91 @@ def test_resolve_bridge_from_env(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("MTGO_BRIDGE_PATH", str(fake_bridge))
     resolved = mtgo_bridge_client._resolve_bridge_path(None)  # type: ignore[attr-defined]
     assert resolved == fake_bridge
+
+
+# --- _sanitize_json_payload --------------------------------------------------
+
+
+def test_sanitize_json_payload_parses_valid_json() -> None:
+    payload = mtgo_bridge_client._sanitize_json_payload('{"a": 1, "b": [2, 3]}')
+    assert payload == {"a": 1, "b": [2, 3]}
+
+
+def test_sanitize_json_payload_strips_bom() -> None:
+    # A leading UTF-8 BOM must be stripped before json.loads.
+    payload = mtgo_bridge_client._sanitize_json_payload('﻿{"ok": true}')
+    assert payload == {"ok": True}
+
+
+def test_sanitize_json_payload_empty_raises() -> None:
+    with pytest.raises(mtgo_bridge_client.BridgeCommandError, match="no output"):
+        mtgo_bridge_client._sanitize_json_payload("   \n\t  ")
+
+
+def test_sanitize_json_payload_invalid_json_raises() -> None:
+    with pytest.raises(mtgo_bridge_client.BridgeCommandError, match="Invalid JSON payload"):
+        mtgo_bridge_client._sanitize_json_payload("{not json}")
+
+
+# --- _resolve_bridge_path branches -------------------------------------------
+
+
+def test_resolve_bridge_env_missing_file_falls_back(monkeypatch, tmp_path: Path) -> None:
+    # MTGO_BRIDGE_PATH set but the file does not exist: must fall through to
+    # the default candidates. With no candidates available, returns None.
+    missing = tmp_path / "does_not_exist.exe"
+    monkeypatch.setenv("MTGO_BRIDGE_PATH", str(missing))
+    monkeypatch.setattr(mtgo_bridge_client, "_default_bridge_candidates", lambda: [])
+    assert mtgo_bridge_client._resolve_bridge_path(None) is None
+
+
+def test_resolve_bridge_explicit_missing_returns_none(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.exe"
+    assert mtgo_bridge_client._resolve_bridge_path(str(missing)) is None
+
+
+# --- _command_worker error paths ---------------------------------------------
+
+
+def _write_stub(tmp_path: Path, body: str) -> Path:
+    """Write a small Python script invoked as ``python <script>``."""
+    script = tmp_path / "stub.py"
+    script.write_text(body)
+    return script
+
+
+def test_command_worker_nonzero_exit_surfaces_stderr(tmp_path: Path) -> None:
+    import sys
+
+    script = _write_stub(
+        tmp_path,
+        "import sys\nsys.stderr.write('boom detail')\nsys.exit(3)\n",
+    )
+    result_queue: queue_mod.Queue = queue_mod.Queue()
+    mtgo_bridge_client._command_worker(sys.executable, [str(script)], result_queue)
+    status, payload = result_queue.get_nowait()
+    assert status == "error"
+    assert "exited with code 3" in payload
+    assert "boom detail" in payload
+
+
+def test_command_worker_timeout_surfaces_message(tmp_path: Path) -> None:
+    import sys
+
+    script = _write_stub(tmp_path, "import time\ntime.sleep(5)\n")
+    result_queue: queue_mod.Queue = queue_mod.Queue()
+    mtgo_bridge_client._command_worker(sys.executable, [str(script)], result_queue, timeout=0.2)
+    status, payload = result_queue.get_nowait()
+    assert status == "error"
+    assert "timed out after" in payload
+
+
+def test_command_worker_success_serializes_payload(tmp_path: Path) -> None:
+    import sys
+
+    script = _write_stub(tmp_path, "import sys\nsys.stdout.write('{\"hi\": 1}')\n")
+    result_queue: queue_mod.Queue = queue_mod.Queue()
+    mtgo_bridge_client._command_worker(sys.executable, [str(script)], result_queue)
+    status, payload = result_queue.get_nowait()
+    assert status == "ok"
+    assert payload == {"hi": 1}


### PR DESCRIPTION
Adds targeted unit tests for the previously unexercised, wx-free code paths in `services/mtgo_bridge_service/commands.py` and `discovery.py`, addressing the test-quality findings in issue #599. New coverage: `_sanitize_json_payload` (valid JSON, leading UTF-8 BOM stripping, empty/whitespace and malformed-JSON error paths); `_resolve_bridge_path` (env var pointing at a missing file falling through to default candidates, and explicit-but-missing path returning `None` directly); and `_command_worker` (non-zero exit surfacing stderr, timeout surfacing the "timed out after" message, and success-path payload serialization through the queue). The worker tests drive a small Python stub script via the current interpreter, so they require no real `MTGOBridge.exe` and run off-Windows. No production code was changed.

## Verification
- `python -m ruff check tests/test_mtgo_bridge_client.py` — passed.
- `python -m black --check tests/test_mtgo_bridge_client.py` — passed (file reformatted to black style before commit).
- `python -m pytest tests/test_mtgo_bridge_client.py -q` — the module's import chain pulls in `utils.constants` -> `utils.constants.keyboard`, which imports `wx`, so the module cannot be collected directly in WSL (this is pre-existing; the original two tests had the same constraint). To validate logic off-Windows I ran the suite with a minimal import-time `wx` stub satisfying only `keyboard.py`'s attribute access (the code under test has no wx dependency): all 11 tests passed (2 existing + 9 new).
- Not verified in WSL: real `wx`/UI behavior and the full suite on Windows. CI on Windows is the source of truth for collection without the stub.

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)