### PR TITLE
test: cover BridgeCommandFuture, watch transport, and bridge entry points

### DIFF
--- a/tests/test_mtgo_bridge_client.py
+++ b/tests/test_mtgo_bridge_client.py
@@ -128,15 +128,21 @@ def _write_executable_bridge(tmp_path: Path, body: str) -> Path:
     ``.bat`` shim; POSIX uses a ``chmod +x`` shell shim).
     """
     program = tmp_path / "bridge_program.py"
-    program.write_text(textwrap.dedent(body))
+    # Bodies may contain non-cp1252 characters (e.g. a BOM); persist as UTF-8 so
+    # the write succeeds on Windows and PYTHONUTF8 below decodes the source.
+    program.write_text(textwrap.dedent(body), encoding="utf-8")
 
     if os.name == "nt":
         launcher = tmp_path / "bridge.bat"
-        launcher.write_text(f'@echo off\r\n"{sys.executable}" "{program}" %*\r\n')
+        # PYTHONUTF8 forces the child's stdout to UTF-8 so it can emit a BOM
+        # without tripping the default cp1252 console codec on Windows.
+        launcher.write_text(
+            f'@echo off\r\nset PYTHONUTF8=1\r\n"{sys.executable}" "{program}" %*\r\n'
+        )
         return launcher
 
     launcher = tmp_path / "bridge.sh"
-    launcher.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{program}" "$@"\n')
+    launcher.write_text(f'#!/bin/sh\nPYTHONUTF8=1 exec "{sys.executable}" "{program}" "$@"\n')
     launcher.chmod(launcher.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return launcher
 

--- a/tests/test_mtgo_bridge_client.py
+++ b/tests/test_mtgo_bridge_client.py
@@ -1,9 +1,16 @@
+import multiprocessing as mp
+import os
 import queue as queue_mod
+import stat
+import sys
+import textwrap
 from pathlib import Path
 
 import pytest
 
 from services.mtgo_bridge_service import client as mtgo_bridge_client
+from services.mtgo_bridge_service import commands as bridge_commands
+from services.mtgo_bridge_service import watch as bridge_watch
 
 
 def test_missing_bridge_path_raises(tmp_path: Path) -> None:
@@ -106,3 +113,298 @@ def test_command_worker_success_serializes_payload(tmp_path: Path) -> None:
     status, payload = result_queue.get_nowait()
     assert status == "ok"
     assert payload == {"hi": 1}
+
+
+# --- Executable-bridge stub helper -------------------------------------------
+
+
+def _write_executable_bridge(tmp_path: Path, body: str) -> Path:
+    """Create a directly-runnable ``bridge`` that delegates to a Python script.
+
+    ``submit_bridge_command`` / ``BridgeWatcher`` invoke the resolved path as
+    ``[bridge_path, *args]`` (no interpreter), so the stub must be executable on
+    its own. We emit a Python program plus a thin OS-native launcher that calls
+    the current interpreter, keeping the test cross-platform (Windows CI uses a
+    ``.bat`` shim; POSIX uses a ``chmod +x`` shell shim).
+    """
+    program = tmp_path / "bridge_program.py"
+    program.write_text(textwrap.dedent(body))
+
+    if os.name == "nt":
+        launcher = tmp_path / "bridge.bat"
+        launcher.write_text(f'@echo off\r\n"{sys.executable}" "{program}" %*\r\n')
+        return launcher
+
+    launcher = tmp_path / "bridge.sh"
+    launcher.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{program}" "$@"\n')
+    launcher.chmod(launcher.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return launcher
+
+
+# --- BridgeCommandFuture -----------------------------------------------------
+
+
+def _start_future(tmp_path: Path, body: str, timeout: float | None = None):
+    """Run ``_command_worker`` against a Python stub inside a real process."""
+    script = _write_stub(tmp_path, body)
+    ctx = mp.get_context("spawn")
+    result_queue: mp.Queue = ctx.Queue()
+    process = ctx.Process(
+        target=mtgo_bridge_client._command_worker,
+        args=(sys.executable, [str(script)], result_queue, timeout),
+    )
+    process.start()
+    return bridge_commands.BridgeCommandFuture(process, result_queue)
+
+
+def test_future_result_returns_payload_on_ok(tmp_path: Path) -> None:
+    future = _start_future(tmp_path, 'import sys\nsys.stdout.write(\'{"ok": true, "n": 5}\')\n')
+    try:
+        assert future.result(timeout=30) == {"ok": True, "n": 5}
+    finally:
+        future.cancel()
+
+
+def test_future_result_raises_on_error_status(tmp_path: Path) -> None:
+    future = _start_future(
+        tmp_path,
+        "import sys\nsys.stderr.write('kaput')\nsys.exit(2)\n",
+    )
+    try:
+        with pytest.raises(bridge_commands.BridgeCommandError, match="exited with code 2"):
+            future.result(timeout=30)
+    finally:
+        future.cancel()
+
+
+def test_future_result_times_out_and_cancels_on_empty_queue() -> None:
+    """An empty result queue makes ``result`` time out, raise, and tear down."""
+    ctx = mp.get_context("spawn")
+    empty_queue: mp.Queue = ctx.Queue()
+    # A long-lived child whose teardown ``cancel()`` must guarantee.
+    process = ctx.Process(target=_idle_forever)
+    process.start()
+    future = bridge_commands.BridgeCommandFuture(process, empty_queue)
+    try:
+        with pytest.raises(bridge_commands.BridgeCommandError, match="did not produce a result"):
+            future.result(timeout=0.2)
+        # result() calls cancel() on timeout, which terminates the process.
+        process.join(10)
+        assert not process.is_alive()
+    finally:
+        if process.is_alive():
+            process.terminate()
+            process.join(5)
+
+
+def _idle_forever() -> None:
+    import time
+
+    while True:
+        time.sleep(0.1)
+
+
+# --- _queue_replace ----------------------------------------------------------
+
+
+def test_queue_replace_into_empty_queue() -> None:
+    q: queue_mod.Queue = queue_mod.Queue(maxsize=1)
+    bridge_watch._queue_replace(q, {"v": 1})
+    assert q.get_nowait() == {"v": 1}
+
+
+def test_queue_replace_overwrites_stale_item() -> None:
+    q: queue_mod.Queue = queue_mod.Queue(maxsize=1)
+    q.put_nowait({"v": 1})
+    bridge_watch._queue_replace(q, {"v": 2})
+    assert q.get_nowait() == {"v": 2}
+    assert q.empty()
+
+
+# --- _watch_worker (real subprocess streaming parser) ------------------------
+
+
+def _run_watch_to_completion(bridge: Path, *, max_iterations: int = 300) -> list:
+    """Drive ``_watch_worker`` against ``bridge`` and collect emitted payloads.
+
+    Uses a real ``maxsize=1`` queue (production semantics: only the latest
+    snapshot is retained), draining as items arrive until the worker exits.
+    """
+    ctx = mp.get_context("spawn")
+    out_queue: mp.Queue = ctx.Queue(maxsize=1)
+    stop_event = ctx.Event()
+    process = ctx.Process(
+        target=bridge_watch._watch_worker,
+        args=(str(bridge), out_queue, stop_event),
+    )
+    process.start()
+
+    seen: list = []
+    iterations = max_iterations
+    while iterations > 0 and (process.is_alive() or not out_queue.empty()):
+        try:
+            seen.append(out_queue.get(timeout=0.1))
+        except queue_mod.Empty:
+            pass
+        iterations -= 1
+
+    stop_event.set()
+    process.join(10)
+    if process.is_alive():
+        process.terminate()
+        process.join(5)
+    return seen
+
+
+def test_watch_worker_strips_bom_and_skips_malformed(tmp_path: Path) -> None:
+    """A BOM-prefixed object parses; an interleaved malformed line is skipped."""
+    bridge = _write_executable_bridge(
+        tmp_path,
+        r"""
+        import sys, time
+        sys.stdout.write('this is not json\n')
+        sys.stdout.flush()
+        time.sleep(0.2)
+        sys.stdout.write('﻿{"timer": 1}\n')
+        sys.stdout.flush()
+        """,
+    )
+    seen = _run_watch_to_completion(bridge)
+    assert {"timer": 1} in seen
+    # The malformed line must never have produced a payload.
+    assert "this is not json" not in seen
+    assert {} not in seen
+
+
+def test_watch_worker_parses_multiline_object(tmp_path: Path) -> None:
+    """The bracket-depth parser reassembles an object spanning several reads."""
+    bridge = _write_executable_bridge(
+        tmp_path,
+        r"""
+        import sys
+        sys.stdout.write('{\n')
+        sys.stdout.write('  "timer": 2,\n')
+        sys.stdout.write('  "opponent": "alice"\n')
+        sys.stdout.write('}\n')
+        sys.stdout.flush()
+        """,
+    )
+    seen = _run_watch_to_completion(bridge)
+    assert {"timer": 2, "opponent": "alice"} in seen
+
+
+# --- BridgeWatcher lifecycle -------------------------------------------------
+
+
+def test_bridge_watcher_streams_then_stops(tmp_path: Path) -> None:
+    bridge = _write_executable_bridge(
+        tmp_path,
+        r"""
+        import sys, time
+        sys.stdout.write('{"timer": 42}\n')
+        sys.stdout.flush()
+        # Stay alive so the parent exercises stop()/teardown explicitly.
+        time.sleep(30)
+        """,
+    )
+    with bridge_watch.BridgeWatcher(bridge_path=bridge) as watcher:
+        payload = watcher.latest(block=True, timeout=20)
+        assert payload == {"timer": 42}
+        process = watcher._process
+        assert process is not None and process.is_alive()
+    # __exit__ -> stop() must have terminated the background process.
+    process.join(10)
+    assert not process.is_alive()
+
+
+def test_bridge_watcher_latest_nonblocking_empty_returns_none(tmp_path: Path) -> None:
+    bridge = _write_executable_bridge(
+        tmp_path,
+        "import time\ntime.sleep(30)\n",
+    )
+    watcher = bridge_watch.BridgeWatcher(bridge_path=bridge)
+    watcher.start()
+    try:
+        assert watcher.latest(block=False) is None
+    finally:
+        watcher.stop()
+
+
+# --- Convenience entry points (argv contract) --------------------------------
+
+
+def test_fetch_collection_snapshot_invokes_collection_mode(tmp_path: Path) -> None:
+    bridge = _write_executable_bridge(
+        tmp_path,
+        r"""
+        import json, sys
+        print(json.dumps({"mode": sys.argv[1], "argv": sys.argv[1:]}))
+        """,
+    )
+    payload = mtgo_bridge_client.fetch_collection_snapshot(bridge_path=str(bridge), timeout=30)
+    assert payload == {"mode": "collection", "argv": ["collection"]}
+
+
+def test_fetch_match_history_invokes_history_mode(tmp_path: Path) -> None:
+    bridge = _write_executable_bridge(
+        tmp_path,
+        r"""
+        import json, sys
+        print(json.dumps({"argv": sys.argv[1:]}))
+        """,
+    )
+    payload = mtgo_bridge_client.fetch_match_history(bridge_path=str(bridge), timeout=30)
+    assert payload == {"argv": ["history"]}
+
+
+def test_fetch_trade_snapshot_passes_status_subcommand(tmp_path: Path) -> None:
+    bridge = _write_executable_bridge(
+        tmp_path,
+        r"""
+        import json, sys
+        print(json.dumps({"argv": sys.argv[1:]}))
+        """,
+    )
+    payload = mtgo_bridge_client.fetch_trade_snapshot(bridge_path=str(bridge), timeout=30)
+    assert payload == {"argv": ["trade", "status"]}
+
+
+def test_accept_trade_passes_accept_subcommand(tmp_path: Path) -> None:
+    bridge = _write_executable_bridge(
+        tmp_path,
+        r"""
+        import json, sys
+        print(json.dumps({"argv": sys.argv[1:]}))
+        """,
+    )
+    payload = mtgo_bridge_client.accept_trade(bridge_path=str(bridge), timeout=30)
+    assert payload == {"argv": ["trade", "accept"]}
+
+
+def test_run_bridge_command_passes_extra_args(tmp_path: Path) -> None:
+    bridge = _write_executable_bridge(
+        tmp_path,
+        r"""
+        import json, sys
+        print(json.dumps({"argv": sys.argv[1:]}))
+        """,
+    )
+    payload = mtgo_bridge_client.run_bridge_command(
+        "all", bridge_path=str(bridge), extra_args=("--verbose",), timeout=30
+    )
+    assert payload == {"argv": ["all", "--verbose"]}
+
+
+def test_async_entry_point_returns_future_resolving_payload(tmp_path: Path) -> None:
+    bridge = _write_executable_bridge(
+        tmp_path,
+        r"""
+        import json, sys
+        print(json.dumps({"argv": sys.argv[1:]}))
+        """,
+    )
+    future = mtgo_bridge_client.fetch_collection_snapshot_async(bridge_path=str(bridge))
+    try:
+        assert future.result(timeout=30) == {"argv": ["collection"]}
+    finally:
+        future.cancel()


### PR DESCRIPTION
## Summary

Closes the test-quality gaps flagged in issue #693 for `tests/test_mtgo_bridge_client.py`. It adds real-objects/real-subprocess coverage for the previously untested pieces of the MTGO bridge client: the `BridgeCommandFuture` lifecycle (ok / error-status / timeout+cancel), the entire `watch.py` streaming transport (`_watch_worker` BOM stripping, malformed-line skipping, and the bracket-depth multi-line parser; `_queue_replace` overwrite/empty semantics; and `BridgeWatcher` start/stop/latest/context-manager lifecycle), and all six convenience entry points (`fetch_collection_snapshot`, `fetch_match_history`, `fetch_trade_snapshot` -> `trade status`, `accept_trade` -> `trade accept`, `run_bridge_command` extra-args passthrough, and the async future entry point) asserting their argv contract. Per the project testing guidelines, nothing internal is mocked: tests drive real `multiprocessing` queues/processes and a cross-platform executable stub bridge (a `.bat` shim on Windows CI, a `chmod +x` shell shim on POSIX) so the bridge path is invoked exactly as production does (`[bridge_path, *args]`).

## Verification

- `python -m ruff check tests/test_mtgo_bridge_client.py` — passed.
- `python -m black --check tests/test_mtgo_bridge_client.py` — passed (file reformatted by black, then clean).
- Could NOT run `pytest tests/test_mtgo_bridge_client.py` in WSL: importing the module pulls in `utils.constants` -> `utils.constants.keyboard` -> `import wx`, and `wx` is not installable off-Windows. This is the same constraint as the rest of the suite, which runs on the Windows CI runner.
- To self-verify the new test logic from WSL, I ran each new test body in a standalone harness that injected a minimal `utils.constants` stub (exposing only `BRIDGE_PROCESS_TERMINATE_TIMEOUT_SECONDS`) to bypass the wx import, then exercised the real `commands`/`watch`/`client` code paths: future ok/error/timeout+cancel, `_queue_replace`, `_watch_worker` (BOM + malformed-skip and multi-line, each run 3x for flakiness — deterministic), `BridgeWatcher` lifecycle + non-blocking `latest()`, and all entry points all passed. The watch tests use a `maxsize=1` queue (production semantics: only the latest snapshot is retained) and split the BOM/malformed case from the multi-line case so each is deterministic.
- NOT verified: behavior on Windows specifically (the `.bat` launcher branch and `wx`-importable environment) — that path is covered only by CI on the Windows runner.

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)