### PR TITLE
test: cover session_manager untested validation/migration/persistence paths

### DIFF
--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -120,3 +120,191 @@ def test_session_manager_validates_defaults_and_config(tmp_path):
 
     config_data = json.loads(config_file.read_text(encoding="utf-8"))
     assert config_data["deck_selector_save_path"] == str(deck_dir)
+
+
+def _make_manager(tmp_path, settings: dict | None = None, repo: StubDeckRepo | None = None):
+    settings_file = tmp_path / "settings.json"
+    if settings is not None:
+        settings_file.write_text(json.dumps(settings), encoding="utf-8")
+    return DeckSelectorSessionManager(
+        repo if repo is not None else StubDeckRepo(),
+        settings_file=settings_file,
+        config_file=tmp_path / "config.json",
+        default_deck_dir=tmp_path / "decks",
+    )
+
+
+def test_placement_filter_migrates_legacy_values(tmp_path):
+    manager = _make_manager(
+        tmp_path,
+        {
+            "deck_placement_op": ">=",
+            "deck_placement_field": "wins",
+            "deck_placement_value": "3",
+        },
+    )
+    assert manager.get_deck_placement_filter() == ("≥", "Wins", "3")
+
+    manager = _make_manager(
+        tmp_path,
+        {"deck_placement_op": "<=", "deck_placement_field": "placement"},
+    )
+    assert manager.get_deck_placement_filter() == ("≤", "Placement", "")
+
+
+def test_placement_filter_invalid_falls_back(tmp_path):
+    manager = _make_manager(
+        tmp_path,
+        {"deck_placement_op": "??", "deck_placement_field": "bogus", "deck_placement_value": "1"},
+    )
+    assert manager.get_deck_placement_filter() == ("-", "Placement", "1")
+
+
+def test_update_placement_filter_round_trips_and_migrates(tmp_path):
+    manager = _make_manager(tmp_path)
+    manager.update_deck_placement_filter(">=", "wins", "5")
+    assert manager.settings["deck_placement_op"] == "≥"
+    assert manager.settings["deck_placement_field"] == "Wins"
+    assert manager.settings["deck_placement_value"] == "5"
+    assert manager.get_deck_placement_filter() == ("≥", "Wins", "5")
+
+    manager.update_deck_placement_filter("??", "bogus", "9")
+    assert manager.settings["deck_placement_op"] == "-"
+    assert manager.settings["deck_placement_field"] == "Placement"
+    assert manager.settings["deck_placement_value"] == "9"
+
+
+def test_save_removes_stale_saved_deck_info(tmp_path):
+    repo = StubDeckRepo()
+    repo.set_current_deck({"name": "Burn"})
+    manager = _make_manager(tmp_path, repo=repo)
+    save_kwargs = {
+        "current_format": "Modern",
+        "left_mode": "builder",
+        "deck_data_source": "mtgo",
+        "zone_cards": {"main": [], "side": [], "out": []},
+    }
+    manager.save(**save_kwargs)
+    data = json.loads(manager.settings_file.read_text(encoding="utf-8"))
+    assert data["saved_deck_info"] == {"name": "Burn"}
+
+    repo.set_current_deck(None)
+    manager.save(**save_kwargs)
+    data = json.loads(manager.settings_file.read_text(encoding="utf-8"))
+    assert "saved_deck_info" not in data
+
+    # A subsequent restore must not set deck_info from stale state.
+    restored = manager.restore_session_state({"main": [], "side": [], "out": []})
+    assert "deck_info" not in restored
+
+
+def test_restore_on_empty_settings_returns_only_left_mode(tmp_path):
+    repo = StubDeckRepo()
+    manager = _make_manager(tmp_path, repo=repo)
+    target = {"main": [], "side": [], "out": []}
+    restored = manager.restore_session_state(target)
+    assert restored == {"left_mode": "research"}
+    assert repo.get_current_deck_text() == ""
+    assert repo.get_current_deck() is None
+
+
+def test_restore_ignores_malformed_window_size_and_nonlist_zone(tmp_path):
+    manager = _make_manager(
+        tmp_path,
+        {
+            "window_size": [800, 600, 100],
+            "screen_pos": [5, 5],
+            "saved_zone_cards": {"main": "not-a-list", "side": [], "out": []},
+        },
+    )
+    restored = manager.restore_session_state({"main": [], "side": [], "out": []})
+    assert "window_size" not in restored
+    assert restored["screen_pos"] == (5, 5)
+    assert "zone_cards" not in restored
+
+
+def test_corrupt_settings_json_degrades_to_defaults(tmp_path):
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{not valid json", encoding="utf-8")
+    manager = DeckSelectorSessionManager(
+        StubDeckRepo(),
+        settings_file=settings_file,
+        config_file=tmp_path / "config.json",
+        default_deck_dir=tmp_path / "decks",
+    )
+    assert manager.settings == {}
+    assert manager.get_current_format() == "Modern"
+
+
+def test_average_method_and_hours_validation(tmp_path):
+    manager = _make_manager(tmp_path)
+    assert manager.get_average_method() == "karsten"
+    manager.update_average_method("arithmetic")
+    assert manager.settings["average_method"] == "arithmetic"
+    assert manager.get_average_method() == "arithmetic"
+    manager.update_average_method("bogus")
+    assert manager.settings["average_method"] == "karsten"
+
+    assert manager.get_average_hours() == 24
+    manager.update_average_hours(48)
+    assert manager.settings["average_hours"] == 48
+    assert manager.get_average_hours() == 48
+    manager.update_average_hours(13)
+    assert manager.settings["average_hours"] == 24
+
+    manager.settings["average_hours"] = "not-a-number"
+    assert manager.get_average_hours() == 24
+    manager.settings["average_hours"] = "48"
+    assert manager.get_average_hours() == 48
+
+
+def test_event_logging_enabled_round_trips(tmp_path):
+    manager = _make_manager(tmp_path)
+    assert manager.get_event_logging_enabled() is False
+    manager.update_event_logging_enabled(True)
+    assert manager.settings["event_logging_enabled"] is True
+    assert manager.get_event_logging_enabled() is True
+
+
+def test_deck_view_and_pile_sort_modes(tmp_path):
+    manager = _make_manager(tmp_path)
+    assert manager.get_deck_view_mode("main") == "grid"
+    manager.update_deck_view_mode("main", "table")
+    assert manager.settings["deck_view_modes"]["main"] == "table"
+    assert manager.get_deck_view_mode("main") == "table"
+    manager.update_deck_view_mode("side", "bogus")
+    assert manager.settings["deck_view_modes"]["side"] == "grid"
+
+    assert manager.get_pile_sort_mode("main") == "mv"
+    manager.update_pile_sort_mode("main", "color")
+    assert manager.settings["deck_pile_sort_modes"]["main"] == "color"
+    assert manager.get_pile_sort_mode("main") == "color"
+    manager.update_pile_sort_mode("side", "bogus")
+    assert manager.settings["deck_pile_sort_modes"]["side"] == "mv"
+
+
+def test_event_type_player_and_date_filters(tmp_path):
+    manager = _make_manager(tmp_path)
+    assert manager.get_deck_event_type_filter() == "All"
+    manager.update_deck_event_type_filter("League")
+    assert manager.settings["deck_event_type_filter"] == "League"
+    assert manager.get_deck_event_type_filter() == "League"
+    manager.update_deck_event_type_filter("bogus")
+    assert manager.settings["deck_event_type_filter"] == "All"
+
+    assert manager.get_deck_player_filter() == ""
+    manager.update_deck_player_filter("Alice")
+    assert manager.get_deck_player_filter() == "Alice"
+
+    assert manager.get_deck_date_filter() == ""
+    manager.update_deck_date_filter("2026-06-01")
+    assert manager.get_deck_date_filter() == "2026-06-01"
+
+
+def test_tutorial_shown_persists_to_disk(tmp_path):
+    manager = _make_manager(tmp_path)
+    assert manager.is_tutorial_shown() is False
+    manager.mark_tutorial_shown()
+    assert manager.is_tutorial_shown() is True
+    data = json.loads(manager.settings_file.read_text(encoding="utf-8"))
+    assert data["tutorial_shown"] is True


### PR DESCRIPTION
Adds focused non-wx unit tests for `controllers/session_manager.py` (`DeckSelectorSessionManager`) to close the coverage gaps flagged in #610. New tests exercise the placement-filter legacy migration maps and invalid-value fallbacks, the `save()` branch that drops stale `saved_deck_info` when no current deck exists, the `restore_session_state` guard branches (empty settings, malformed `window_size` length, non-list saved zone entries), corrupt-JSON degradation to defaults, all the validating getters/updaters (average method/hours with int coercion, event logging, per-zone deck-view/pile-sort modes, event-type/player/date filters), and tutorial-flag persistence to disk. No production code was changed.

## Verification
- `python -m ruff check tests/test_session_manager.py` — passed
- `python -m black --check tests/test_session_manager.py` — passed (unchanged)
- `python -m py_compile tests/test_session_manager.py controllers/session_manager.py` — passed
- `python -m pytest tests/test_session_manager.py` could NOT be run in WSL: the module imports `utils.constants`, which transitively imports `wx` (`ModuleNotFoundError: No module named 'wx'`). This affects the entire test file, including the pre-existing tests, so the added tests must be validated on Windows CI where `wx` is available. The new tests use the same module-load path and stub repo as the existing passing tests, so they are expected to pass there.

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)