### PR TITLE
test: cover color params and anchor branches in rules_browser html_render

### DIFF
--- a/tests/test_rules_browser_html_render.py
+++ b/tests/test_rules_browser_html_render.py
@@ -126,3 +126,61 @@ def test_render_outline_empty_sections_still_produces_valid_html() -> None:
     out = render_outline_to_html([])
     assert out.startswith("<html>")
     assert out.endswith("</body></html>")
+
+
+def test_render_outline_applies_color_params_to_body_tag() -> None:
+    sections = [_Sec(7, "Additional Rules", [_Sub("700", "General", "")])]
+    out = render_outline_to_html(
+        sections,
+        bg_color="#000000",
+        text_color="#FFFFFF",
+        link_color="#FF0000",
+    )
+    assert 'bgcolor="#000000"' in out
+    assert 'text="#FFFFFF"' in out
+    assert 'link="#FF0000"' in out
+
+
+def test_render_outline_uses_text_color_for_headings() -> None:
+    sections = [_Sec(7, "Additional Rules", [_Sub("700", "General", "")])]
+    out = render_outline_to_html(sections, text_color="#ABCDEF")
+    # Section heading (h2) and subsection heading (h3) both wrap their text
+    # in a <font color="..."> using the configured text color.
+    assert out.count('<font color="#ABCDEF">') == 2
+
+
+def test_render_outline_default_colors_emit_dark_theme() -> None:
+    sections = [_Sec(7, "Additional Rules", [_Sub("700", "General", "")])]
+    out = render_outline_to_html(sections)
+    assert 'bgcolor="#22272E"' in out
+    assert 'text="#E6EDF3"' in out
+    assert 'link="#7AA2F7"' in out
+
+
+def test_render_outline_paragraph_without_leading_rule_id_is_unanchored() -> None:
+    # Free-prose paragraphs that do not begin with a rule-id token must pass
+    # through without a per-rule <a name="..."> anchor.
+    body = "This introductory note has no rule id at the start."
+    sections = [_Sec(7, "Additional Rules", [_Sub("702", "Keyword Abilities", body)])]
+    out = render_outline_to_html(sections)
+    assert "This introductory note has no rule id at the start." in out
+    # No per-rule name anchor inside a <p> body paragraph (only the h3 carries
+    # the subsection-id anchor name="702").
+    assert "<p><a name=" not in out
+
+
+def test_render_outline_linkified_leading_rule_id_is_not_double_anchored() -> None:
+    # When the cross-ref linkifier rewrites the leading rule-id token itself,
+    # the per-rule anchoring pass must NOT also wrap it: the paragraph now
+    # starts with an <a href=...> lead-in, so no extra <a name="702.9">
+    # anchor is added on top.
+    body = "702.9 Flying is an evasion ability."
+
+    def linkifier(escaped: str) -> str:
+        return escaped.replace("702.9", '<a href="#702.9">702.9</a>', 1)
+
+    sections = [_Sec(7, "Additional Rules", [_Sub("702", "Keyword Abilities", body)])]
+    out = render_outline_to_html(sections, cross_ref_linkifier=linkifier)
+    assert '<a href="#702.9">702.9</a>' in out
+    # The leading id was linkified, so the per-rule name anchor must be absent.
+    assert '<a name="702.9">' not in out

--- a/widgets/frames/rules_browser/html_render.py
+++ b/widgets/frames/rules_browser/html_render.py
@@ -97,14 +97,14 @@ def _anchor_first_rule_id(escaped_paragraph: str) -> str:
     """Wrap the leading rule-id token in an ``<a name="…">`` anchor.
 
     The cross-ref linkifier must run *before* this so we don't double-wrap
-    the same token. Looks only at the first 12 chars of the paragraph for
-    a rule-id prefix; that keeps us safe from also matching IDs deeper in
-    the body that are already pure text.
+    the same token: a linkified leading id starts with an ``<a href=…>``
+    lead-in, so the anchored regex — which only matches a bare rule-id at
+    the very start of the paragraph — simply fails to match and returns the
+    paragraph unchanged. Paragraphs that don't lead with a rule id (free
+    prose) also fall through unchanged.
     """
     match = _RULE_HEADER_LINE_RE.match(escaped_paragraph)
     if match is None:
         return escaped_paragraph
     rule_id = match.group(1)
-    # If this token was already linkified by the cross-ref pass we'd see an
-    # ``<a href=…>`` lead-in instead — guard by checking the raw start.
     return f'<a name="{rule_id}">{rule_id}</a>{escaped_paragraph[len(rule_id):]}'


### PR DESCRIPTION
## Summary

Closes the test-review gaps for `tests/test_rules_browser_html_render.py`. Adds non-wx unit tests for the previously untested `bg_color`/`text_color`/`link_color` parameters of `render_outline_to_html` (custom values on the `<body>` tag, `text_color` applied to the `h2`/`h3` `<font>` headings, and the default dark-theme palette), plus tests for the two uncovered branches of `_anchor_first_rule_id`: free-prose paragraphs that do not lead with a rule id stay unanchored, and a cross-ref-linkified leading rule id is not double-anchored. Also rewrites the misleading "guard by checking the raw start" comment in `_anchor_first_rule_id` to describe the actual mechanism (a linkified leading id no longer matches the bare-rule-id regex, so it falls through unchanged — there is no explicit guard).

## Verification

- `python -m ruff check` and `python -m black --check` on both changed files: pass.
- `python -m pytest tests/test_rules_browser_html_render.py` cannot run in WSL: the test imports `widgets.frames.rules_browser.html_render`, whose package `__init__.py` imports `wx`, which is not installable off-Windows (pre-existing limitation, not introduced here). The full suite runs on Windows CI.
- Each new assertion was validated against the renderer directly in WSL by loading `html_render.py` via `importlib` (bypassing the wx-importing package `__init__`); all new assertions pass.
- Not verified in WSL: actual `wx.html.HtmlWindow` rendering of the produced HTML.

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)