### PR TITLE
test: cover get_stats_for_format remote-raises and force_refresh branches (#692)

### DIFF
--- a/tests/test_metagame_repository.py
+++ b/tests/test_metagame_repository.py
@@ -916,6 +916,51 @@ def test_get_stats_falls_back_to_live_when_remote_returns_none(tmp_path, monkeyp
     assert called == ["modern"]
 
 
+def test_get_stats_falls_back_to_live_when_remote_raises(tmp_path, monkeypatch):
+    """A remote stats exception should be swallowed and the live navigator used."""
+
+    class _BoomClient:
+        def get_metagame_stats_for_format(self, _fmt):
+            raise RuntimeError("network error")
+
+    live_stats = {"modern": {"timestamp": 0.0, "UR Murktide": {"results": {}}}}
+    called = []
+
+    def fake_live_stats(fmt):
+        called.append(fmt)
+        return live_stats
+
+    monkeypatch.setattr("repositories.scrapers.mtggoldfish.get_archetype_stats", fake_live_stats)
+
+    repo = _make_repo(tmp_path, remote_client=_BoomClient())
+    result = repo.get_stats_for_format("modern")
+
+    assert result == live_stats
+    assert called == ["modern"]
+
+
+def test_get_stats_force_refresh_skips_remote(tmp_path, monkeypatch):
+    """force_refresh=True must bypass the remote snapshot and scrape live data."""
+    remote_stats = {"modern": {"timestamp": 1711234567.0, "UR Murktide": {"results": {}}}}
+    remote = _FakeRemoteClient(stats=remote_stats)
+
+    live_stats = {"modern": {"timestamp": 0.0, "Amulet Titan": {"results": {}}}}
+    called = []
+
+    def fake_live_stats(fmt):
+        called.append(fmt)
+        return live_stats
+
+    monkeypatch.setattr("repositories.scrapers.mtggoldfish.get_archetype_stats", fake_live_stats)
+
+    repo = _make_repo(tmp_path, remote_client=remote)
+    result = repo.get_stats_for_format("modern", force_refresh=True)
+
+    assert result == live_stats
+    assert called == ["modern"]
+    assert remote.stats_calls == [], "remote client must not be consulted on force_refresh"
+
+
 def test_remote_client_not_used_when_disabled(tmp_path, monkeypatch):
     """Without an injected client and REMOTE_SNAPSHOTS_ENABLED=False, no remote calls."""
     monkeypatch.setattr("repositories.metagame_repository.REMOTE_SNAPSHOTS_ENABLED", False)


### PR DESCRIPTION
## Summary

Closes #692. The test-review sweep flagged that two branches of `MetagameRepository.get_stats_for_format` in `repositories/metagame_repository/archetype_resolution.py` were untested: the remote-snapshot exception fall-through (the `except Exception` that swallows a remote failure and proceeds to the live scrape) and the `force_refresh=True` path that bypasses the remote client entirely. This PR adds two focused unit tests mirroring the existing `test_get_stats_falls_back_to_live_when_remote_returns_none` style: one asserts a raising remote client is swallowed and the live navigator (`repositories.scrapers.mtggoldfish.get_archetype_stats`) is used, and one asserts `force_refresh=True` never consults the remote client and scrapes live data. No production code was changed.

## Verification

- `python -m ruff check tests/test_metagame_repository.py` — passed.
- `python -m black --check tests/test_metagame_repository.py` — passed (unchanged).
- `python -m py_compile tests/test_metagame_repository.py` — passed.
- Could NOT run pytest in WSL: `tests/test_metagame_repository.py` transitively imports `wx` (via `repositories.remote_snapshot_client` -> `utils.constants.keyboard`), which is not importable off-Windows. This is a pre-existing collection blocker for this file, confirmed by collecting the file on unmodified `main`. The new tests reuse the exact monkeypatch target and `_FakeRemoteClient`/`_make_repo` helpers as the adjacent passing tests, so they are expected to pass under the Windows CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)