### PR TITLE
test: strengthen test_paths coverage for fallback and detection branches

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 import utils.constants.paths as paths
@@ -97,8 +99,20 @@ def test_translate_worktree_path_on_native_linux_is_noop(monkeypatch):
     assert paths._translate_worktree_path("C:\\foo") == "C:\\foo"
 
 
+@pytest.mark.skipif(
+    os.name != "nt",
+    reason="Full WSL-gitdir resolution needs a real Windows host where C:\\ paths exist on disk.",
+)
 def test_default_base_dir_resolves_wsl_gitdir_on_windows(tmp_path, monkeypatch):
-    """Worktrees created by WSL git leave WSL-form pointers; Windows Python must translate."""
+    """Worktrees created by WSL git leave WSL-form pointers; Windows Python must translate.
+
+    This is the real integration case: a ``/mnt/<drive>/...`` pointer must be
+    translated back to a ``<drive>:\\...`` path that points at the on-disk
+    primary repo, so ``_default_base_dir`` walks all the way up to ``repo_root``.
+    It can only run on Windows, where the translated drive path resolves to a
+    real directory; on POSIX hosts the translator itself is covered by
+    ``test_translate_worktree_path_on_windows``.
+    """
     repo_root = tmp_path / "repo"
     worktree_root = tmp_path / "repo-issue-123"
     worktree_subdir = worktree_root / "scripts"
@@ -106,26 +120,114 @@ def test_default_base_dir_resolves_wsl_gitdir_on_windows(tmp_path, monkeypatch):
     gitdir.mkdir(parents=True)
     worktree_subdir.mkdir(parents=True)
 
-    # Simulate the pointer that WSL git would write: a /mnt/<drive>/... path.
-    # Build it from the real tmp_path by rewriting its drive prefix.
-    drive = tmp_path.drive  # e.g. "C:" on Windows, "" on Linux
-    if drive:
-        wsl_prefix = f"/mnt/{drive[0].lower()}"
-        wsl_gitdir = wsl_prefix + str(gitdir)[len(drive) :].replace("\\", "/")
-    else:
-        # On non-Windows test hosts, fabricate a WSL path that maps back to tmp_path's posix form.
-        wsl_gitdir = "/mnt/c" + str(gitdir)
+    # Simulate the pointer that WSL git would write: a /mnt/<drive>/... path,
+    # built from the real tmp_path by rewriting its drive prefix.
+    drive = tmp_path.drive  # e.g. "C:" on Windows
+    wsl_prefix = f"/mnt/{drive[0].lower()}"
+    wsl_gitdir = wsl_prefix + str(gitdir)[len(drive) :].replace("\\", "/")
     (worktree_root / ".git").write_text(f"gitdir: {wsl_gitdir}\n", encoding="utf-8")
 
     monkeypatch.delenv(paths.BASE_DATA_DIR_ENV_VAR, raising=False)
     monkeypatch.chdir(worktree_subdir)
-    monkeypatch.setattr(paths.os, "name", "nt")
 
