### PR TITLE
test: close branch gaps in test_deck_formatting.py

### DIFF
--- a/tests/test_deck_formatting.py
+++ b/tests/test_deck_formatting.py
@@ -120,6 +120,32 @@ def test_format_deck_list_entry_missing_source_uses_wizard_emoji():
     assert entry == "🧙🏾‍♂️ Bob\nModern Challenge"
 
 
+def test_format_deck_list_entry_empty_falls_back_to_unknown():
+    assert deck_formatting.format_deck_list_entry({}) == "Unknown"
+
+
+def test_format_deck_list_entry_empty_with_source_prepends_emoji_to_unknown():
+    entry = deck_formatting.format_deck_list_entry({}, show_source=True)
+    assert entry == "🧙🏾‍♂️ Unknown"
+
+
+def test_format_deck_list_entry_event_only_keeps_unknown_identity():
+    entry = deck_formatting.format_deck_list_entry({"event": "Modern Challenge"})
+    assert entry == "Unknown\nModern Challenge"
+
+
+# ---------------------------------------------------------------------------
+# re-exports
+# ---------------------------------------------------------------------------
+def test_normalize_date_is_reexported():
+    assert deck_formatting.normalize_date("Modern Challenge 2024-01-02") == "2024-01-02"
+
+
+def test_classify_event_type_is_reexported():
+    assert deck_formatting.classify_event_type("Modern Challenge") == "Challenge"
+    assert deck_formatting.classify_event_type("Friday Night") is None
+
+
 # ---------------------------------------------------------------------------
 # simple_summary_html
 # ---------------------------------------------------------------------------
@@ -127,3 +153,9 @@ def test_simple_summary_html_escapes_and_breaks():
     html = deck_formatting.simple_summary_html("a<b>&\nc")
     assert "a&lt;b&gt;&amp;<br>c" in html
     assert html.startswith("<html>")
+
+
+def test_simple_summary_html_full_template():
+    assert deck_formatting.simple_summary_html("hi") == (
+        '<html><body bgcolor="#22272E" text="#ECECEC">' '<font size="2">hi</font>' "</body></html>"
+    )


### PR DESCRIPTION
Closes the low-severity coverage gaps flagged for `tests/test_deck_formatting.py` in the test-review sweep. Adds assertions for the empty / source-less fallback combinations of `format_deck_list_entry` (the `Unknown` fallback, the `Unknown` + source-emoji case, and the event-only identity), explicitly asserts the `normalize_date` / `classify_event_type` re-exports actually resolve to the underlying helpers, and pins the full `simple_summary_html` template string (not just the escaped body) so the HTML tail is regression-protected. No production code changed — tests only.

## Verification
- `python -m pytest tests/test_deck_formatting.py -q` → 24 passed.
- `python -m ruff check tests/test_deck_formatting.py` → all checks passed.
- `python -m black --check tests/test_deck_formatting.py` → clean (after formatting).
- These tests load `deck_formatting.py` directly via `importlib` and are wx-free, so they run fully in WSL. No wx/UI behavior is exercised by this change, so nothing additional needed Windows verification.

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)