### PR TITLE
ci(reports): install d2 so dependency-diagram SVGs render on automated/reports

### DIFF
--- a/.github/workflows/refresh-reports.yml
+++ b/.github/workflows/refresh-reports.yml
@@ -51,6 +51,12 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install d2 (renders the dependency-diagram SVGs)
+        # Without d2 on PATH, generate_dependency_diagrams.py silently skips SVG
+        # rendering and emits only graph.json, so the published reports branch
+        # would carry no rendered diagrams. Install it so the SVGs are produced.
+        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
+
       - name: Publish regenerated reports to the single reports branch
         run: |
           set -euo pipefail


### PR DESCRIPTION
Follow-up to #795.

`scripts/generate_dependency_diagrams.py` skips SVG rendering when the `d2` binary isn't on PATH — it writes `graph.json` and exits 0. The refresh workflow never installed `d2`, so the rendered SVGs only ever survived as a frozen copy committed in `main`. Now that #795 removed them from `main` and the reports branch is rebuilt from `main` each run, the SVGs vanished (the latest run published `graph.json` only).

This adds a `d2` install step (the exact command the generator itself recommends) so `dependencies_level_1.svg` and `dependencies_level_2.svg` are rendered and published on `automated/reports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)