### PR TITLE
test: harden test_radar_bulk_replace (cover except branch + distinct column values)

### DIFF
--- a/tests/test_radar_bulk_replace.py
+++ b/tests/test_radar_bulk_replace.py
@@ -31,15 +31,19 @@ def _radar(
 
 
 def _card(name: str, *, copies: int) -> dict:
+    # Every numeric field gets a distinct value so a column-order swap, a
+    # float/int truncation, or a distribution mismatch cannot pass silently.
+    # ``copies`` drives ``appearances`` (the field the round-trip tests assert
+    # on); all other fields are offset to stay unique even when copies == 4.
     return {
         "card_name": name,
         "appearances": copies,
-        "total_copies": copies * 2,
-        "max_copies": 4,
-        "avg_copies": 2.0,
+        "total_copies": copies * 2 + 1,
+        "max_copies": 3,
+        "avg_copies": 2.5,
         "inclusion_rate": 0.5,
-        "expected_copies": 1.0,
-        "copy_distribution": {"4": copies},
+        "expected_copies": 1.25,
+        "copy_distribution": {"4": copies, "3": 7},
     }
 
 
@@ -69,12 +73,12 @@ def test_bulk_replace_persists_all_entries(repo):
     # cannot slip through (_card sets distinct values for every field).
     bolt = burn.mainboard_cards[0]
     assert bolt.appearances == 10
-    assert bolt.total_copies == 20
-    assert bolt.max_copies == 4
-    assert bolt.avg_copies == 2.0
+    assert bolt.total_copies == 21
+    assert bolt.max_copies == 3
+    assert bolt.avg_copies == 2.5
     assert bolt.inclusion_rate == 0.5
-    assert bolt.expected_copies == 1.0
-    assert bolt.copy_distribution == {4: 10}
+    assert bolt.expected_copies == 1.25
+    assert bolt.copy_distribution == {4: 10, 3: 7}
     assert repo.get_total_decks("modern") == 30
     assert repo.get_total_decks("legacy") == 5
 
@@ -167,6 +171,32 @@ def test_bulk_replace_duplicate_keys_in_one_batch_abort_transaction(repo):
     # The whole batch rolled back: neither variant of the duplicate key persisted.
     assert repo.get_radar("modern", "modern-burn") is None
     assert repo.get_total_decks("modern") == 0
+
+
+def test_bulk_replace_skips_entry_that_raises_during_normalization(repo):
+    """An entry that blows up inside ``_build_rows`` is logged and skipped.
+
+    ``total_decks_analyzed`` is fed a non-numeric string, so the ``int(...)``
+    coercion raises. This is past the ``None`` validity gates, so it can only be
+    handled by the ``try/except`` in ``bulk_replace`` -- which must drop the bad
+    entry and still persist the surrounding valid ones in the same batch.
+    """
+    entries = [
+        _radar(fmt="modern", href="modern-burn", name="Burn", decks=10),
+        {
+            "format": "modern",
+            "archetype": {"name": "Broken", "href": "modern-broken"},
+            "total_decks_analyzed": "not-a-number",
+        },
+        _radar(fmt="legacy", href="legacy-control", name="Control", decks=5),
+    ]
+
+    replaced = repo.bulk_replace(entries)
+
+    assert replaced == 2
+    assert repo.get_radar("modern", "modern-burn") is not None
+    assert repo.get_radar("modern", "modern-broken") is None
+    assert repo.get_radar("legacy", "legacy-control") is not None
 
 
 def test_bulk_replace_empty_returns_zero(repo):


### PR DESCRIPTION
Addresses the two test-review findings for `tests/test_radar_bulk_replace.py` (#718). The `try/except` in `RadarRepository.bulk_replace` was never exercised, and the `_card` helper used coinciding numeric values across fields, meaning a column-order swap or float/int truncation in the write/read path could pass silently. This adds a test that feeds `bulk_replace` an entry whose normalization raises inside `_build_rows` (a non-numeric `total_decks_analyzed`), pinning the skip-and-continue behavior of the except branch, and rewrites `_card` to set distinct values for every numeric field (plus a multi-key `copy_distribution`) so any column/type confusion now fails the assertion.

## Verification
- `python -m ruff check tests/test_radar_bulk_replace.py` — passed.
- `python -m black --check tests/test_radar_bulk_replace.py` — passed (unchanged).
- Verified the logic out-of-band by loading `repositories/radar_repository/writes.py` directly (bypassing the wx import chain): the bad entry raises `ValueError` inside `_build_rows` (confirming the except branch fires), and a card with the new distinct values round-trips to the expected row `(..., 10, 21, 3, 2.5, 0.5, 1.25, '{"3": 7, "4": 10}')`.
- Could NOT run the pytest module itself in WSL: `tests/test_radar_bulk_replace.py` transitively imports `utils.constants` -> `utils.constants.keyboard` -> `wx`, which is not importable off-Windows. The full suite must be run on Windows / in CI.

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)