### PR TITLE
test: cover count-only line boundary in deck parser

### DIFF
--- a/tests/test_deck_service.py
+++ b/tests/test_deck_service.py
@@ -30,6 +30,33 @@ def test_deck_to_dictionary_handles_empty_lines(deck_service):
     assert deck_dict["Sideboard Lightning Bolt"] == 2.0
 
 
+def test_deck_to_dictionary_skips_count_only_lines(deck_service):
+    """A line with a count but no card name yields no entry."""
+    # "4" has no name after the count; "5 " strips to "5" (same boundary).
+    deck_text = "4\n5 \n2 Island\n"
+
+    deck_dict = deck_service.deck_to_dictionary(deck_text)
+
+    assert deck_dict == {"Island": 2.0}
+
+
+def test_analyze_deck_skips_count_only_lines(deck_service):
+    """analyze_deck drops count-only lines instead of creating empty-name entries."""
+    deck_text = "4\n2 Island\n\nSideboard\n3\n1 Abrade\n"
+
+    stats = deck_service.analyze_deck(deck_text)
+
+    mainboard_dict = dict(stats["mainboard_cards"])
+    sideboard_dict = dict(stats["sideboard_cards"])
+    assert mainboard_dict == {"Island": 2}
+    assert sideboard_dict == {"Abrade": 1}
+    # No empty-name entry leaked into either zone.
+    assert "" not in mainboard_dict
+    assert "" not in sideboard_dict
+    assert stats["unique_mainboard"] == 1
+    assert stats["unique_sideboard"] == 1
+
+
 def test_analyze_deck_preserves_fractional_quantities(deck_service):
     """Test that analyze_deck preserves fractional quantities from average decks."""
     deck_text = (


### PR DESCRIPTION
Adds focused unit tests for the `_iter_entries` count-only / empty-name boundary in the deck parser, the single low-severity gap flagged for `tests/test_deck_service.py` in the test-review sweep. A deck line that contains a count but no card name (e.g. `4`, or `5 ` which strips to the same) is silently skipped by the parser; the new tests pin that behavior for both `deck_to_dictionary` and `analyze_deck` (mainboard and sideboard zones), asserting no empty-name entry leaks into the results. No production code changed — this is a test-only addition matching the existing file's style and `deck_service` fixture.

## Verification
- `python -m ruff check tests/test_deck_service.py` — passed.
- `python -m black --check tests/test_deck_service.py` — passed (unchanged).
- `python -m pytest tests/test_deck_service.py` could NOT run in WSL: the file imports `services.deck_service.DeckService`, whose import chain pulls in `utils.constants.keyboard` which `import wx` (not installable off Windows). This is the documented WSL limitation; the suite runs on Windows CI.
- Behavior of the new assertions was confirmed by loading `services/deck_service/parser.py` directly (bypassing the wx import chain) and exercising `deck_to_dictionary` and `analyze_deck` on the boundary inputs: count-only lines produce no entry, and only the valid `Island`/`Abrade` cards appear.

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)