### PR TITLE
test: cover defensive branches and mixin helpers in card panel stats lookup

### DIFF
--- a/tests/test_card_panel_stats_lookup.py
+++ b/tests/test_card_panel_stats_lookup.py
@@ -3,14 +3,32 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 
-from widgets.panels.card_panel.properties import _find_card_frequency, _stats_lookup_names
+from widgets.panels.card_panel.properties import (
+    CardPanelPropertiesMixin,
+    _find_card_frequency,
+    _stats_lookup_names,
+)
 
 
 @dataclass
 class _Freq:
     card_name: str
     total_copies: int = 1
+
+
+def _mixin(**state: object) -> CardPanelPropertiesMixin:
+    """Build a bare mixin instance with the ``self`` state its methods read.
+
+    The mixin defines no ``__init__`` and mutates no UI, so a plain instance
+    with the relevant ``_current_*`` attributes is sufficient to exercise its
+    pure helpers without constructing the wx-backed panel.
+    """
+    instance = CardPanelPropertiesMixin()
+    for name, value in state.items():
+        setattr(instance, name, value)
+    return instance
 
 
 def test_stats_lookup_names_prefers_front_face_for_dfc() -> None:
@@ -71,3 +89,88 @@ def test_stats_lookup_names_returns_empty_for_empty_string() -> None:
 
 def test_stats_lookup_names_returns_empty_for_whitespace_only() -> None:
     assert _stats_lookup_names("   ") == []
+
+
+def test_stats_lookup_names_skips_empty_front_face() -> None:
+    # A ``//`` name whose front face is blank should not yield an empty
+    # candidate; only the full (back-only) name is returned.
+    assert _stats_lookup_names("// Ice") == ["// Ice"]
+
+
+def test_find_card_frequency_ignores_entry_without_card_name() -> None:
+    # Entries missing ``card_name`` fall back to the empty-string default and
+    # never match a real lookup name.
+    cards = [SimpleNamespace(total_copies=4)]
+    assert _find_card_frequency(cards, "Lightning Bolt") is None
+
+
+def test_find_card_frequency_matches_entry_with_empty_card_name() -> None:
+    # The empty-string default must not spuriously match a blank candidate.
+    cards = [SimpleNamespace(card_name="", total_copies=4)]
+    assert _find_card_frequency(cards, "Lightning Bolt") is None
+
+
+def test_format_number_handles_none() -> None:
+    assert _mixin()._format_number(None) == "—"
+
+
+def test_format_number_renders_integer_with_thousands_separator() -> None:
+    assert _mixin()._format_number(1234) == "1,234"
+
+
+def test_format_number_renders_whole_float_as_integer() -> None:
+    assert _mixin()._format_number(1234.0) == "1,234"
+
+
+def test_format_number_renders_fractional_float_with_two_decimals() -> None:
+    assert _mixin()._format_number(1234.5) == "1,234.50"
+
+
+def test_format_average_handles_none() -> None:
+    assert _mixin()._format_average(None) == "—"
+
+
+def test_format_average_renders_two_decimals() -> None:
+    assert _mixin()._format_average(2.5) == "2.50"
+
+
+def test_archetype_name_returns_none_when_no_archetype() -> None:
+    assert _mixin(_current_archetype=None)._archetype_name() is None
+
+
+def test_archetype_name_returns_none_when_name_missing() -> None:
+    assert _mixin(_current_archetype={})._archetype_name() is None
+
+
+def test_archetype_name_returns_name_when_present() -> None:
+    assert _mixin(_current_archetype={"name": "Burn"})._archetype_name() == "Burn"
+
+
+def test_lookup_main_freq_returns_none_without_radar() -> None:
+    assert _mixin(_current_radar=None)._lookup_main_freq("Lightning Bolt") is None
+
+
+def test_lookup_side_freq_returns_none_without_radar() -> None:
+    assert _mixin(_current_radar=None)._lookup_side_freq("Lightning Bolt") is None
+
+
+def test_lookup_main_freq_resolves_front_face_from_radar() -> None:
+    radar = SimpleNamespace(
+        mainboard_cards=[_Freq(card_name="Ajani, Nacatl Pariah", total_copies=4)],
+        sideboard_cards=[],
+    )
+    found = _mixin(_current_radar=radar)._lookup_main_freq(
+        "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger"
+    )
+    assert found is not None
+    assert found.total_copies == 4
+
+
+def test_lookup_side_freq_resolves_from_radar() -> None:
+    radar = SimpleNamespace(
+        mainboard_cards=[],
+        sideboard_cards=[_Freq(card_name="Lightning Bolt", total_copies=2)],
+    )
+    found = _mixin(_current_radar=radar)._lookup_side_freq("Lightning Bolt")
+    assert found is not None
+    assert found.total_copies == 2


### PR DESCRIPTION
## Summary

Addresses the test-review finding for \`tests/test_card_panel_stats_lookup.py\` (low severity). Adds unit coverage for the two previously untested defensive branches in the stats-name resolution helpers — an empty DFC front face (\`"// Ice"\`) and a frequency entry that is missing or has an empty \`card_name\` — and exercises the previously untested pure mixin methods (\`_format_number\`, \`_format_average\`, \`_archetype_name\`, \`_lookup_main_freq\`, \`_lookup_side_freq\`) by constructing a bare \`CardPanelPropertiesMixin\` instance with stubbed \`self\` state. This is test-only; no production code changed.

## Verification

- \`python -m ruff check tests/test_card_panel_stats_lookup.py\` — passed.
- \`python -m black --check tests/test_card_panel_stats_lookup.py\` — passed (would be left unchanged).
- The test module's import chain pulls in \`wx\` via \`widgets/panels/card_panel/__init__.py\`, so it cannot be collected directly in WSL. To validate the added test logic I ran the file under a throwaway local \`wx\` stub (not committed): all 27 tests passed (12 existing + 15 new). The authoritative run on Windows (real \`wx\`) is left to CI / the human reviewer, since wx is not importable in WSL.

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)