### PR TITLE
test: cover edition-label and empty-guard branch gaps in card HTML renderer

### DIFF
--- a/tests/test_card_panel_html_renderer.py
+++ b/tests/test_card_panel_html_renderer.py
@@ -75,6 +75,14 @@ def test_replace_mana_symbols_threads_symbol_size(tmp_path) -> None:
     assert 'width="24" height="24"' in out
 
 
+def test_replace_mana_symbols_empty_returns_empty() -> None:
+    # The empty/None guard short-circuits before the resolver is ever called.
+    def _boom(token: str):  # noqa: ARG001
+        raise AssertionError("resolver must not be called for empty input")
+
+    assert replace_mana_symbols("", _boom) == ""
+
+
 def test_render_flavor_text_escapes_and_converts_newlines() -> None:
     out = render_flavor_text("Fear cuts deeper <than swords>.\nNext line & more.")
     assert "&lt;than swords&gt;" in out
@@ -117,6 +125,10 @@ def test_build_card_html_meta_get_subscript_fallback() -> None:
     html = build_card_html(meta, None, _no_png)
     assert "Mox Ruby" in html
     assert "Artifact" in html
+    # Every subscript-read field is rendered, not just name/type_line: the
+    # oracle text and the mana-cost fallback both come through the same path.
+    assert "Add R." in html
+    assert "{0}" in html
 
 
 def test_build_card_html_meta_get_subscript_keyerror_uses_default() -> None:
@@ -198,6 +210,36 @@ def test_build_card_html_renders_card_and_printing_fields() -> None:
     assert "161" in html
     assert "Christopher Rush" in html
     assert "<i>The sparkmage shrieked." in html
+
+
+def test_build_card_html_edition_label_set_name_only() -> None:
+    """With a set name but no set code, the label is the bare name (no parens)."""
+    meta = {
+        "name": "Lightning Bolt",
+        "mana_cost": "{R}",
+        "type_line": "Instant",
+        "oracle_text": "",
+    }
+    printing = {"set_name": "Limited Edition Alpha", "set": ""}
+    html = build_card_html(meta, printing, _no_png)
+    assert "Limited Edition Alpha" in html
+    # No parenthesised code is appended when the set code is absent.
+    assert "Limited Edition Alpha (" not in html
+
+
+def test_build_card_html_edition_label_set_code_only() -> None:
+    """With a set code but no set name, the label is the upper-cased code alone."""
+    meta = {
+        "name": "Lightning Bolt",
+        "mana_cost": "{R}",
+        "type_line": "Instant",
+        "oracle_text": "",
+    }
+    printing = {"set_name": "", "set": "lea"}
+    html = build_card_html(meta, printing, _no_png)
+    assert ">LEA<" in html
+    # No parenthesised form when there is no set name to pair it with.
+    assert "(LEA)" not in html
 
 
 def test_build_card_html_creature_includes_pt() -> None:


### PR DESCRIPTION
Adds three focused unit tests to `tests/test_card_panel_html_renderer.py` to close the low-severity branch gaps flagged for that file in the test-review sweep (issue #703): the `edition_label` set_name-only and set_code-only branches in `build_card_html`, the empty/None guard in `replace_mana_symbols` (asserting the PNG resolver is never invoked), and a strengthened subscript-meta access test that now asserts the richer oracle-text and mana-cost fields render rather than only name/type_line. This is a test-only change; no production code was modified.

## Verification
- `python -m ruff check tests/test_card_panel_html_renderer.py` — passed.
- `python -m black --check tests/test_card_panel_html_renderer.py` — passed (unchanged).
- The test module cannot be collected under WSL because importing `widgets.panels.card_panel.html_renderer` runs the package `__init__.py`, which imports `wx` (not installable off-Windows). This collection failure pre-exists on `main` and is unrelated to this change. To validate the new assertions in WSL I loaded `html_renderer.py` in isolation (stubbing the package so `__init__` does not run) and executed each new test's assertions against the real renderer functions — all passed.
- The full pytest run for this file (and any wx-dependent UI behavior) must be validated on Windows / in CI.

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)