### PR TITLE
test: cover exc.name is None branch in test_reset_helpers

### DIFF
--- a/tests/test_reset_helpers.py
+++ b/tests/test_reset_helpers.py
@@ -77,14 +77,19 @@ def test_transitive_missing_optional_dependency_is_silent(monkeypatch):
     """
     module_path = "pkg.target_mod"
 
-    def fake_import(name, *args, **kwargs):
-        # Simulate the target module importing an absent optional dependency.
-        raise ImportError("No module named 'wx'", name="wx")
-
-    monkeypatch.setattr(test_helpers, "__import__", fake_import, raising=False)
-    # ``__import__`` is looked up as a builtin; patch builtins to be safe.
     import builtins
 
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        # Simulate *only* the target module importing an absent optional
+        # dependency; delegate everything else so pytest internals keep working.
+        if name == module_path:
+            raise ImportError("No module named 'wx'", name="wx")
+        return real_import(name, *args, **kwargs)
+
+    # ``__import__`` is looked up as a builtin, so patching builtins is what
+    # actually intercepts the call inside ``_optional_reset``.
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
     with warnings.catch_warnings(record=True) as caught:
@@ -93,3 +98,31 @@ def test_transitive_missing_optional_dependency_is_silent(monkeypatch):
 
     assert fn() is None
     assert not caught, [str(c.message) for c in caught]
+
+
+def test_import_error_without_name_warns(monkeypatch):
+    """An ImportError with no ``.name`` (``exc.name is None``) must warn.
+
+    Without a populated ``name`` attribute we cannot distinguish a benign
+    missing optional dependency from a broken target module, so the safe
+    behaviour is to surface a warning rather than silently no-op.
+    """
+    module_path = "pkg.nameless_target"
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == module_path:
+            raise ImportError("import failed with no name attribute")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn = test_helpers._optional_reset(module_path, "reset_x")
+
+    assert fn() is None
+    assert any(module_path in str(c.message) for c in caught)


### PR DESCRIPTION
This addresses the two low-severity findings for `tests/test_reset_helpers.py` from the test-review sweep. It adds a test that exercises the previously-untested `exc.name is None` branch of `_optional_reset` (a bare `ImportError` with no `.name`), asserting the resolver surfaces a warning instead of silently no-opping. It also removes the dead `test_helpers.__import__` setattr — `__import__` is resolved as a builtin so that monkeypatch never intercepted the call — and scopes the `fake_import` hooks in both monkeypatching tests to the target module so pytest's own teardown/import machinery keeps working normally (the unscoped hook caused a pytest INTERNALERROR during report formatting).

## Verification
- `python -m pytest tests/test_reset_helpers.py -q` -> 5 passed.
- `python -m ruff check tests/test_reset_helpers.py` -> All checks passed.
- `python -m black --check tests/test_reset_helpers.py` -> would be left unchanged.
- Manually confirmed the new branch fires the warning (`exc.name is None` path) and that a bare `ImportError` indeed has `.name == None`.
- This is a test-only, non-wx change; no GUI/wx behavior is involved, so nothing required Windows. The full wx UI suite was not run (wx not importable in WSL), but the touched file has no wx dependency.

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)
