### PR TITLE
test: close coverage gaps in test_diagnostics.py (#712)

### DIFF
--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -82,6 +82,18 @@ class TestEventLogger:
         el = EventLogger(tmp_path)
         assert el.path == tmp_path / "events.jsonl"
 
+    def test_write_failure_is_non_fatal(self, tmp_path: Path) -> None:
+        """An I/O error while writing must be swallowed, never raised."""
+        # A regular file sitting where the logs directory should be makes
+        # ``mkdir`` (and thus the whole write) fail with an OSError.
+        blocker = tmp_path / "logs"
+        blocker.write_text("not a directory")
+        el = EventLogger(blocker / "nested", enabled=True)
+
+        el.log("boom")  # must not raise
+
+        assert not el.path.exists()
+
 
 # ---------------------------------------------------------------------------
 # export_diagnostics_bundle
@@ -219,8 +231,6 @@ class TestExportDiagnosticsBundle:
         """Bundle export must never open a network socket."""
         import socket
 
-        original_connect = socket.socket.connect
-
         def forbid_connect(self, *args, **kwargs):  # type: ignore[override]
             raise AssertionError("export_diagnostics_bundle must not make network calls")
 
@@ -228,9 +238,8 @@ class TestExportDiagnosticsBundle:
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir()
 
-        # Should not raise
+        # Should not raise. ``monkeypatch`` restores ``connect`` automatically.
         export_diagnostics_bundle(tmp_path / "bundle.zip", logs_dir=logs_dir)
-        monkeypatch.setattr(socket.socket, "connect", original_connect)
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +251,24 @@ class TestGetAppVersion:
     def test_returns_non_empty_string(self) -> None:
         assert isinstance(_get_app_version(), str)
         assert _get_app_version()
+
+    def test_falls_back_to_constants_app_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When package metadata is unavailable, use utils.constants.APP_VERSION."""
+        import importlib.metadata
+        import sys
+        import types
+
+        def raise_metadata(*args, **kwargs):  # type: ignore[no-untyped-def]
+            raise importlib.metadata.PackageNotFoundError("mtgo_tools")
+
+        monkeypatch.setattr(importlib.metadata, "version", raise_metadata)
+        # Inject a lightweight stand-in so the import succeeds without pulling in
+        # the real utils.constants package (which imports wx).
+        fake = types.ModuleType("utils.constants")
+        fake.APP_VERSION = "9.9.9"  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "utils.constants", fake)
+
+        assert _get_app_version() == "9.9.9"
 
     def test_falls_through_to_unknown(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If both metadata and constants lookups fail, fall back to 'unknown'."""

--- a/utils/diagnostics.py
+++ b/utils/diagnostics.py
@@ -70,7 +70,7 @@ class EventLogger:
                 self._path.replace(self._path.with_suffix(".jsonl.1"))
             with self._path.open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(entry) + "\n")
-        except Exception as exc:  # pragma: no cover – I/O failure is non-fatal
+        except Exception as exc:  # I/O failure is non-fatal
             logger.debug("EventLogger write failed: {}", exc)
 
 


### PR DESCRIPTION
Closes the low-severity test-review findings for `tests/test_diagnostics.py`: the `EventLogger._write` exception branch and the `utils.constants.APP_VERSION` fallback in `_get_app_version` are now exercised, and the redundant manual `socket.connect` restore in `test_no_network_calls` is removed (monkeypatch restores it automatically). A test now covers the formerly `# pragma: no cover` write-failure path, so that pragma is dropped. With these additions, this module's tests give `utils/diagnostics.py` 100% line coverage. The `utils.constants` fallback is covered by injecting a lightweight stand-in module via `sys.modules`, avoiding an import of the real wx-dependent `utils.constants` package.

## Verification
- `python -m pytest tests/test_diagnostics.py -q` → 26 passed (was 24).
- `python -m pytest tests/test_diagnostics.py --cov=utils.diagnostics --cov-report=term-missing` → `utils/diagnostics.py` 100% (0 missing).
- `python -m ruff check tests/test_diagnostics.py utils/diagnostics.py` → all checks passed.
- `python -m black --check tests/test_diagnostics.py utils/diagnostics.py` → clean (formatting applied to the test file before commit).
- Not verifiable in WSL: nothing wx/UI related is touched by this change; `utils/diagnostics.py` makes no wx calls, and these tests do not import wx.

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)