### PR TITLE
test: tighten store_service tests (issue #724)

### DIFF
--- a/tests/test_store_service.py
+++ b/tests/test_store_service.py
@@ -43,16 +43,6 @@ def test_load_store_reads_valid_json(tmp_path: Path, store_service: StoreService
     assert result == payload
 
 
-def test_load_store_returns_empty_on_invalid_json(tmp_path: Path, store_service: StoreService):
-    """Invalid JSON is ignored and returns an empty dict."""
-    path = tmp_path / "corrupt.json"
-    path.write_text("{bad json", encoding="utf-8")
-
-    result = store_service.load_store(path)
-
-    assert result == {}
-
-
 def test_load_store_handles_oserror(monkeypatch, tmp_path: Path, store_service: StoreService):
     """OS errors while reading a store fall back to an empty dict and log a warning."""
     from loguru import logger
@@ -126,17 +116,26 @@ def test_save_store_preserves_unicode(tmp_path: Path, store_service: StoreServic
     assert "\\u00e9" not in raw  # ensure it was not escaped
 
 
-def test_save_store_handles_write_errors(monkeypatch, tmp_path: Path, store_service: StoreService):
-    """Errors during write operations are swallowed gracefully."""
-    target = tmp_path / "store.json"
+def test_save_store_handles_write_errors(tmp_path: Path, store_service: StoreService):
+    """A real OS write error is swallowed and logged, not raised."""
+    from loguru import logger
 
-    def fake_atomic_write(*args, **kwargs):  # pylint: disable=unused-argument
-        raise OSError("no space left on device")
+    # Place a regular file where save_store expects a parent directory. The
+    # real atomic write then fails when it tries to mkdir the parent, raising
+    # a genuine OSError (NotADirectoryError) without patching internals.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    target = blocker / "store.json"
 
-    monkeypatch.setattr("services.store_service.atomic_write_json", fake_atomic_write)
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        store_service.save_store(target, {"notes": {}})
+    finally:
+        logger.remove(sink_id)
 
-    store_service.save_store(target, {"notes": {}})
     assert not target.exists()
+    assert any("Failed to write" in message for message in messages)
 
 
 def test_get_store_service_returns_singleton():


### PR DESCRIPTION
## Summary

Addresses the two low-severity findings from the test-review sweep for `tests/test_store_service.py`. Removes the redundant `test_load_store_returns_empty_on_invalid_json` test (the existing `test_load_store_logs_invalid_json_branch` already asserts both the empty-dict result and the warning log for the same input), and rewrites `test_save_store_handles_write_errors` so it no longer patches the internal `atomic_write_json`. Instead it triggers a genuine `OSError` (`NotADirectoryError`) by placing a regular file where `save_store` expects a parent directory, and asserts the documented `Failed to write` warning is logged rather than relying solely on file-absence.

## Verification

Ran in WSL:
- `python -m pytest tests/test_store_service.py -q` -> 8 passed (was 9; one redundant test removed). The rewritten write-error test exercises the real `OSError` branch and passes against the unmodified `atomic_write_json`.
- `python -m ruff check tests/test_store_service.py` -> All checks passed.
- `python -m black --check tests/test_store_service.py` -> unchanged.

This change is test-only and touches no `wx`/UI code, so there is nothing UI-dependent to verify on Windows. `wx` is not importable in WSL, but it is not involved here.

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)