### PR TITLE
test: dedupe and cover delegated validation in test_math_utils (#715)

### DIFF
--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -50,11 +50,6 @@ class TestHypergeometricProbability:
         prob = hypergeometric_probability(60, 4, 7, 0)
         assert 0.599 <= prob <= 0.602
 
-    def test_impossible_draw_raises_error(self) -> None:
-        """Requesting more target cards than exist in deck raises ValueError."""
-        with pytest.raises(ValueError, match="cannot exceed successes in population"):
-            hypergeometric_probability(60, 4, 7, 5)
-
     def test_guaranteed_draw(self) -> None:
         """Drawing all copies when sample equals available copies.
 
@@ -183,6 +178,18 @@ class TestInputValidation:
         """Negative minimum successes in at_least should raise."""
         with pytest.raises(ValueError, match="Minimum successes must be non-negative"):
             hypergeometric_at_least(60, 4, 7, -1)
+
+    def test_at_least_delegates_validation_to_probability(self) -> None:
+        """at_least delegates non-min_successes validation to the strict function.
+
+        Only ``min_successes`` is checked directly; the remaining arguments are
+        validated lazily when ``hypergeometric_probability`` is called inside the
+        summation loop, so an out-of-range argument must still surface as a
+        ValueError. Sample size exceeding population reaches that call because
+        ``min_successes`` is in range and ``max_successes`` is non-zero here.
+        """
+        with pytest.raises(ValueError, match="cannot exceed population"):
+            hypergeometric_at_least(60, 4, 61, 1)
 
 
 class TestProbabilityBounds:


### PR DESCRIPTION
## Summary

Addresses the low-severity test-quality findings for `tests/test_math_utils.py` from the test-review sweep. Removes an exact-duplicate `ValueError` test (`test_impossible_draw_raises_error` duplicated `test_target_exceed_successes_raises` — both asserted `hypergeometric_probability(60, 4, 7, 5)` raises "cannot exceed successes in population"), and adds a test covering the previously-untested delegated-validation path of `hypergeometric_at_least`, where arguments other than `min_successes` are validated lazily inside the summation loop via `hypergeometric_probability`. The "unreachable defensive branches" finding is left as-is: those guards in `utils/math_utils.py` are genuinely unreachable given the prior input validation, and adding contrived tests for dead code would not improve quality; this change stays test-only and minimal.

## Verification

Ran in WSL:
- `python -m pytest tests/test_math_utils.py -q` — 31 passed.
- `python -m ruff check tests/test_math_utils.py` — passed.
- `python -m black --check tests/test_math_utils.py` — passed (no changes).

These are pure-math, non-wx tests, so they run fully in WSL. No wx/UI behavior is involved, so nothing required Windows. No source code was changed.

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)
