### PR TITLE
Share marquee selection across all card views via an app-level filter

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from utils.logging_config import configure_logging
 from utils.runtime_flags import set_automation_enabled
 from widgets.frames.app_frame import make_app_frame
 from widgets.frames.splash_frame import LoadingFrame
+from widgets.panels.card_table_panel.marquee import is_marquee_surface
 
 # Global flag for automation mode
 _automation_enabled = False
@@ -21,6 +22,24 @@ _automation_port = 19847
 
 class MetagameWxApp(wx.App):
     """Bootstrap the redesigned deck builder."""
+
+    def FilterEvent(self, event: wx.Event) -> int:  # noqa: N802 - wx override
+        """Route a left-press on a marked background surface into the marquee.
+
+        Runs before the event is dispatched to any window, so a press on a
+        non-interactive zone (which doesn't bind its own handler) can still
+        start the active deck view's rubber-band selection. Returns -1 so normal
+        processing always continues — the filter only *adds* the marquee start,
+        it never consumes the press.
+        """
+        if event.GetEventType() == wx.wxEVT_LEFT_DOWN and is_marquee_surface(
+            event.GetEventObject()
+        ):
+            top = self.GetTopWindow()
+            begin = getattr(top, "begin_active_marquee", None)
+            if callable(begin):
+                begin(wx.GetMousePosition())
+        return -1
 
     def OnInit(self) -> bool:  # noqa: N802 - wx override
         logger.info("Starting MTGO Metagame Deck Builder (wx)")

--- a/tests/ui/test_marquee_selection.py
+++ b/tests/ui/test_marquee_selection.py
@@ -1,0 +1,182 @@
+"""Tests for the shared marquee machinery and per-view rubber-band selection.
+
+Covers the surface-marker opt-in, the :class:`MarqueeController` lifecycle, and
+that the grid and table views select the cards a rectangle covers — the contract
+that lets a marquee be driven from any view (and started from any marked surface).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import wx
+
+from widgets.mana_icon_factory import ManaIconFactory
+from widgets.panels.card_table_panel.grid_view import DeckGridView
+from widgets.panels.card_table_panel.marquee import (
+    MarqueeController,
+    is_marquee_surface,
+    mark_marquee_surfaces_recursively,
+)
+from widgets.panels.card_table_panel.table_view import DeckTableView
+
+_BIG_RECT = wx.Rect(0, 0, 100_000, 100_000)
+
+_META: dict[str, dict[str, Any]] = {
+    "grizzly bears": {"mana_value": 2, "type_line": "Creature — Bear", "colors": ["G"]},
+    "llanowar elves": {"mana_value": 1, "type_line": "Creature — Elf", "colors": ["G"]},
+    "forest": {"mana_value": 0, "type_line": "Basic Land — Forest", "colors": []},
+}
+
+
+def _get_metadata(name: str) -> dict[str, Any]:
+    return _META.get(name.lower(), {})
+
+
+def _cards() -> list[dict[str, Any]]:
+    return [
+        {"name": "Grizzly Bears", "qty": 2},
+        {"name": "Llanowar Elves", "qty": 4},
+        {"name": "Forest", "qty": 6},
+    ]
+
+
+# ----- surface markers -----
+@pytest.mark.usefixtures("wx_app")
+def test_marker_roundtrips_and_recursion_filters_by_type():
+    """Only vanilla panels/static chrome opt in; controls and subclasses don't."""
+    frame = wx.Frame(None)
+    try:
+        plain = wx.Panel(frame)
+        label = wx.StaticText(plain, label="hi")
+        button = wx.Button(plain, label="go")
+
+        class _SubPanel(wx.Panel):
+            pass
+
+        sub = _SubPanel(plain)
+
+        assert not is_marquee_surface(plain)
+        mark_marquee_surfaces_recursively(frame)
+
+        assert is_marquee_surface(plain)  # vanilla wx.Panel
+        assert is_marquee_surface(label)  # vanilla wx.StaticText
+        assert not is_marquee_surface(button)  # a control
+        assert not is_marquee_surface(sub)  # a wx.Panel subclass
+        assert not is_marquee_surface(None)
+    finally:
+        frame.Destroy()
+
+
+# ----- controller lifecycle -----
+@pytest.mark.usefixtures("wx_app")
+def test_controller_drives_begin_update_finish():
+    frame = wx.Frame(None)
+    try:
+        window = wx.Window(frame)
+        # Capture on a never-shown window is platform-fragile; neutralise it.
+        window.CaptureMouse = lambda: None  # type: ignore[assignment]
+        window.HasCapture = lambda: False  # type: ignore[assignment]
+        window.ReleaseMouse = lambda: None  # type: ignore[assignment]
+
+        events: list[Any] = []
+        controller = MarqueeController(
+            window,
+            to_logical=lambda p: p,
+            on_begin=lambda additive: events.append(("begin", additive)),
+            on_select=lambda rect: events.append(("select", rect.GetWidth(), rect.GetHeight())),
+            on_finish=lambda: events.append(("finish",)),
+        )
+        controller._update_overlay = lambda: None  # type: ignore[assignment]
+
+        assert not controller.active
+        controller.begin(wx.Point(5, 5), additive=True)
+        assert controller.active
+        controller.update(wx.Point(25, 35))
+        controller.finish()
+
+        assert not controller.active
+        assert ("begin", True) in events
+        assert ("finish",) in events
+        # The post-update select reports a 20×30 rectangle.
+        assert ("select", 20, 30) in events
+    finally:
+        frame.Destroy()
+
+
+# ----- grid view -----
+@pytest.mark.usefixtures("wx_app")
+def test_grid_marquee_selects_covered_cards():
+    frame = wx.Frame(None)
+    try:
+        view = DeckGridView(
+            frame,
+            "main",
+            _get_metadata,
+            lambda _n, _s: None,
+            lambda _n, _q: ("owned", (0, 0, 0)),
+            ManaIconFactory(icon_size=12),
+            on_select=lambda _c: None,
+            on_hover=None,
+        )
+        view.set_cards(_cards())
+
+        view._marquee_begin(False)
+        view._marquee_select(_BIG_RECT)
+
+        assert view._selected_names == {"Grizzly Bears", "Llanowar Elves", "Forest"}
+        assert view.get_selected_name() is None  # multi-select reports no single
+    finally:
+        frame.Destroy()
+
+
+@pytest.mark.usefixtures("wx_app")
+def test_grid_additive_marquee_unions_with_existing():
+    frame = wx.Frame(None)
+    try:
+        view = DeckGridView(
+            frame,
+            "main",
+            _get_metadata,
+            lambda _n, _s: None,
+            lambda _n, _q: ("owned", (0, 0, 0)),
+            ManaIconFactory(icon_size=12),
+            on_select=lambda _c: None,
+            on_hover=None,
+        )
+        view.set_cards(_cards())
+        view.set_selected("Forest")
+
+        # A Shift-additive marquee keeps the prior selection and adds its hits.
+        view._marquee_begin(True)
+        view._marquee_select(_BIG_RECT)
+
+        assert "Forest" in view._selected_names
+        assert view._selected_names == {"Grizzly Bears", "Llanowar Elves", "Forest"}
+    finally:
+        frame.Destroy()
+
+
+# ----- table view -----
+@pytest.mark.usefixtures("wx_app")
+def test_table_marquee_selects_covered_rows():
+    frame = wx.Frame(None)
+    try:
+        view = DeckTableView(
+            frame,
+            "main",
+            _get_metadata,
+            on_select=lambda _c: None,
+            on_hover=None,
+            icon_factory=ManaIconFactory(icon_size=12),
+        )
+        view.set_cards(_cards())
+
+        view._marquee_begin(False)
+        view._marquee_select(_BIG_RECT)
+
+        assert view._selected_names == {"Grizzly Bears", "Llanowar Elves", "Forest"}
+        assert view.get_selected_name() is None
+    finally:
+        frame.Destroy()

