### PR TITLE
test: cover non-square blend in card image display logic

### DIFF
--- a/tests/test_card_image_display_logic.py
+++ b/tests/test_card_image_display_logic.py
@@ -122,6 +122,27 @@ def test_blend_output_length_matches_input():
     assert len(blend_rgb_bytes(data1, data2, W, H, 0.5)) == W * H * 3
 
 
+@pytest.mark.parametrize("alpha", [0.0, 0.35, 1.0])
+def test_blend_non_square_matches_reference(alpha):
+    """Blend must be correct when width != height.
+
+    ``blend_rgb_bytes`` reconstructs PIL images from ``(w, h)``; swapping the
+    two would only ever be caught by a rectangular image, since square inputs
+    are dimension-symmetric.  This guards against a width/height transposition.
+    """
+    nw, nh = 6, 10  # deliberately non-square so w and h are not interchangeable
+    rng = random.Random(7)
+    data1 = bytes(rng.randint(0, 255) for _ in range(nw * nh * 3))
+    data2 = bytes(rng.randint(0, 255) for _ in range(nw * nh * 3))
+
+    expected = _blend_bitmaps_reference(data1, data2, alpha)
+    actual = blend_rgb_bytes(data1, data2, nw, nh, alpha)
+
+    assert len(actual) == nw * nh * 3
+    for i, (e, a) in enumerate(zip(expected, actual)):
+        assert abs(e - a) <= 1, f"Pixel mismatch at byte {i}: expected {e}, got {a} (alpha={alpha})"
+
+
 # ── rounded corner tests (exercise production corner helpers) ─────────────────
 
 RW, RH = 20, 20


### PR DESCRIPTION
## Summary

Adds a parametrized blend test exercising `blend_rgb_bytes` with width != height (6x10) in `tests/test_card_image_display_logic.py`. The existing blend tests all use square images, which are dimension-symmetric, so a width/height transposition in the production helper would go undetected. The new test reconstructs the same reference output and compares pixel-for-pixel, directly guarding against that class of regression. This addresses the lone low-severity finding from the test-review sweep (the missing w!=h blend dimension).

## Verification

Run in WSL:
- `python -m ruff check tests/test_card_image_display_logic.py` — passed.
- `python -m black --check tests/test_card_image_display_logic.py` — passed (unchanged).
- `python -m pytest tests/test_card_image_display_logic.py -q` — 22 passed (includes the 3 new non-square parametrizations).

This is a wx-free, pure-bytes test (PIL + numpy only); no wx/UI behavior is involved, so nothing in this change requires Windows. The full wx UI suite was not run as it is not importable in WSL, but it is unaffected by this test-only change.

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)