### PR TITLE
test: strengthen opponent-detection assertions (#694)

### DIFF
--- a/tests/test_opponent_detection.py
+++ b/tests/test_opponent_detection.py
@@ -43,21 +43,30 @@ def test_find_opponent_names_ignores_non_match_titles(monkeypatch: pytest.Monkey
     assert find_opponent_names() == []
 
 
+def test_find_opponent_names_empty_title_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No open windows yields no opponents."""
+    monkeypatch.setattr(
+        "utils.find_opponent_names.pygetwindow.getAllTitles",
+        lambda: [],
+    )
+    assert find_opponent_names() == []
+
+
 @pytest.mark.parametrize(
-    "titles",
+    "titles, expected",
     [
-        ["Champion vs."],
-        ["vs."],
-        ["Champion vs. "],
-        ["Champion vs. Rival", "Lobby vs."],
+        (["Champion vs."], []),
+        (["vs."], []),
+        (["Champion vs. "], []),
+        (["Champion vs. Rival", "Lobby vs."], ["Rival"]),
     ],
 )
 def test_find_opponent_names_skips_blank_opponents(
-    monkeypatch: pytest.MonkeyPatch, titles: Iterable[str]
+    monkeypatch: pytest.MonkeyPatch, titles: Iterable[str], expected: list[str]
 ) -> None:
     """A trailing 'vs.' yields an empty name that must not be emitted as an opponent."""
     monkeypatch.setattr(
         "utils.find_opponent_names.pygetwindow.getAllTitles",
         lambda: list(titles),
     )
-    assert "" not in find_opponent_names()
+    assert find_opponent_names() == expected


### PR DESCRIPTION
Strengthens `tests/test_opponent_detection.py` per the test-review findings: the `test_find_opponent_names_skips_blank_opponents` case now asserts the full expected opponent list per parametrized input instead of the near-tautological `"" not in result`, and an explicit `test_find_opponent_names_empty_title_list` pins the empty-title-list behavior (the previously unpinned low finding). Expected values were derived from the real `find_opponent_names` implementation (splitting on `vs.`, stripping, dropping blanks).

## Verification
- `python -m ruff check tests/test_opponent_detection.py` — passed
- `python -m black --check tests/test_opponent_detection.py` — unchanged
- `python -m pytest tests/test_opponent_detection.py -q` — 8 passed

This change is test-only and does not import `wx`; no UI behavior is involved, so nothing was left unverifiable in WSL beyond the inherent absence of `wx` (not relevant here).

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)