### PR TITLE
test: harden background_worker tests (#697)

### DIFF
--- a/tests/test_background_worker.py
+++ b/tests/test_background_worker.py
@@ -28,12 +28,14 @@ def _synchronous_call_after(monkeypatch):
 def test_background_worker_submit():
     worker = BackgroundWorker()
     result = []
+    done = threading.Event()
 
     def task():
         result.append(1)
+        done.set()
 
     worker.submit(task)
-    time.sleep(0.1)
+    assert done.wait(timeout=1.0)
 
     assert result == [1]
     worker.shutdown()
@@ -73,14 +75,16 @@ def test_background_worker_stops_loop():
 
 def test_background_worker_context_manager():
     result = []
+    done = threading.Event()
 
     with BackgroundWorker() as worker:
 
         def task():
             result.append(1)
+            done.set()
 
         worker.submit(task)
-        time.sleep(0.1)
+        assert done.wait(timeout=1.0)
 
     assert result == [1]
     assert worker.is_stopped()
@@ -89,14 +93,16 @@ def test_background_worker_context_manager():
 def test_background_worker_shutdown_waits_for_threads():
     worker = BackgroundWorker()
     completed = []
+    started = threading.Event()
 
     def slow_task():
+        started.set()
         while not worker.is_stopped():
-            time.sleep(0.1)
+            time.sleep(0.01)
         completed.append(1)
 
     worker.submit(slow_task)
-    time.sleep(0.1)
+    assert started.wait(timeout=1.0)
 
     worker.shutdown(timeout=2.0)
 
@@ -106,15 +112,19 @@ def test_background_worker_shutdown_waits_for_threads():
 def test_background_worker_multiple_threads():
     worker = BackgroundWorker()
     results = []
+    lock = threading.Lock()
+    all_done = threading.Barrier(4, timeout=1.0)
 
     def task(value):
-        results.append(value)
+        with lock:
+            results.append(value)
+        all_done.wait()
 
     worker.submit(task, 1)
     worker.submit(task, 2)
     worker.submit(task, 3)
 
-    time.sleep(0.2)
+    all_done.wait()
     worker.shutdown()
 
     assert sorted(results) == [1, 2, 3]
@@ -191,25 +201,22 @@ def test_background_worker_on_error_receives_exception():
     assert success_called == []
 
 
-def test_background_worker_on_success_not_called_on_error():
+def test_background_worker_forwards_args_and_kwargs():
     worker = BackgroundWorker()
-    success_called = []
+    received = []
     done = threading.Event()
 
-    def task():
-        raise RuntimeError("fail")
+    def task(a, b, *, c):
+        received.append((a, b, c))
 
-    def on_success(result):
-        success_called.append(result)
-
-    def on_error(_exc):
+    def on_success(_result):
         done.set()
 
-    worker.submit(task, on_success=on_success, on_error=on_error)
+    worker.submit(task, 1, 2, c=3, on_success=on_success)
     assert done.wait(timeout=1.0)
     worker.shutdown()
 
-    assert success_called == []
+    assert received == [(1, 2, 3)]
 
 
 def test_background_worker_error_without_on_error_is_swallowed():
@@ -234,7 +241,7 @@ def test_background_worker_error_without_on_error_is_swallowed():
     assert after == [1]
 
 
-def test_background_worker_call_after_runs_synchronously_without_wx():
+def test_background_worker_call_after_runs_synchronously():
     # The callback is marshalled synchronously: off-Windows wx is absent and
     # _call_after falls back to a direct call; on the headless CI runner the
     # _synchronous_call_after fixture stubs wx.CallAfter to the same effect.


### PR DESCRIPTION
Addresses the low-severity test-review findings for `tests/test_background_worker.py`. Removes the redundant `on_success-not-called` test (its assertion was a subset of the existing `on_error` test) and replaces it with a kwargs-forwarding test that covers the previously untested `**kwargs` path in `BackgroundWorker.submit`. Converts the sleep-based completion waits in the submit, context-manager, multiple-threads, and shutdown-waits tests to deterministic `threading.Event`/`Barrier` synchronization to remove timing flakiness, and renames the misleading `..._without_wx` test to `..._runs_synchronously` (the callback also runs synchronously on the headless CI runner via the existing `wx.CallAfter` stub).

## Verification
Ran in WSL:
- `python -m ruff check tests/test_background_worker.py` — passed
- `python -m black --check tests/test_background_worker.py` — clean
- `python -m pytest tests/test_background_worker.py -q` — 12 passed

These tests are wx-free (the autouse fixture stubs `wx.CallAfter` only when wx is importable), so they run fully in WSL. No wx/UI behavior is exercised; nothing here requires a Windows runner.

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)