### PR TITLE
test: cover perf_phase context manager in test_perf.py

### DIFF
--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from utils.perf import timed
+from utils.perf import perf_phase, timed
 
 
 def test_timed_returns_value():
@@ -89,3 +89,40 @@ def test_timed_does_not_log_on_exception():
             f()
 
     mock_logger.debug.assert_not_called()
+
+
+def test_perf_phase_logs_once_with_name_and_ms():
+    """perf_phase must log once at INFO with the PERF template, name, and non-negative ms."""
+    with patch("utils.perf.logger") as mock_logger:
+        with perf_phase("analyze_deck"):
+            pass
+
+    mock_logger.log.assert_called_once()
+    call_args = mock_logger.log.call_args
+    level_arg, template, ms_arg, name_arg = call_args.args
+    assert level_arg == "INFO"
+    assert template == "PERF | {:>7.1f} ms | {}"
+    assert isinstance(ms_arg, float)
+    assert ms_arg >= 0.0
+    assert name_arg == "analyze_deck"
+
+
+def test_perf_phase_forwards_level():
+    """The keyword-only level arg must be forwarded to logger.log."""
+    with patch("utils.perf.logger") as mock_logger:
+        with perf_phase("scrape", level="DEBUG"):
+            pass
+
+    mock_logger.log.assert_called_once()
+    assert mock_logger.log.call_args.args[0] == "DEBUG"
+
+
+def test_perf_phase_logs_on_exception():
+    """perf_phase logs from its finally block even when the segment raises."""
+    with patch("utils.perf.logger") as mock_logger:
+        with pytest.raises(ValueError, match="boom"):
+            with perf_phase("doomed"):
+                raise ValueError("boom")
+
+    mock_logger.log.assert_called_once()
+    assert mock_logger.log.call_args.args[3] == "doomed"


### PR DESCRIPTION
## Summary

`tests/test_perf.py` thoroughly exercised the `timed` decorator but provided zero coverage of the second public function in `utils/perf.py`, the `perf_phase` context manager. This adds three focused tests covering its non-trivial behaviors: a happy-path test asserting a single `logger.log` call at INFO with the fixed `PERF | {:>7.1f} ms | {}` template, a non-negative float millisecond value, and the segment name; a test asserting the keyword-only `level` arg is forwarded; and an exception-path test asserting the `finally` block still emits the log when the wrapped segment raises (the deliberate behavioral contrast with `timed`, which does not log on exception).

## Verification

- `python -m ruff check tests/test_perf.py` — passed
- `python -m black --check tests/test_perf.py` — passed (unchanged)
- `python -m pytest tests/test_perf.py -q` — 11 passed

`utils/perf.py` is pure Python with no wx dependency, so the full relevant test suite runs in WSL. No wx/UI behavior is involved in this change, so there is nothing that required Windows-only verification.

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)