--- a/tests/ui/test_pile_view_selection.py
+++ b/tests/ui/test_pile_view_selection.py
@@ -276,9 +276,8 @@ def test_rubber_band_past_canvas_selects_every_card():
         ((_label, members),) = view._piles
         all_uids = {entry["_uid"] for entry in members}
 
-        view._rubber_start = wx.Point(0, 0)
-        view._rubber_end = wx.Point(10_000, 10_000)  # far past the canvas
-        view._select_within_rubber()
+        # A rectangle far past the canvas, applied through the marquee callback.
+        view._marquee_select(wx.Rect(0, 0, 10_000, 10_000))
 
         assert view._selected_uids == all_uids
     finally:
@@ -293,14 +292,13 @@ def test_begin_marquee_at_screen_starts_a_selection_from_outside():
         view = _make_view(frame, lambda _card: None)
         view.set_cards([{"name": "Grizzly Bears", "qty": 4}])
         # Don't spawn the real overlay popup for a never-shown test window.
-        view._update_marquee_overlay = lambda: None  # type: ignore[assignment]
+        view._marquee._update_overlay = lambda: None  # type: ignore[assignment]
 
         view.begin_marquee_at_screen(wx.Point(500, 500))
 
-        assert view._rubber_start is not None
-        assert view._rubber_end == view._rubber_start
-        assert view._marquee_start_screen is not None
-        view._rubber_timer.Stop()
+        assert view._marquee.active
+        view._marquee.cancel()
+        assert not view._marquee.active
     finally:
         frame.Destroy()
 

--- a/widgets/frames/app_frame/frame/__init__.py
+++ b/widgets/frames/app_frame/frame/__init__.py
@@ -45,6 +45,7 @@ from widgets.frames.timer_alert import TimerAlertFrame
 from widgets.frames.top_cards import TopCardsFrame
 from widgets.mana_icon_factory import ManaIconFactory
 from widgets.panels.card_table_panel import CardTablePanel
+from widgets.panels.card_table_panel.marquee import mark_marquee_surfaces_recursively
 from widgets.panels.deck_builder_panel import DeckBuilderPanel
 from widgets.panels.deck_research_panel import DeckResearchPanel
 
