### PR TITLE
test(radar): strengthen bulk_replace coverage (1H/3M)

### DIFF
--- a/tests/test_radar_bulk_replace.py
+++ b/tests/test_radar_bulk_replace.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
 from repositories.radar_repository import RadarRepository
 
 
-def _radar(*, fmt: str, href: str, name: str, decks: int, mb: list[dict] | None = None) -> dict:
+def _radar(
+    *,
+    fmt: str,
+    href: str,
+    name: str,
+    decks: int,
+    mb: list[dict] | None = None,
+    sb: list[dict] | None = None,
+) -> dict:
     return {
         "format": fmt,
         "generated_at": "2026-05-01T00:00:00Z",
@@ -16,7 +26,7 @@ def _radar(*, fmt: str, href: str, name: str, decks: int, mb: list[dict] | None 
         "total_decks_analyzed": decks,
         "decks_failed": 0,
         "mainboard_cards": mb or [],
-        "sideboard_cards": [],
+        "sideboard_cards": sb or [],
     }
 
 
@@ -54,6 +64,17 @@ def test_bulk_replace_persists_all_entries(repo):
     assert burn is not None
     assert burn.total_decks_analyzed == 10
     assert [c.card_name for c in burn.mainboard_cards] == ["Bolt"]
+    # Lock the full column mapping and the copy_distribution JSON round-trip so a
+    # column-order swap, float/int truncation, or distribution-normalization bug
+    # cannot slip through (_card sets distinct values for every field).
+    bolt = burn.mainboard_cards[0]
+    assert bolt.appearances == 10
+    assert bolt.total_copies == 20
+    assert bolt.max_copies == 4
+    assert bolt.avg_copies == 2.0
+    assert bolt.inclusion_rate == 0.5
+    assert bolt.expected_copies == 1.0
+    assert bolt.copy_distribution == {4: 10}
     assert repo.get_total_decks("modern") == 30
     assert repo.get_total_decks("legacy") == 5
 
@@ -80,11 +101,12 @@ def test_bulk_replace_overwrites_existing_snapshot(repo):
                 href="modern-burn",
                 name="Burn",
                 decks=10,
-                mb=[_card("Bolt", copies=4)],
+                mb=[_card("Bolt", copies=4), _card("Lightning Helix", copies=4)],
             )
         ]
     )
-    # Re-hydrate with new data for the same key.
+    # Re-hydrate with new data for the same key, dropping "Lightning Helix" from
+    # the snapshot entirely so the DELETE-before-INSERT must purge it.
     repo.bulk_replace(
         [
             _radar(
@@ -100,7 +122,51 @@ def test_bulk_replace_overwrites_existing_snapshot(repo):
     burn = repo.get_radar("modern", "modern-burn")
     assert burn is not None
     assert burn.total_decks_analyzed == 99
+    # Stale "Lightning Helix" row must be gone, not orphaned/duplicated.
+    assert [c.card_name for c in burn.mainboard_cards] == ["Bolt"]
     assert burn.mainboard_cards[0].appearances == 8
+
+
+def test_bulk_replace_routes_mainboard_and_sideboard(repo):
+    repo.bulk_replace(
+        [
+            _radar(
+                fmt="modern",
+                href="modern-burn",
+                name="Burn",
+                decks=10,
+                mb=[_card("Bolt", copies=10)],
+                sb=[_card("Pyroblast", copies=2)],
+            )
+        ]
+    )
+
+    burn = repo.get_radar("modern", "modern-burn")
+    assert burn is not None
+    # Zones must round-trip without cross-contamination.
+    assert [c.card_name for c in burn.mainboard_cards] == ["Bolt"]
+    assert [c.card_name for c in burn.sideboard_cards] == ["Pyroblast"]
+    assert burn.sideboard_cards[0].appearances == 2
+
+
+def test_bulk_replace_duplicate_keys_in_one_batch_abort_transaction(repo):
+    """Two entries sharing a (format, href) key collide on the radars PK.
+
+    The DELETE is idempotent but both INSERTs run, so the single transaction
+    aborts with an IntegrityError and nothing from the batch is persisted. This
+    pins down the failure mode for duplicate upstream hrefs during bulk hydration.
+    """
+    entries = [
+        _radar(fmt="modern", href="modern-burn", name="Burn A", decks=10),
+        _radar(fmt="modern", href="modern-burn", name="Burn B", decks=20),
+    ]
+
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.bulk_replace(entries)
+
+    # The whole batch rolled back: neither variant of the duplicate key persisted.
+    assert repo.get_radar("modern", "modern-burn") is None
+    assert repo.get_total_decks("modern") == 0
 
 
 def test_bulk_replace_empty_returns_zero(repo):


### PR DESCRIPTION
Strengthens `tests/test_radar_bulk_replace.py` to close the 1 high / 3 medium test-quality findings in issue #603, without touching production code. Adds a duplicate-key test that pins down the documented failure mode (a duplicate `(format, href)` within one batch aborts the single transaction with `sqlite3.IntegrityError` and persists nothing), full round-trip assertions of every `StoredRadarCard` stat field plus the `copy_distribution` JSON normalization, an overwrite test that proves stale cards are purged by the DELETE-before-INSERT, and a mainboard+sideboard test that proves both zones round-trip without cross-contamination.

## Verification
- Ran `tests/test_radar_bulk_replace.py` (6 tests, all passing) from WSL with a minimal `wx` stub injected into `sys.modules`, because `utils.constants` transitively imports `wx`, which is not importable in WSL. Each new assertion was first confirmed against the real `RadarRepository` SQLite round-trip via a probe script before being written, so the asserted values reflect actual behavior (e.g. the duplicate-key case raising `IntegrityError` and rolling back).
- `python -m ruff check tests/test_radar_bulk_replace.py` and `python -m black --check tests/test_radar_bulk_replace.py` both pass.
- Could NOT verify under the real Windows `wx` environment / full UI suite from WSL; the change is test-only and `wx`-independent, but the canonical run is the Windows CI test job. No production/`wx` UI behavior was changed.

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)