### PR TITLE
test: offline coverage for fetch_deck_text_from_visual_page

### DIFF
--- a/tests/test_mtggoldfish_visual.py
+++ b/tests/test_mtggoldfish_visual.py
@@ -11,6 +11,8 @@ Two layers of coverage:
   upstream page-structure changes.
 """
 
+from unittest.mock import Mock, patch
+
 import pytest
 
 from repositories.scrapers.mtggoldfish_visual import (
@@ -78,6 +80,43 @@ def test_parse_visual_page_raises_when_no_card_piles():
 def test_parse_visual_page_raises_when_containers_missing():
     with pytest.raises(ValueError):
         parse_visual_page("<html><body><p>no piles here</p></body></html>")
+
+
+@patch("repositories.scrapers.mtggoldfish_visual.requests.get")
+def test_fetch_deck_text_from_visual_page_offline(mock_get):
+    """Offline cover of the fetch path: mock the HTTP call, parse fixed HTML."""
+    html = _visual_html(
+        main_alts=["Mox Opal", "Mox Opal", "Ornithopter"],
+        side_alts=["Galvanic Blast", "Galvanic Blast"],
+    )
+    mock_response = Mock()
+    mock_response.text = html
+    mock_response.raise_for_status = Mock()
+    mock_get.return_value = mock_response
+
+    text = fetch_deck_text_from_visual_page("12345")
+
+    # The fetcher hits the unprotected visual endpoint for the given deck id.
+    mock_get.assert_called_once()
+    assert mock_get.call_args.args[0] == "https://www.mtggoldfish.com/deck/visual/12345"
+    # raise_for_status must be honoured before parsing.
+    mock_response.raise_for_status.assert_called_once()
+    # The page text is parsed into the same plain-text decklist contract.
+    main_block, sep, side_block = text.partition("\n\n")
+    assert sep == "\n\n"
+    assert main_block == "2 Mox Opal\n1 Ornithopter"
+    assert side_block == "2 Galvanic Blast"
+
+
+@patch("repositories.scrapers.mtggoldfish_visual.requests.get")
+def test_fetch_deck_text_from_visual_page_propagates_http_error(mock_get):
+    """A non-2xx response surfaces via raise_for_status, not silent parsing."""
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock(side_effect=RuntimeError("404"))
+    mock_get.return_value = mock_response
+
+    with pytest.raises(RuntimeError):
+        fetch_deck_text_from_visual_page("12345")
 
 
 @pytest.mark.network


### PR DESCRIPTION
Adds offline unit coverage for `fetch_deck_text_from_visual_page` in `repositories/scrapers/mtggoldfish_visual.py`, which was previously only exercised by a network-gated (skipped) smoke test. Two new tests patch the module-level `curl_cffi` `requests.get`: a happy path that feeds fixed `/deck/visual/` HTML and asserts the fetcher targets the unprotected `/deck/visual/{id}` URL, calls `raise_for_status`, and parses the page into the expected plain-text decklist; and an error path confirming a failing `raise_for_status` propagates rather than being silently parsed. This follows the existing `@patch("...requests.get")` convention used in `tests/test_mtggoldfish.py` and the project guideline of mocking only network/scraping.

## Verification
- `python -m ruff check tests/test_mtggoldfish_visual.py` — passed.
- `python -m black --check tests/test_mtggoldfish_visual.py` — passed (unchanged).
- The test module cannot be collected directly in WSL because `repositories.scrapers.mtggoldfish_visual` transitively imports `utils.constants` -> `utils.constants.keyboard` -> `wx`, and `wx` is not importable off-Windows. This is pre-existing (the same failure occurs on `origin/main` before this change) and the suite runs on Windows in CI. To gain confidence off-Windows, I stubbed `wx` and ran the exact mock/assert logic of both new tests directly; both passed. Full pytest collection and any wx/UI behavior must be validated on Windows CI.

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)