@@ -150,9 +151,6 @@ class AppFrame(
         self.root_panel.SetBackgroundColour(DARK_BG)
         root_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.root_panel.SetSizer(root_sizer)
-        # Pressing the bare application background (outside any control) starts a
-        # pile-view marquee, so the selection box can be drawn from anywhere.
-        self.root_panel.Bind(wx.EVT_LEFT_DOWN, self._on_background_marquee_down)
 
         left_panel = self._build_left_panel(self.root_panel)
         root_sizer.Add(left_panel, 0, wx.EXPAND | wx.ALL, PADDING_LG)
@@ -160,19 +158,23 @@ class AppFrame(
         right_container = self._build_right_container(self.root_panel)
         root_sizer.Add(right_container, 1, wx.EXPAND | wx.ALL, PADDING_LG)
 
-    def _on_background_marquee_down(self, event: wx.MouseEvent) -> None:
-        """Begin a pile-view marquee from a press on the application background.
+        # Opt every bare background/static surface into starting a marquee, so a
+        # press on any non-interactive zone draws the selection box. Controls and
+        # the card-view canvases are excluded (the canvases start their own
+        # marquee); the app's FilterEvent routes a marked press to the active
+        # view. See widgets/panels/card_table_panel/marquee.py.
+        mark_marquee_surfaces_recursively(self.root_panel)
 
-        Only fires on the bare panel area (controls consume their own clicks),
-        and only when the visible deck tab is showing the pile view — otherwise
-        the press is left to its default handling.
+    def begin_active_marquee(self, screen_point: wx.Point) -> None:
+        """Start a marquee on the visible deck view from a screen-space press.
+
+        Called by the app-level event filter when a press lands on a marked
+        surface. No-op unless the current deck tab hosts a card view with cards.
         """
         page = self.deck_tabs.GetCurrentPage()
-        pile_view = getattr(page, "pile_view", None)
-        if pile_view is not None and getattr(page, "view_mode", None) == "pile":
-            pile_view.begin_marquee_at_screen(wx.GetMousePosition())
-            return
-        event.Skip()
+        begin = getattr(page, "begin_marquee_at_screen", None)
+        if callable(begin):
+            begin(screen_point)
 
     def _setup_status_bar(self) -> None:
         self.status_bar = self.CreateStatusBar()
@@ -185,7 +187,6 @@ class AppFrame(
         """Compose the right side of the window: toolbar over (center | inspector)."""
         right_panel = wx.Panel(parent)
         right_panel.SetBackgroundColour(DARK_BG)
-        right_panel.Bind(wx.EVT_LEFT_DOWN, self._on_background_marquee_down)
         right_sizer = wx.BoxSizer(wx.VERTICAL)
         right_panel.SetSizer(right_sizer)
 

--- a/widgets/panels/card_table_panel/frame.py
+++ b/widgets/panels/card_table_panel/frame.py
@@ -182,6 +182,27 @@ class CardTablePanel(CardTablePanelHandlersMixin, CardTablePanelPropertiesMixin,
         self._update_pile_sort_button_visibility()
 
     # ----- public API -----
+    @property
+    def active_view(self) -> wx.Window | None:
+        """The card view currently on top (grid/table/pile), or None if empty."""
+        if not self.cards:
+            return None
+        return {
+            "grid": self.grid_view,
+            "table": self.table_view,
+            "pile": self.pile_view,
+        }.get(self.view_mode)
+
+    def begin_marquee_at_screen(self, screen_point: wx.Point) -> None:
+        """Start a rubber-band selection on the active view from a screen point.
+
+        Lets the app route a press on any non-interactive surface into the
+        visible view's marquee, so the selection box can be drawn from anywhere.
+        """
+        view = self.active_view
+        if view is not None:
+            view.begin_marquee_at_screen(screen_point)
+
     def set_view_mode(self, mode: str, *, persist: bool = True) -> None:
         if mode not in VIEW_MODES:
             return

--- a/widgets/panels/card_table_panel/grid_view.py
+++ b/widgets/panels/card_table_panel/grid_view.py
@@ -65,6 +65,7 @@ from widgets.panels.card_table_panel.card_render import (
     build_image_name_candidates,
     resolve_card_color,
 )
+from widgets.panels.card_table_panel.marquee import RUBBER_AUTOSCROLL_PX, MarqueeController
 from widgets.panels.card_table_panel.pile_view import _ImageCache
 from widgets.panels.card_table_panel.scrolling import scroll_by_wheel
 
@@ -125,10 +126,25 @@ class DeckGridView(wx.ScrolledWindow):
         self._on_remove = on_remove
 
         self._cards: list[dict[str, Any]] = []
-        self._selected_name: str | None = None
+        # Multi-selection by card name (a single click selects exactly one).
+        # Marquee can select several; the highlight covers every name in the set.
+        self._selected_names: set[str] = set()
         self._hover_name: str | None = None
         self._pressed: tuple[str, int] | None = None
         self._cols: int = _DEFAULT_COLUMNS
+        # See pile view: the panel echoes our reported selection back via
+        # set_selected(); suppress that round-trip while we report a multi-select
+        # marquee so the echoed None can't wipe the set we just built.
+        self._suppress_set_selected: bool = False
+        self._marquee = MarqueeController(
+            self,
+            to_logical=self._to_logical,
+            on_begin=self._marquee_begin,
+            on_select=self._marquee_select,
+            on_finish=self._marquee_finish,
+            autoscroll=self._autoscroll_towards,
+        )
+        self._marquee_base: set[str] | None = None
 
         self._image_cache = _ImageCache()
         # Per-name load generation so a stale in-flight decode (e.g. of an old
@@ -163,6 +179,7 @@ class DeckGridView(wx.ScrolledWindow):
         self.Bind(wx.EVT_MOTION, self._on_motion)
         self.Bind(wx.EVT_MOUSEWHEEL, self._on_wheel)
         self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
+        self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self._on_capture_lost)
 
     # ----- public API consumed by CardTablePanel -----
     def set_cards(self, cards: list[dict[str, Any]], preserve_scroll: bool = False) -> None:
@@ -182,17 +199,24 @@ class DeckGridView(wx.ScrolledWindow):
         self.Refresh()
 
     def set_selected(self, name: str | None) -> None:
-        self._selected_name = name
+        # Ignored while we broadcast our own (possibly multi-) selection: the
+        # panel echoes it straight back and a bare name can't represent a set.
+        if self._suppress_set_selected:
+            return
+        self._selected_names = {name} if name else set()
         self.Refresh()
 
     def get_selected_name(self) -> str | None:
-        return self._selected_name
+        if len(self._selected_names) != 1:
+            return None
+        return next(iter(self._selected_names))
 
     def get_selected_card(self) -> dict[str, Any] | None:
-        if not self._selected_name:
+        name = self.get_selected_name()
+        if not name:
             return None
         for card in self._cards:
-            if card["name"].lower() == self._selected_name.lower():
+            if card["name"].lower() == name.lower():
                 return card
         return None
 
@@ -202,7 +226,7 @@ class DeckGridView(wx.ScrolledWindow):
             return False
         for idx, card in enumerate(self._cards):
             if card["name"].lower() == name.lower():
-                self._selected_name = card["name"]
+                self._selected_names = {card["name"]}
                 self._ensure_visible(self._card_rect(idx))
                 self.Refresh()
                 return True
@@ -285,9 +309,11 @@ class DeckGridView(wx.ScrolledWindow):
 
     def _shows_actions(self, name: str) -> bool:
         lower = name.lower()
-        return (self._hover_name is not None and lower == self._hover_name.lower()) or (
-            self._selected_name is not None and lower == self._selected_name.lower()
-        )
+        if self._hover_name is not None and lower == self._hover_name.lower():
+            return True
+        # Only show the inline +/−/× on a lone selection; a marquee multi-select
+        # shouldn't plaster controls across every chosen card.
+        return len(self._selected_names) == 1 and name in self._selected_names
 
     # ----- image loading -----
     def _prefetch_images(self) -> None:
@@ -538,13 +564,13 @@ class DeckGridView(wx.ScrolledWindow):
 
     def _draw_overlays(self, dc: wx.DC) -> None:
         """Draw selection border, accent badge and +/−/× over the blitted cards."""
-        sel = self._selected_name
+        sel = self._selected_names
         hov = self._hover_name
         if not sel and not hov:
             return
         for idx, card in enumerate(self._cards):
             name = card["name"]
-            is_selected = sel is not None and name.lower() == sel.lower()
+            is_selected = name in sel
             is_hover = hov is not None and name.lower() == hov.lower()
             if not (is_selected or is_hover):
                 continue
@@ -580,9 +606,7 @@ class DeckGridView(wx.ScrolledWindow):
         Used by the oversized-deck fallback path that bypasses the canvas.
         """
         name = card["name"]
-        is_selected = (
-            self._selected_name is not None and name.lower() == self._selected_name.lower()
-        )
+        is_selected = name in self._selected_names
         self._draw_card_static(dc, rect, card)
         if is_selected:
             self._draw_qty(dc, rect, card, True)
@@ -652,6 +676,8 @@ class DeckGridView(wx.ScrolledWindow):
         point = self._to_logical(event.GetPosition())
         idx = self._hit_test(point)
         if idx is None:
+            # Empty space: start a rubber-band selection (clear unless Shift).
+            self._marquee.begin(event.GetPosition(), additive=event.ShiftDown())
             return
         card = self._cards[idx]
         name = card["name"]
@@ -665,10 +691,25 @@ class DeckGridView(wx.ScrolledWindow):
                     self._fire_action(name, slot)
                     return
 
-        if self._selected_name and name.lower() == self._selected_name.lower():
-            self._on_select(None)
+        if self._selected_names == {name}:
+            self._selected_names = set()
+            self._notify_selection(None)
         else:
+            self._selected_names = {name}
+            self._notify_selection(card)
+        self.Refresh()
+
+    def begin_marquee_at_screen(self, screen_point: wx.Point) -> None:
+        """Start a marquee from anywhere in the app (e.g. the frame background)."""
+        self._marquee.begin_at_screen(screen_point)
+
+    def _notify_selection(self, card: dict[str, Any] | None) -> None:
+        """Report selection to the panel, guarding the set_selected echo."""
+        self._suppress_set_selected = True
+        try:
             self._on_select(card)
+        finally:
+            self._suppress_set_selected = False
 
     def _fire_action(self, name: str, slot: int) -> None:
         if slot == 0 and self._on_delta:
@@ -679,11 +720,21 @@ class DeckGridView(wx.ScrolledWindow):
             self._on_remove(name)
 
     def _on_left_up(self, _event: wx.MouseEvent) -> None:
+        if self._marquee.active:
+            self._marquee.finish()
+            return
         if self._pressed is not None:
             self._pressed = None
             self.Refresh()
 
+    def _on_capture_lost(self, _event: wx.MouseCaptureLostEvent) -> None:
+        self._marquee.cancel()
+        self.Refresh()
+
     def _on_motion(self, event: wx.MouseEvent) -> None:
+        if self._marquee.active:
+            self._marquee.update(event.GetPosition())
+            return
         point = self._to_logical(event.GetPosition())
         idx = self._hit_test(point)
         hovered = self._cards[idx]["name"] if idx is not None else None
@@ -702,3 +753,52 @@ class DeckGridView(wx.ScrolledWindow):
         if self._hover_name is not None:
             self._hover_name = None
             self.Refresh()
+
+    # ----- rubber-band marquee -----
+    def _marquee_begin(self, additive: bool) -> None:
+        if not additive and self._selected_names:
+            self._selected_names = set()
+            self._notify_selection(None)
+        # Snapshot the (post-clear) selection so additive hits union into it.
+        self._marquee_base = set(self._selected_names)
+        # Hover controls would otherwise linger over the card the press started on.
+        self._hover_name = None
+        self.Refresh()
+
+    def _marquee_select(self, rect: wx.Rect) -> None:
+        chosen: set[str] = set(self._marquee_base or ())
+        for idx, card in enumerate(self._cards):
+            if rect.Intersects(self._card_rect(idx)):
+                chosen.add(card["name"])
+        if chosen != self._selected_names:
+            self._selected_names = chosen
+            # One card chosen reports that card; several (or none) report None so
+            # the inspector falls back to hover, mirroring the pile view.
+            if len(chosen) == 1:
+                self._notify_selection(self._card_for(next(iter(chosen))))
+            else:
+                self._notify_selection(None)
+            self.Refresh()
+
+    def _marquee_finish(self) -> None:
+        self._marquee_base = None
+        self.Refresh()
+
+    def _card_for(self, name: str) -> dict[str, Any] | None:
+        for card in self._cards:
+            if card["name"] == name:
+                return card
+        return None
+
+    def _autoscroll_towards(self, client_pos: wx.Point) -> None:
+        """Scroll one step toward any viewport edge the pointer is held beyond."""
+        client_h = self.GetClientSize().GetHeight()
+        view_x, view_y = self.GetViewStart()
+        new_y = view_y
+        if client_pos.y < 0:
+            new_y = max(0, view_y - RUBBER_AUTOSCROLL_PX)
+        elif client_pos.y > client_h:
+            new_y = view_y + RUBBER_AUTOSCROLL_PX
+        if new_y != view_y:
+            # Scroll clamps to the virtual bounds, so overshoot is harmless.
+            self.Scroll(view_x, new_y)

--- a/widgets/panels/card_table_panel/marquee.py
+++ b/widgets/panels/card_table_panel/marquee.py
@@ -1,0 +1,216 @@
+"""Shared rubber-band (marquee) selection machinery for the card views.
+
+Every card view — pile, grid and table — supports the same gesture: press on an
+empty surface and drag a rectangle to multi-select the cards it covers. The
+mechanics of that gesture (mouse capture, a cursor-polling timer so the box
+keeps growing past the window edge, the app-level outline overlay, auto-scroll)
+are identical across the views; only *which* items a rectangle selects differs.
+
+:class:`MarqueeController` owns the shared mechanics for one view. The view hands
+it a target window plus a few callbacks and otherwise just forwards its mouse
+events. The selection itself stays in the view (it knows its own layout and
+selection model), driven by the ``on_select`` callback.
+
+The opt-in *surface marker* lets the application decide which background windows
+may originate a marquee. A press is routed to the active view's controller only
+when it lands on a window that was explicitly marked — see
+``mark_marquee_surface``. This is what makes "drag from any non-interactive zone"
+work without binding a handler onto every panel: an app-level event filter checks
+the marker and forwards. Card-view canvases are deliberately *not* marked; they
+begin their own marquee from their empty-space press so a click on a card still
+selects the card.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import wx
+
+from widgets.panels.card_table_panel.marquee_overlay import MarqueeOverlay
+
+# While a rubber-band is active a timer polls the global cursor so the box keeps
+# tracking (and the view keeps auto-scrolling) even when the pointer is dragged
+# past the window edge — the OS only delivers motion events while the cursor is
+# over the window, which would otherwise freeze the box at the edge.
+_RUBBER_POLL_MS = 30
+# Per-tick auto-scroll step while the pointer is held beyond a viewport edge.
+RUBBER_AUTOSCROLL_PX = 24
+
+# Windows carrying this attribute (set truthy) are valid marquee origins.
+_MARQUEE_SURFACE_ATTR = "_marquee_surface"
+
+# Plain background/decoration window types that a recursive mark treats as
+# non-interactive surfaces. Exact-type checks (not isinstance) so the card-view
+# canvases and the panels that subclass wx.Panel are never swept in — only
+# vanilla backgrounds and static chrome opt in.
+_RECURSIVE_SURFACE_TYPES = (wx.Panel, wx.StaticText, wx.StaticLine)
+
+
+def mark_marquee_surface(window: wx.Window) -> None:
+    """Mark ``window`` as a surface a marquee may be started from."""
+    setattr(window, _MARQUEE_SURFACE_ATTR, True)
+
+
+def is_marquee_surface(window: wx.Window | None) -> bool:
+    """Whether ``window`` was opted in as a marquee surface."""
+    return bool(getattr(window, _MARQUEE_SURFACE_ATTR, False))
+
+
+def mark_marquee_surfaces_recursively(root: wx.Window) -> None:
+    """Opt ``root`` and its plain background/static descendants into marquee.
+
+    Sweeps the tree once and marks every vanilla ``wx.Panel`` / ``wx.StaticText``
+    / ``wx.StaticLine`` (by exact type, so custom panels and controls are left
+    out). Run on the app's chrome after it is built; the card-view canvases are
+    intentionally excluded and originate their own marquee.
+    """
+    stack: list[wx.Window] = [root]
+    while stack:
+        window = stack.pop()
+        if type(window) in _RECURSIVE_SURFACE_TYPES:
+            mark_marquee_surface(window)
+        stack.extend(window.GetChildren())
+
+
+class MarqueeController:
+    """Drives one view's rubber-band selection.
+
+    The view supplies:
+
+    * ``to_logical(client_point)`` — map a client point on ``window`` to the
+      view's logical (scroll-aware) coordinates.
+    * ``on_begin(additive)`` — called once when a marquee starts; the view
+      snapshots/clears its selection here (``additive`` is the Shift state).
+    * ``on_select(logical_rect)`` — called whenever the rectangle changes; the
+      view selects the items it covers.
+    * ``on_finish()`` — called when the marquee ends (commit or cancel); the
+      view drops any per-drag state.
+    * ``autoscroll(client_point)`` — optional; scroll one step toward an edge
+      the pointer is held beyond.
+    """
+
+    def __init__(
+        self,
+        window: wx.Window,
+        *,
+        to_logical: Callable[[wx.Point], wx.Point],
+        on_begin: Callable[[bool], None],
+        on_select: Callable[[wx.Rect], None],
+        on_finish: Callable[[], None],
+        autoscroll: Callable[[wx.Point], None] | None = None,
+    ) -> None:
+        self._window = window
+        self._to_logical = to_logical
+        self._on_begin = on_begin
+        self._on_select = on_select
+        self._on_finish = on_finish
+        self._autoscroll = autoscroll
+
+        # Logical (scroll-aware) corners of the active rectangle; None when idle.
+        self._start: wx.Point | None = None
+        self._end: wx.Point | None = None
+        # Fixed screen-space origin for the outline overlay (screen-anchored so
+        # the visible box doesn't shift when the content scrolls under it).
+        self._start_screen: wx.Point | None = None
+        self._overlay: MarqueeOverlay | None = None
+        self._timer = wx.Timer(window)
+        window.Bind(wx.EVT_TIMER, self._on_timer, self._timer)
+
+    @property
+    def active(self) -> bool:
+        return self._start is not None
+
+    # ----- lifecycle -----
+    def begin(self, client_point: wx.Point, *, additive: bool) -> None:
+        """Start a marquee at a client point on the target window."""
+        if self.active:
+            return
+        logical = self._to_logical(client_point)
+        self._start = logical
+        self._end = logical
+        self._start_screen = self._window.ClientToScreen(client_point)
+        if not self._window.HasCapture():
+            self._window.CaptureMouse()
+        self._timer.Start(_RUBBER_POLL_MS)
+        self._on_begin(additive)
+        self._on_select(self._rect())
+        self._update_overlay()
+
+    def begin_at_screen(self, screen_point: wx.Point, *, additive: bool = False) -> None:
+        """Start a marquee from anywhere on screen (e.g. the frame background).
+
+        The pointer may be well outside the target window; capturing the mouse
+        routes the rest of the drag to it regardless, and the polling timer
+        tracks the cursor by its global position from there on.
+        """
+        self.begin(self._window.ScreenToClient(screen_point), additive=additive)
+
+    def update(self, client_point: wx.Point) -> None:
+        """Extend the rectangle to a new client point."""
+        if not self.active:
+            return
+        self._end = self._to_logical(client_point)
+        self._on_select(self._rect())
+        self._update_overlay()
+
+    def finish(self) -> None:
+        """Commit and tear down the active marquee."""
+        if not self.active:
+            return
+        self._teardown()
+        self._on_finish()
+
+    def cancel(self) -> None:
+        """Tear down without committing (e.g. on mouse-capture loss)."""
+        was_active = self.active
+        self._teardown()
+        if was_active:
+            self._on_finish()
+
+    def _teardown(self) -> None:
+        self._timer.Stop()
+        if self._overlay is not None:
+            self._overlay.cancel()
+        self._start = None
+        self._end = None
+        self._start_screen = None
+        if self._window.HasCapture():
+            self._window.ReleaseMouse()
+
+    # ----- internals -----
+    def _rect(self) -> wx.Rect:
+        # _start/_end are only read while active, where both are set.
+        x1, y1 = self._start  # type: ignore[misc]
+        x2, y2 = self._end  # type: ignore[misc]
+        return wx.Rect(min(x1, x2), min(y1, y2), abs(x2 - x1), abs(y2 - y1))
+
+    def _update_overlay(self) -> None:
+        if self._start_screen is None:
+            return
+        if self._overlay is None:
+            self._overlay = MarqueeOverlay(self._window.GetTopLevelParent())
+        self._overlay.update(self._start_screen, wx.GetMousePosition())
+
+    def _on_timer(self, _event: wx.TimerEvent) -> None:
+        """Extend the rectangle toward the live cursor while the button is held.
+
+        Reading the global cursor (rather than relying on motion events, which
+        the OS stops sending once the pointer leaves the window) keeps the box
+        growing past the canvas edges and lets a held-at-the-edge drag scroll the
+        view so the whole canvas — not just the visible part — is reachable.
+        """
+        if not self.active:
+            self._timer.Stop()
+            return
+        # If the button came up off-window we may have missed the up event; the
+        # selection is already committed, so just stand down.
+        if not wx.GetMouseState().LeftIsDown():
+            self.finish()
+            return
+        client = self._window.ScreenToClient(wx.GetMousePosition())
+        if self._autoscroll is not None:
+            self._autoscroll(client)
+        # Recompute in logical space *after* any scroll so the endpoint tracks
+        # the content the cursor now sits over.
+        self.update(client)

--- a/widgets/panels/card_table_panel/pile_view.py
+++ b/widgets/panels/card_table_panel/pile_view.py
@@ -47,7 +47,7 @@ from utils.constants import (
 )
 from utils.image_effects import apply_rounded_corner_alpha
 from widgets.panels.card_table_panel import scroll_perf
-from widgets.panels.card_table_panel.marquee_overlay import MarqueeOverlay
+from widgets.panels.card_table_panel.marquee import RUBBER_AUTOSCROLL_PX, MarqueeController
 from widgets.panels.card_table_panel.scrolling import scroll_by_wheel
 from widgets.panels.card_table_panel.sorting import (
     PILE_SORT_MV,
@@ -67,14 +67,6 @@ _PILE_TOP = _PILE_PAD  # top inset for the first card in a pile
 # and draw directly (culled), so a pathological pile can't allocate a huge
 # canvas. Comfortably clears any real deck zone.
 _MAX_CANVAS_PX = 20000
-
-# While a rubber-band selection is active a timer polls the global cursor so the
-# box keeps tracking (and the view keeps auto-scrolling) even when the pointer
-# is dragged past the window edge — the OS only delivers motion events while the
-# cursor is over the window, which would otherwise freeze the box at the edge.
-_RUBBER_POLL_MS = 30
-# Per-tick auto-scroll step while the pointer is held beyond a viewport edge.
-_RUBBER_AUTOSCROLL_PX = 24
 
 
 class _ImageCache:
@@ -134,16 +126,19 @@ class DeckPileView(wx.ScrolledWindow):
         # None), so we suppress it to keep the per-copy selection we just made.
         self._suppress_set_selected: bool = False
 
-        # Rectangle selection state. Selection is computed in logical (scrolled)
-        # coordinates; the visible outline is drawn by an app-level overlay in
-        # screen coordinates so it spans the whole window without clipping.
-        self._rubber_start: wx.Point | None = None
-        self._rubber_end: wx.Point | None = None
-        self._marquee_start_screen: wx.Point | None = None
-        self._marquee_overlay: MarqueeOverlay | None = None
-        # Polls the cursor while a rubber-band is active so the marquee survives
-        # the pointer leaving the window (see _RUBBER_POLL_MS).
-        self._rubber_timer = wx.Timer(self)
+        # Rectangle (rubber-band) selection. The shared controller owns the
+        # capture/timer/overlay/auto-scroll; this view supplies per-copy
+        # hit-testing through the callbacks below. _marquee_base snapshots the
+        # selection a Shift-additive marquee unions its new hits into.
+        self._marquee = MarqueeController(
+            self,
+            to_logical=self._to_logical,
+            on_begin=self._marquee_begin,
+            on_select=self._marquee_select,
+            on_finish=self._marquee_finish,
+            autoscroll=self._autoscroll_towards,
+        )
+        self._marquee_base: set[int] | None = None
 
         # Drag state.
         self._drag_active = False
@@ -182,7 +177,6 @@ class DeckPileView(wx.ScrolledWindow):
         self.Bind(wx.EVT_MOUSEWHEEL, self._on_wheel)
         self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
         self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self._on_capture_lost)
-        self.Bind(wx.EVT_TIMER, self._on_rubber_timer, self._rubber_timer)
 
     # ----- public API consumed by CardTablePanel -----
     def set_cards(self, cards: list[dict[str, Any]]) -> None:
@@ -575,43 +569,20 @@ class DeckPileView(wx.ScrolledWindow):
 
     # ----- rubber-band marquee -----
     def begin_marquee_at_screen(self, screen_point: wx.Point) -> None:
-        """Start a marquee from anywhere in the app (e.g. the frame background).
+        """Start a marquee from anywhere in the app (e.g. the frame background)."""
+        self._marquee.begin_at_screen(screen_point)
 
-        The pointer may be well outside this widget; capturing the mouse here
-        routes the rest of the drag to us regardless, and the polling timer
-        tracks the cursor by its global position from there on.
-        """
-        client_point = self.ScreenToClient(screen_point)
-        self._begin_marquee(self._to_logical(client_point), client_point, additive=False)
-
-    def _begin_marquee(
-        self, logical_point: wx.Point, client_point: wx.Point, *, additive: bool
-    ) -> None:
-        if not additive:
-            self._selected_uids.clear()
+    def _marquee_begin(self, additive: bool) -> None:
+        if not additive and self._selected_uids:
+            self._selected_uids = set()
             self._notify_selection_changed()
-        self._rubber_start = logical_point
-        self._rubber_end = logical_point
-        self._marquee_start_screen = self.ClientToScreen(client_point)
-        if not self.HasCapture():
-            self.CaptureMouse()
-        # Poll the cursor so the box keeps growing past the window edge and
-        # auto-scrolls; motion events alone stop once the pointer leaves.
-        self._rubber_timer.Start(_RUBBER_POLL_MS)
-        self._update_marquee_overlay()
+        # Snapshot the (post-clear) selection so additive hits union into it.
+        self._marquee_base = set(self._selected_uids)
         self.Refresh()
 
-    def _update_marquee_overlay(self) -> None:
-        if self._marquee_start_screen is None:
-            return
-        if self._marquee_overlay is None:
-            self._marquee_overlay = MarqueeOverlay(self.GetTopLevelParent())
-        self._marquee_overlay.update(self._marquee_start_screen, wx.GetMousePosition())
-
-    def _clear_marquee_overlay(self) -> None:
-        if self._marquee_overlay is not None:
-            self._marquee_overlay.cancel()
-        self._marquee_start_screen = None
+    def _marquee_finish(self) -> None:
+        self._marquee_base = None
+        self.Refresh()
 
     # ----- event handlers -----
     def _on_left_down(self, event: wx.MouseEvent) -> None:
@@ -620,7 +591,7 @@ class DeckPileView(wx.ScrolledWindow):
 
         if hit is None:
             # Empty space: start a rubber-band selection (clear previous unless shift).
-            self._begin_marquee(point, event.GetPosition(), additive=event.ShiftDown())
+            self._marquee.begin(event.GetPosition(), additive=event.ShiftDown())
             return
 
         _pile_idx, _member_idx, entry = hit
@@ -672,11 +643,8 @@ class DeckPileView(wx.ScrolledWindow):
 
     def _on_motion(self, event: wx.MouseEvent) -> None:
         point = self._to_logical(event.GetPosition())
-        if self._rubber_start is not None:
-            self._rubber_end = point
-            self._select_within_rubber()
-            self._update_marquee_overlay()
-            self.Refresh()
+        if self._marquee.active:
+            self._marquee.update(event.GetPosition())
             return
 
         if self._drag_press and event.LeftIsDown():
@@ -704,17 +672,12 @@ class DeckPileView(wx.ScrolledWindow):
                 self.Refresh()
 
     def _on_left_up(self, event: wx.MouseEvent) -> None:
+        if self._marquee.active:
+            self._marquee.finish()
+            return
         if self.HasCapture():
             self.ReleaseMouse()
         point = self._to_logical(event.GetPosition())
-
-        if self._rubber_start is not None:
-            self._rubber_timer.Stop()
-            self._clear_marquee_overlay()
-            self._rubber_start = None
-            self._rubber_end = None
-            self.Refresh()
-            return
 
         if self._drag_active:
             self._drop_at(point)
@@ -738,45 +701,11 @@ class DeckPileView(wx.ScrolledWindow):
             self.Refresh()
 
     def _on_capture_lost(self, _event: wx.MouseCaptureLostEvent) -> None:
-        self._rubber_timer.Stop()
-        self._clear_marquee_overlay()
-        self._rubber_start = None
-        self._rubber_end = None
+        self._marquee.cancel()
         self._drag_active = False
         self._drag_press = None
         self._drag_uids = []
         self._drag_pos = None
-        self.Refresh()
-
-    def _on_rubber_timer(self, _event: wx.TimerEvent) -> None:
-        """Extend the active rubber-band toward the live cursor position.
-
-        Reading the global cursor (rather than relying on motion events, which
-        the OS stops sending once the pointer leaves the window) keeps the box
-        growing past the canvas edges and lets a held-at-the-edge drag scroll
-        the view so the whole canvas — not just the visible part — is reachable.
-        """
-        if self._rubber_start is None:
-            self._rubber_timer.Stop()
-            return
-        # If the button came up off-window we may have missed EVT_LEFT_UP; the
-        # marquee selection is already committed, so just stand down.
-        if not wx.GetMouseState().LeftIsDown():
-            self._rubber_timer.Stop()
-            self._clear_marquee_overlay()
-            if self.HasCapture():
-                self.ReleaseMouse()
-            self._rubber_start = None
-            self._rubber_end = None
-            self.Refresh()
-            return
-        client_pos = self.ScreenToClient(wx.GetMousePosition())
-        self._autoscroll_towards(client_pos)
-        # Recompute in logical space *after* any scroll so the endpoint tracks
-        # the content the cursor now sits over.
-        self._rubber_end = self._to_logical(client_pos)
-        self._select_within_rubber()
-        self._update_marquee_overlay()
         self.Refresh()
 
     def _autoscroll_towards(self, client_pos: wx.Point) -> None:
@@ -784,7 +713,7 @@ class DeckPileView(wx.ScrolledWindow):
         client_w, client_h = self.GetClientSize()
         view_x, view_y = self.GetViewStart()
         new_x, new_y = view_x, view_y
-        step = _RUBBER_AUTOSCROLL_PX
+        step = RUBBER_AUTOSCROLL_PX
         if client_pos.x < 0:
             new_x = max(0, view_x - step)
         elif client_pos.x > client_w:
@@ -798,15 +727,9 @@ class DeckPileView(wx.ScrolledWindow):
             self.Scroll(new_x, new_y)
 
     # ----- selection helpers -----
-    def _select_within_rubber(self) -> None:
-        if not (self._rubber_start and self._rubber_end):
-            return
-        rect = wx.Rect(self._rubber_start, self._rubber_end)
-        # wx.Rect with two points may have negative width/height; normalise.
-        x1, y1 = self._rubber_start
-        x2, y2 = self._rubber_end
-        rect = wx.Rect(min(x1, x2), min(y1, y2), abs(x2 - x1), abs(y2 - y1))
-        chosen: set[int] = set()
+    def _marquee_select(self, rect: wx.Rect) -> None:
+        """Select every copy the logical ``rect`` covers (union with base)."""
+        chosen: set[int] = set(self._marquee_base or ())
         for pile_idx, (_label, members) in enumerate(self._piles):
             total = len(members)
             for member_idx, entry in enumerate(members):
@@ -820,6 +743,7 @@ class DeckPileView(wx.ScrolledWindow):
         if chosen != self._selected_uids:
             self._selected_uids = chosen
             self._notify_selection_changed()
+            self.Refresh()
 
     def _notify_selection_changed(self) -> None:
         # The panel syncs the reported selection back into every view,

--- a/widgets/panels/card_table_panel/table_view.py
+++ b/widgets/panels/card_table_panel/table_view.py
@@ -28,6 +28,7 @@ import wx.grid as gridlib
 
 from utils.constants import DARK_ALT, DARK_BG, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
 from widgets.mana_icon_factory import ManaIconFactory
+from widgets.panels.card_table_panel.marquee import MarqueeController
 from widgets.panels.card_table_panel.sorting import (
     COL_COLOR,
     COL_MANA,
@@ -113,9 +114,15 @@ class DeckTableView(wx.Panel):
         self._rows: list[dict[str, Any]] = []  # cards in current display order
         self._sort_column: str = COL_NAME
         self._sort_descending: bool = False
-        self._selected_name: str | None = None
+        # Multi-selection by card name; a single click selects exactly one row,
+        # a marquee can select several. Native row selection renders the set.
+        self._selected_names: set[str] = set()
         self._hover_row: int = -1
         self._needs_autosize: bool = True
+        # Suppress the panel's set_selected() echo while we report our own
+        # (possibly multi-) selection, so an echoed None can't wipe the set.
+        self._suppress_set_selected: bool = False
+        self._marquee_base: set[str] | None = None
         # Natural widths populated by _autosize_columns; _fit_to_width starts
         # from these so resizing the panel wider re-expands the columns.
         self._natural_widths: dict[int, int] = {}
@@ -181,11 +188,25 @@ class DeckTableView(wx.Panel):
 
         sizer.Add(self.grid, 1, wx.EXPAND)
 
+        # Rubber-band selection lives on the grid's inner window (the surface the
+        # rows are drawn on and the one that carries the scroll offset).
+        grid_window = self.grid.GetGridWindow()
+        self._marquee = MarqueeController(
+            grid_window,
+            to_logical=self._to_logical,
+            on_begin=self._marquee_begin,
+            on_select=self._marquee_select,
+            on_finish=self._marquee_finish,
+        )
+
         self.grid.Bind(gridlib.EVT_GRID_LABEL_LEFT_CLICK, self._on_header_click)
         self.grid.Bind(gridlib.EVT_GRID_CELL_LEFT_CLICK, self._on_cell_click)
         self.grid.Bind(gridlib.EVT_GRID_SELECT_CELL, self._on_cell_select)
-        self.grid.GetGridWindow().Bind(wx.EVT_MOTION, self._on_grid_motion)
-        self.grid.GetGridWindow().Bind(wx.EVT_LEAVE_WINDOW, self._on_grid_leave)
+        grid_window.Bind(wx.EVT_LEFT_DOWN, self._on_grid_left_down)
+        grid_window.Bind(wx.EVT_LEFT_UP, self._on_grid_left_up)
+        grid_window.Bind(wx.EVT_MOTION, self._on_grid_motion)
+        grid_window.Bind(wx.EVT_LEAVE_WINDOW, self._on_grid_leave)
+        grid_window.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self._on_grid_capture_lost)
         self.Bind(wx.EVT_SIZE, self._on_panel_resize)
 
     # ----- public API consumed by CardTablePanel -----
@@ -196,11 +217,17 @@ class DeckTableView(wx.Panel):
         self._refresh()
 
     def set_selected(self, name: str | None) -> None:
-        self._selected_name = name
+        # Ignored while we broadcast our own selection (the panel echoes it back
+        # and a bare name can't represent a multi-select set).
+        if self._suppress_set_selected:
+            return
+        self._selected_names = {name} if name else set()
         self._apply_selection_highlight()
 
     def get_selected_name(self) -> str | None:
-        return self._selected_name
+        if len(self._selected_names) != 1:
+            return None
+        return next(iter(self._selected_names))
 
     # ----- internal helpers -----
     def _label(self, col_id: str) -> str:
@@ -338,13 +365,16 @@ class DeckTableView(wx.Panel):
 
     def _apply_selection_highlight(self) -> None:
         self.grid.ClearSelection()
-        if not self._selected_name:
+        if not self._selected_names:
             return
+        wanted = {n.lower() for n in self._selected_names}
+        first = True
         for idx, card in enumerate(self._rows):
-            if card["name"].lower() == self._selected_name.lower():
-                self.grid.SelectRow(idx)
-                self.grid.MakeCellVisible(idx, 0)
-                return
+            if card["name"].lower() in wanted:
+                self.grid.SelectRow(idx, addToSelected=not first)
+                if first:
+                    self.grid.MakeCellVisible(idx, 0)
+                    first = False
 
     # ----- event handlers -----
     def _on_header_click(self, event: gridlib.GridEvent) -> None:
@@ -369,14 +399,14 @@ class DeckTableView(wx.Panel):
         if event.GetCol() == _ACTIONS_COL:
             self._handle_action_click(row, card["name"], event.GetPosition())
             return
-        if self._selected_name and card["name"].lower() == self._selected_name.lower():
-            self._selected_name = None
+        if self._selected_names == {card["name"]}:
+            self._selected_names = set()
             self._apply_selection_highlight()
-            self._on_select(None)
+            self._notify_selection(None)
             return
-        self._selected_name = card["name"]
+        self._selected_names = {card["name"]}
         self._apply_selection_highlight()
-        self._on_select(card)
+        self._notify_selection(card)
 
     def _handle_action_click(self, row: int, name: str, pos: wx.Point) -> None:
         # Convert the event position (device coords on the grid window) into an
@@ -400,7 +430,10 @@ class DeckTableView(wx.Panel):
         event.Veto()
 
     def _on_grid_motion(self, event: wx.MouseEvent) -> None:
-        if self._selected_name or self._on_hover is None:
+        if self._marquee.active:
+            self._marquee.update(event.GetPosition())
+            return
+        if self._selected_names or self._on_hover is None:
             event.Skip()
             return
         x, y = self.grid.CalcUnscrolledPosition(event.GetPosition())
@@ -416,3 +449,73 @@ class DeckTableView(wx.Panel):
     def _on_grid_leave(self, event: wx.MouseEvent) -> None:
         self._hover_row = -1
         event.Skip()
+
+    # ----- rubber-band marquee -----
+    def begin_marquee_at_screen(self, screen_point: wx.Point) -> None:
+        """Start a marquee from anywhere in the app (e.g. the frame background)."""
+        self._marquee.begin_at_screen(screen_point)
+
+    def _on_grid_left_down(self, event: wx.MouseEvent) -> None:
+        # A press on a real row is left to the grid (cell-click selection); a
+        # press on the empty area below the rows starts a marquee instead.
+        _x, y = self.grid.CalcUnscrolledPosition(event.GetPosition())
+        row = self.grid.YToRow(y)
+        if row == wx.NOT_FOUND or not (0 <= row < len(self._rows)):
+            self._marquee.begin(event.GetPosition(), additive=event.ShiftDown())
+            return
+        event.Skip()
+
+    def _on_grid_left_up(self, event: wx.MouseEvent) -> None:
+        if self._marquee.active:
+            self._marquee.finish()
+            return
+        event.Skip()
+
+    def _on_grid_capture_lost(self, _event: wx.MouseCaptureLostEvent) -> None:
+        self._marquee.cancel()
+
+    def _to_logical(self, client_point: wx.Point) -> wx.Point:
+        x, y = self.grid.CalcUnscrolledPosition(client_point)
+        return wx.Point(x, y)
+
+    def _marquee_begin(self, additive: bool) -> None:
+        if not additive and self._selected_names:
+            self._selected_names = set()
+            self._apply_selection_highlight()
+            self._notify_selection(None)
+        self._marquee_base = set(self._selected_names)
+
+    def _marquee_select(self, rect: wx.Rect) -> None:
+        chosen: set[str] = set(self._marquee_base or ())
+        for idx, card in enumerate(self._rows):
+            row_rect = self.grid.CellToRect(idx, 0)
+            # Full-row selection: a row is in the box when their vertical spans
+            # overlap (the horizontal position within the row is irrelevant).
+            if rect.GetTop() <= row_rect.GetBottom() and rect.GetBottom() >= row_rect.GetTop():
+                chosen.add(card["name"])
+        if chosen != self._selected_names:
+            self._selected_names = chosen
+            self._apply_selection_highlight()
+            # One row chosen reports that card; several (or none) report None so
+            # the inspector falls back to hover, mirroring the other views.
+            if len(chosen) == 1:
+                self._notify_selection(self._card_for(next(iter(chosen))))
+            else:
+                self._notify_selection(None)
+
+    def _marquee_finish(self) -> None:
+        self._marquee_base = None
+
+    def _card_for(self, name: str) -> dict[str, Any] | None:
+        for card in self._rows:
+            if card["name"] == name:
+                return card
+        return None
+
+    def _notify_selection(self, card: dict[str, Any] | None) -> None:
+        """Report selection to the panel, guarding the set_selected echo."""
+        self._suppress_set_selected = True
+        try:
+            self._on_select(card)
+        finally:
+            self._suppress_set_selected = False


### PR DESCRIPTION
## What & why

The rubber-band (marquee) selection lived entirely inside the pile view, and the "draw a box from the background" gesture was wired with two ad-hoc `EVT_LEFT_DOWN` binds on the root/right panels. Because mouse-down events don't bubble in wx, those binds only fired when a press landed *exactly* on one of two container windows — every nested non-interactive child panel swallowed the click, so almost no zone in the left panel could start a marquee. This reworks marquee selection to be shared by all three views and startable from any non-interactive surface.

## Changes

**Shared machinery — `widgets/panels/card_table_panel/marquee.py` (new)**
- `MarqueeController` owns the view-agnostic mechanics: mouse capture, the cursor-polling timer (so the box grows past the window edge), the app-level outline overlay, and auto-scroll. A view supplies `to_logical` / `on_begin` / `on_select` / `on_finish` (+ optional `autoscroll`) and otherwise just forwards its mouse events.
- Opt-in surface marker: `mark_marquee_surface` / `is_marquee_surface` / `mark_marquee_surfaces_recursively`. The recursive sweep marks only vanilla `wx.Panel` / `wx.StaticText` / `wx.StaticLine` (exact type), so controls and the custom view canvases are excluded.

**Pile view** — refactored onto `MarqueeController`; behaviour preserved. Shift-additive marquee now correctly unions with the prior selection (previously a latent no-op).

**Grid & table views** — gained marquee multi-select. Selection becomes a set of card names (`_selected_names`); a single click still selects exactly one, a marquee can select several, and the highlight covers the whole set. A multi-select reports `None` to the inspector (hover wins), mirroring the pile view; a `set_selected` suppress-guard stops the panel's name echo from wiping a multi-select. The table starts a marquee from the empty area below its rows (and from any marked chrome); grid/pile start from any empty canvas space.

**App wiring**
- `MetagameWxApp.FilterEvent` (`main.py`): on a left-press whose target is a marked surface, routes to the active view's marquee. Returns `-1` always — it only *adds* the marquee start, never consumes the press, so controls and the canvases keep working. (Confirmed via probe that this wx build delivers mouse events to `FilterEvent`.)
- `AppFrame.begin_active_marquee` replaces `_on_background_marquee_down`; the "pile view must be the active tab" condition is dropped — the deck table panel is always on, so it picks whichever view is showing. The two ad-hoc binds are removed; surfaces are marked once after the UI is built.
- `CardTablePanel.active_view` + `begin_marquee_at_screen`.

## Tests
- New `tests/ui/test_marquee_selection.py`: surface markers (type filtering), controller begin/update/finish lifecycle, and grid/table rectangle selection (incl. additive union).
- `tests/ui/test_pile_view_selection.py` updated to the controller-based internals.
- Full suite green (1454 passed, 5 pre-existing skips); ruff + black clean.

## Verification
- Unit tests cover per-view selection logic, the controller, and the markers.
- Live smoke: app launches cleanly with all the new wiring (FilterEvent install, recursive surface marking, imports), loads a deck, and renders. The actual drag gesture isn't scriptable through the automation harness (no mouse-drag command), so **live marquee behaviour in each view is worth a manual pass** before merge — hence draft.

## Notes / follow-ups
- Surfaces are marked once after build; dynamically-rebuilt chrome subtrees would need re-marking, but the chrome is static today.
- Table marquee selects rows by vertical overlap (full-row, x ignored) and has no auto-scroll past the viewport edge yet (pile/grid do). This is the marquee slice of the larger #779/#780 work (drag-to-reorder is still separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
