### PR TITLE
test: trim duplicated repo tests from test_collection_loading.py

### DIFF
--- a/tests/test_collection_loading.py
+++ b/tests/test_collection_loading.py
@@ -1,97 +1,18 @@
+"""Integration tests for CollectionService against a real CardRepository.
+
+These exercise the service<->real-repo collaboration end to end. The
+``CardRepository.load_collection_from_file`` parsing rules are covered
+exhaustively in ``test_card_repository.py`` and are not re-tested here.
+"""
+
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from repositories.card_repository import CardRepository
 from services.collection_service import CollectionService
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "sample_collection_export.json"
-
-
-def test_card_repository_reads_collection_export():
-    repo = CardRepository()
-
-    cards = repo.load_collection_from_file(FIXTURE_PATH)
-
-    assert len(cards) == 4
-
-    names = [card["name"] for card in cards]
-    assert names == ["Lightning Bolt", "Island", "Lightning Bolt", "Spell Pierce"]
-    assert cards[-1]["quantity"] == 2
-    # The normalized `id` field is preserved from the export entries.
-    assert cards[0]["id"] == 1001
-
-
-def test_card_repository_handles_flat_list_format(tmp_path):
-    repo = CardRepository()
-    list_path = tmp_path / "collection_list.json"
-    payload = [
-        {"name": "Opt", "quantity": 3},
-        {"name": "Consider", "quantity": "2"},
-    ]
-    list_path.write_text(json.dumps(payload), encoding="utf-8")
-
-    cards = repo.load_collection_from_file(list_path)
-
-    assert len(cards) == 2
-    assert [card["name"] for card in cards] == ["Opt", "Consider"]
-    assert cards[1]["quantity"] == 2
-    # Entries without an `id` key must not gain a spurious one.
-    assert "id" not in cards[0]
-
-
-def test_card_repository_returns_empty_for_missing_file(tmp_path):
-    repo = CardRepository()
-
-    cards = repo.load_collection_from_file(tmp_path / "does_not_exist.json")
-
-    assert cards == []
-
-
-def test_card_repository_returns_empty_for_invalid_json(tmp_path):
-    repo = CardRepository()
-    bad_path = tmp_path / "broken.json"
-    bad_path.write_bytes(b"{not valid json")
-
-    cards = repo.load_collection_from_file(bad_path)
-
-    assert cards == []
-
-
-def test_card_repository_returns_empty_for_no_entries(tmp_path):
-    repo = CardRepository()
-
-    empty_dict_path = tmp_path / "empty_collection.json"
-    empty_dict_path.write_text(
-        json.dumps({"collection": {"name": "Collection", "items": []}}),
-        encoding="utf-8",
-    )
-    missing_list_path = tmp_path / "missing_list.json"
-    missing_list_path.write_text(json.dumps({"mode": "Collection"}), encoding="utf-8")
-
-    assert repo.load_collection_from_file(empty_dict_path) == []
-    assert repo.load_collection_from_file(missing_list_path) == []
-
-
-def test_card_repository_coerces_and_skips_quantities(tmp_path):
-    repo = CardRepository()
-    list_path = tmp_path / "quantities.json"
-    payload = [
-        {"name": "Float Down", "quantity": "2.5"},  # float-string -> int(float(...)) == 2
-        {"name": "Float Round", "quantity": "3.0"},  # float-string -> 3
-        {"name": "Bad String", "quantity": "abc"},  # non-numeric -> skipped
-        {"name": "Null Qty", "quantity": None},  # None -> skipped
-        {"name": "Negative", "quantity": -1},  # negative -> skipped
-        {"name": "   ", "quantity": 5},  # blank name -> skipped
-        {"name": "", "quantity": 5},  # empty name -> skipped
-    ]
-    list_path.write_text(json.dumps(payload), encoding="utf-8")
-
-    cards = repo.load_collection_from_file(list_path)
-
-    assert [card["name"] for card in cards] == ["Float Down", "Float Round"]
-    assert [card["quantity"] for card in cards] == [2, 3]
 
 
 def test_collection_service_loads_inventory_from_export(tmp_path):
@@ -111,16 +32,6 @@ def test_collection_service_loads_inventory_from_export(tmp_path):
     assert service.get_owned_count("Spell Pierce") == 2
     # Lookups are case-insensitive regardless of caller casing.
     assert service.get_owned_count("lightning bolt") == 5
-
-
-def test_collection_service_load_missing_file_returns_empty(tmp_path):
-    repo = CardRepository()
-    service = CollectionService(card_repository=repo)
-
-    assert service.load_collection(tmp_path / "nope.json")
-
-    assert service.get_inventory() == {}
-    assert service.is_loaded()
 
 
 def test_collection_service_short_circuits_when_already_loaded(tmp_path):


### PR DESCRIPTION
## Summary

Trims `tests/test_collection_loading.py` to its intended scope per issue #685: the value of this file is the `CollectionService` <-> real `CardRepository` integration. Six `CardRepository`-only tests (export reading, flat-list parsing, missing file, invalid JSON, no-entries, quantity coercion/skip) duplicated the exhaustive parsing coverage already in `test_card_repository.py`, and the service missing-file test duplicated `test_collection_service.py::test_load_collection_nonexistent_file`. These duplicates are removed and a module docstring documents the focused scope. The three remaining tests cover the real load-into-inventory path, the already-loaded short-circuit (incl. `force=True`), and the read-error-returns-False branch (which is not covered with a real repo elsewhere, so it is kept).

## Verification

- `python -m ruff check tests/test_collection_loading.py` — passed.
- `python -m black --check tests/test_collection_loading.py` — passed (no changes).
- `python -m py_compile tests/test_collection_loading.py` — compiles cleanly.
- Could NOT run pytest in WSL: `tests/test_collection_loading.py`, `test_card_repository.py`, and `test_collection_service.py` transitively import `wx` (via `utils.constants.keyboard`), which is not importable off-Windows. These must be validated by CI on Windows. No wx/UI behavior was exercised.

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
