### PR TITLE
feat(layout): leftover width to deck workspace + dynamic grid columns (#785)

### DIFF
--- a/widgets/frames/app_frame/frame/__init__.py
+++ b/widgets/frames/app_frame/frame/__init__.py
@@ -191,8 +191,12 @@ class AppFrame(
         content_split = wx.BoxSizer(wx.HORIZONTAL)
         right_sizer.Add(content_split, 1, wx.EXPAND | wx.BOTTOM, PADDING_LG)
 
+        # The deck workspace takes all leftover horizontal space (proportion 1)
+        # so a wider window grows the workspace — and the grid view fits more
+        # cards per row — rather than leaving empty background (issue #785). The
+        # inspector column stays at its natural width (proportion 0).
         deck_workspace = self._build_deck_workspace(right_panel)
-        content_split.Add(deck_workspace, 0, wx.EXPAND | wx.RIGHT, PADDING_LG)
+        content_split.Add(deck_workspace, 1, wx.EXPAND | wx.RIGHT, PADDING_LG)
 
         inspector_column = wx.BoxSizer(wx.VERTICAL)
         content_split.Add(inspector_column, 0, wx.EXPAND)

--- a/widgets/frames/app_frame/frame/center_panel.py
+++ b/widgets/frames/app_frame/frame/center_panel.py
@@ -67,12 +67,15 @@ class CenterPanelBuilderMixin(_Base):
 
         # Mainboard and Sideboard as top-level tabs
         self._build_deck_tables_tab()
+        # The workspace keeps a *minimum* width that fits GRID_COLUMNS cards
+        # across, but is no longer locked to it (issue #785): all leftover
+        # horizontal space is given to the workspace (see `_build_right_container`
+        # where it is added with a stretch proportion), and each card view fits
+        # as many cards per row as the allotted width allows — the grid view
+        # recomputes its column count on resize.
         deck_tabs_width = CardTablePanel.grid_width()
         self.deck_tabs.SetMinSize((deck_tabs_width, -1))
-        self.deck_tabs.SetMaxSize((deck_tabs_width, -1))
-        detail_box_width = deck_tabs_width + (PADDING_MD * 2)
-        detail_box.SetMinSize((detail_box_width, -1))
-        detail_box.SetMaxSize((detail_box_width, -1))
+        detail_box.SetMinSize((deck_tabs_width + (PADDING_MD * 2), -1))
 
         # Collection status label below the tabs
         self.collection_status_label = wx.StaticText(


### PR DESCRIPTION
## Summary

The deck workspace (central panel) now takes **all leftover horizontal space**, and the grid view fits **as many cards per row as the width allows**. Closes #785.

Previously the workspace was locked to exactly `GRID_COLUMNS` (4) cards wide via a `min == max` size on the tabs/box, so a wide window left a large empty background to the right of the deck.

## Changes
- **Drop the maximum-width lock** in `center_panel.py`; keep only the minimum (still fits 4 cards across) so the window can't shrink below a usable size.
- Add the workspace to the content split with a **stretch proportion (1)** in `frame/__init__.py` so leftover width flows to it; the inspector column keeps its natural width.
- The grid view **already** recomputes its column count from the client width on resize, adding/removing a column only when the width crosses a card-width boundary (exactly the "increments" behaviour the issue asks for) — no change needed there.

## Verification
Launched the app at 1984px wide via the automation harness: the grid now fills the workspace with **~8 columns** instead of 4-with-empty-space. `ruff`/`black`/`py_compile` clean.

![workspace fills width]

## PR series (stacked)
Targets **#779** (`feat/779-table-drag-reorder`). Series for #777: #780 → #779 → **#785** → #781 → #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)