-    # With translation, the resolver must walk up to repo_root.
-    # (On a Linux test host the translated C:\ path won't point at a real dir,
-    # so we only assert the non-regressing behavior under the "nt" branch by
-    # checking the translator in isolation — the full-path integration case is
-    # already covered by test_default_base_dir_uses_primary_repo_root_for_sibling_worktree.)
-    translated = paths._translate_worktree_path(wsl_gitdir)
-    assert translated != wsl_gitdir  # translation kicked in
-    assert not translated.startswith("/mnt/")  # no longer WSL-form
+    # With translation, the resolver must walk up to the primary repo root.
+    assert paths._default_base_dir() == repo_root.resolve()
+
+
+def test_default_base_dir_falls_back_to_repo_root_without_git_marker(tmp_path, monkeypatch):
+    """An installed/copied checkout has no .git; the resolver falls back to the bundled root."""
+    no_git_dir = tmp_path / "no-git" / "nested"
+    no_git_dir.mkdir(parents=True)
+
+    monkeypatch.delenv(paths.BASE_DATA_DIR_ENV_VAR, raising=False)
+    monkeypatch.setattr(paths.sys, "frozen", False, raising=False)
+    monkeypatch.chdir(no_git_dir)
+
+    # cwd has no .git anywhere in its parents, so _base_dir_from_cwd() returns
+    # None and _default_base_dir falls back to three levels up from paths.py.
+    expected = paths.Path(paths.__file__).resolve().parent.parent.parent
+    assert paths._base_dir_from_cwd() is None
+    assert paths._default_base_dir() == expected
+
+
+def test_resolve_gitdir_returns_none_for_non_gitdir_content(tmp_path):
+    """A .git file whose content is not a 'gitdir:' pointer yields None (no crash)."""
+    marker = tmp_path / ".git"
+    marker.write_text("garbage\n", encoding="utf-8")
+
+    assert paths._resolve_gitdir(marker) is None
+
+
+def test_resolve_gitdir_returns_none_for_unreadable_marker(tmp_path, monkeypatch):
+    """An unreadable .git marker is swallowed and reported as None."""
+    marker = tmp_path / ".git"
+    marker.write_text("gitdir: /somewhere\n", encoding="utf-8")
+
+    def _raise_oserror(*args, **kwargs):
+        raise OSError("unreadable")
+
+    monkeypatch.setattr(paths.Path, "read_text", _raise_oserror)
+
+    assert paths._resolve_gitdir(marker) is None
+
+
+def test_primary_worktree_root_falls_back_on_malformed_marker(tmp_path):
+    """A malformed .git pointer falls back to the worktree marker's own parent."""
+    worktree_root = tmp_path / "worktree"
+    worktree_root.mkdir()
+    marker = worktree_root / ".git"
+    marker.write_text("not-a-gitdir-pointer\n", encoding="utf-8")
+
+    assert paths._primary_worktree_root_from_marker(marker) == worktree_root.resolve()
+
+
+def test_running_under_wsl_false_on_non_linux(monkeypatch):
+    monkeypatch.setattr(paths.sys, "platform", "win32")
+    assert paths._running_under_wsl() is False
+
+
+def test_running_under_wsl_true_when_interop_env_set(monkeypatch):
+    monkeypatch.setattr(paths.sys, "platform", "linux")
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+    monkeypatch.setenv("WSL_INTEROP", "/run/WSL/123_interop")
+    assert paths._running_under_wsl() is True
+
+
+def test_running_under_wsl_true_when_proc_version_mentions_microsoft(monkeypatch):
+    monkeypatch.setattr(paths.sys, "platform", "linux")
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+    monkeypatch.delenv("WSL_INTEROP", raising=False)
+
+    import io
+
+    def _fake_open(*args, **kwargs):
+        return io.StringIO("Linux version 5.15.0-microsoft-standard-WSL2")
+
+    monkeypatch.setattr("builtins.open", _fake_open)
+    assert paths._running_under_wsl() is True
+
+
+def test_running_under_wsl_false_on_native_linux(monkeypatch):
+    monkeypatch.setattr(paths.sys, "platform", "linux")
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+    monkeypatch.delenv("WSL_INTEROP", raising=False)
+
+    import io
+
+    def _fake_open(*args, **kwargs):
+        return io.StringIO("Linux version 6.6.0-generic")
+
+    monkeypatch.setattr("builtins.open", _fake_open)
+    assert paths._running_under_wsl() is False
+
+
+def test_running_under_wsl_false_when_proc_version_unreadable(monkeypatch):
+    monkeypatch.setattr(paths.sys, "platform", "linux")
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+    monkeypatch.delenv("WSL_INTEROP", raising=False)
+
+    def _raise_oserror(*args, **kwargs):
+        raise OSError("no /proc/version")
+
+    monkeypatch.setattr("builtins.open", _raise_oserror)
+    assert paths._running_under_wsl() is False


### PR DESCRIPTION
Strengthens `tests/test_paths.py` to close the 4 medium test-quality findings against `utils/constants/paths.py`. The previously redundant Windows-gitdir test is now gated behind a real `os.name == "nt"` skip and asserts the full `_default_base_dir` integration result; new tests cover the no-`.git`-marker fallback to the bundled repo root, the `_resolve_gitdir` error/edge branches (non-`gitdir:` content, unreadable marker, malformed-pointer fallback), and direct `_running_under_wsl` detection (non-linux, `WSL_INTEROP`, `/proc/version` microsoft substring, native Linux, and the `OSError` fallback). No production code was changed.

## Verification
- `python -m ruff check tests/test_paths.py` — passed.
- `python -m black --check tests/test_paths.py` — passed (unchanged).
- `python -m pytest tests/test_paths.py -q` — the `tests` package transitively imports `wx` via `utils.constants.__init__` -> `utils.constants.keyboard`, which is not installable in WSL, so collection fails here exactly as it does for the pre-existing test (confirmed by stashing the change). Running with a minimal local `wx` stub on `PYTHONPATH`, all 23 tests pass and 1 (the Windows-only integration case) is skipped. The real `wx`-backed run and the Windows-only `test_default_base_dir_resolves_wsl_gitdir_on_windows` integration assertion must be validated by CI on Windows; they were not run in WSL.

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)