### PR TITLE
test: make tutorial-gate testable without wx (Humble Object) (#680)

### DIFF
--- a/tests/test_runtime_flags.py
+++ b/tests/test_runtime_flags.py
@@ -2,10 +2,26 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
-import sys
-from unittest.mock import MagicMock, patch
+from pathlib import Path
 
 import pytest
+
+# ``session_logic`` is a wx-free leaf module inside the
+# ``widgets.frames.app_frame`` package, whose ``__init__`` imports ``wx``
+# (unavailable off-Windows). Load it directly from source so the import does not
+# pull in the package ``__init__`` — same approach as ``test_deck_formatting``.
+_SESSION_LOGIC_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "widgets"
+    / "frames"
+    / "app_frame"
+    / "handlers"
+    / "session_logic.py"
+)
+_spec = importlib.util.spec_from_file_location("_session_logic_under_test", _SESSION_LOGIC_PATH)
+_session_logic = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_session_logic)
+should_show_tutorial = _session_logic.should_show_tutorial
 
 
 @pytest.fixture
@@ -35,47 +51,45 @@ def test_set_automation_enabled_coerces_truthy_values(runtime_flags):
     assert runtime_flags.is_automation_enabled() is False
 
 
-_WX_AVAILABLE = importlib.util.find_spec("wx") is not None
-_requires_wx = pytest.mark.skipif(
-    not _WX_AVAILABLE or sys.platform != "win32",
-    reason="AppFrame tutorial-skip checks require wxPython (Windows-only)",
-)
+# --------------------------------------------------------------------------- #
+# Tutorial-gate decision (Humble Object): the pure predicate behind the wx
+# ``wx.CallAfter(self._open_tutorial)`` scheduling in
+# ``AppFrameHandlersMixin._restore_session_state``. Tested here with the real
+# function and the real ``runtime_flags`` flag — no wx, no mocked AppFrame.
+# --------------------------------------------------------------------------- #
 
 
-def _call_restore_session_state(is_automation: bool, tutorial_shown: bool):
-    """Invoke AppFrame._restore_session_state unbound with mocked collaborators."""
-    from widgets.frames.app_frame import AppFrame
-    from widgets.frames.app_frame.handlers import app_frame as handlers_module
-
-    frame = MagicMock()
-    frame.controller.zone_cards = {"main": [], "side": [], "out": []}
-    frame.controller.session_manager.restore_session_state.return_value = {
-        "left_mode": "research",
-    }
-    frame.controller.session_manager.is_tutorial_shown.return_value = tutorial_shown
-    frame.controller.card_repo.is_card_data_ready.return_value = True
-
-    with (
-        patch.object(handlers_module, "is_automation_enabled", return_value=is_automation),
-        patch.object(handlers_module, "wx") as wx_mock,
-    ):
-        AppFrame._restore_session_state(frame)
-        return wx_mock, frame
+def test_show_tutorial_when_not_shown_and_not_automation():
+    assert should_show_tutorial(tutorial_shown=False, automation_enabled=False) is True
 
 
-@_requires_wx
-def test_restore_session_state_schedules_tutorial_when_not_shown_and_not_automation():
-    wx_mock, frame = _call_restore_session_state(is_automation=False, tutorial_shown=False)
-    wx_mock.CallAfter.assert_called_once_with(frame._open_tutorial)
+def test_skip_tutorial_under_automation():
+    assert should_show_tutorial(tutorial_shown=False, automation_enabled=True) is False
 
 
-@_requires_wx
-def test_restore_session_state_skips_tutorial_under_automation():
-    wx_mock, _frame = _call_restore_session_state(is_automation=True, tutorial_shown=False)
-    wx_mock.CallAfter.assert_not_called()
+def test_skip_tutorial_when_already_shown():
+    assert should_show_tutorial(tutorial_shown=True, automation_enabled=False) is False
 
 
-@_requires_wx
-def test_restore_session_state_skips_tutorial_when_already_shown():
-    wx_mock, _frame = _call_restore_session_state(is_automation=False, tutorial_shown=True)
-    wx_mock.CallAfter.assert_not_called()
+def test_skip_tutorial_when_shown_and_automation():
+    assert should_show_tutorial(tutorial_shown=True, automation_enabled=True) is False
+
+
+def test_tutorial_gate_reads_live_automation_flag(runtime_flags):
+    """The gate honours the real process-wide automation flag set at startup."""
+    runtime_flags.set_automation_enabled(True)
+    assert (
+        should_show_tutorial(
+            tutorial_shown=False,
+            automation_enabled=runtime_flags.is_automation_enabled(),
+        )
+        is False
+    )
+    runtime_flags.set_automation_enabled(False)
+    assert (
+        should_show_tutorial(
+            tutorial_shown=False,
+            automation_enabled=runtime_flags.is_automation_enabled(),
+        )
+        is True
+    )

--- a/widgets/frames/app_frame/handlers/app_frame.py
+++ b/widgets/frames/app_frame/handlers/app_frame.py
@@ -15,6 +15,7 @@ from widgets.dialogs.help_dialog import show_help
 from widgets.dialogs.image_download_dialog import show_image_download_dialog
 from widgets.dialogs.tutorial_dialog import show_tutorial
 from widgets.frames.app_frame.handlers.deck_formatting import simple_summary_html
+from widgets.frames.app_frame.handlers.session_logic import should_show_tutorial
 from widgets.frames.mana_keyboard import open_mana_keyboard
 
 if TYPE_CHECKING:
@@ -208,7 +209,10 @@ class AppFrameHandlersMixin(_Base):
 
     def _restore_session_state(self) -> None:
         state = self.controller.session_manager.restore_session_state(self.controller.zone_cards)
-        if not self.controller.session_manager.is_tutorial_shown() and not is_automation_enabled():
+        if should_show_tutorial(
+            tutorial_shown=self.controller.session_manager.is_tutorial_shown(),
+            automation_enabled=is_automation_enabled(),
+        ):
             wx.CallAfter(self._open_tutorial)
 
         # Restore left panel mode

--- a/widgets/frames/app_frame/handlers/session_logic.py
+++ b/widgets/frames/app_frame/handlers/session_logic.py
@@ -1,0 +1,17 @@
+"""Stateless session-restore decision helpers for the app-frame handlers.
+
+Pure functions with no ``self`` and no ``wx`` dependency, factored out of the
+:meth:`AppFrameHandlersMixin._restore_session_state` handler so the gate logic
+can be exercised without a ``wx.App`` (Humble Object pattern).
+"""
+
+from __future__ import annotations
+
+
+def should_show_tutorial(*, tutorial_shown: bool, automation_enabled: bool) -> bool:
+    """Return whether the first-run tutorial should be scheduled on startup.
+
+    The tutorial is shown only when the user has never seen it and the app is
+    not being driven by automation (where interactive dialogs would block).
+    """
+    return not tutorial_shown and not automation_enabled


### PR DESCRIPTION
Addresses the high-severity test-quality findings in #680 for `tests/test_runtime_flags.py`. The `AppFrame` restore portion of that file mocked the entire frame, patched the `wx` module, was skipped off-Windows, and asserted only on `wx.CallAfter` call counts (interaction testing of internal collaborators). Following the Humble Object guidance in `tests/README.md`, the first-run tutorial decision is extracted from `AppFrameHandlersMixin._restore_session_state` into a pure, wx-free helper `should_show_tutorial()` in a new `widgets/frames/app_frame/handlers/session_logic.py` (mirroring the existing `deck_formatting.py` pure-helper module). The handler now calls it; the tests assert on its real return values driven by the real `utils.runtime_flags` flag — no mocked internal components, no `wx`, no platform skips.

## Verification
Ran in WSL (wx not importable here):
- `python -m pytest tests/test_runtime_flags.py -q` -> 8 passed, 0 skipped (previously 3 were win32-only skips).
- `python -m pytest tests/test_deck_formatting.py -q` -> 18 passed (sibling pure-helper pattern, no regression).
- `python -m ruff check` and `python -m black --check` on all three changed files -> clean.
- `python -m py_compile` on `handlers/app_frame.py` and `handlers/session_logic.py` -> OK.

Could NOT verify in WSL: the actual wx behavior of `_restore_session_state` (the `wx.CallAfter(self._open_tutorial)` scheduling and the rest of the session-restore body) — `wx` is not importable off-Windows. The extracted predicate is now fully covered without wx; the thin wx scheduling edge around it remains exercised only by the Windows CI run. The change to the handler is a behavior-preserving extraction (same boolean condition).

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)