### PR TITLE
MTGO smoke test: fix collection export + bridge robustness, add harness commands

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -75,6 +75,45 @@ python -m automation.cli screenshot-window match_history --path screenshots/hist
 
 `screenshot-window` returns an error if the named window is not currently open.
 
+## Exercising MTGO bridge features
+
+These commands drive the live MTGO bridge integration end-to-end (they require a
+built `MTGOBridge.exe` and a running, logged-in MTGO client — see
+`dotnet/MTGOBridge/README.md`).
+
+### Collection export
+
+`refresh-collection` runs the same path as the **Load Collection** toolbar menu
+item: it fetches a fresh collection snapshot from the bridge on a background
+thread and writes a `collection_full_trade_*.json` export into the deck save
+directory. The command returns immediately with the resolved `save_dir`; poll
+that directory (and `status`) for the result.
+
+```bash
+python -m automation.cli --json refresh-collection
+# {"triggered": true, "save_dir": "C:\\Users\\you\\Documents\\mtgo_decks"}
+python -m automation.cli status   # "Fetching collection from MTGO..." -> success/fail
+```
+
+Use `--no-force` to honour the cache freshness window instead of forcing a fetch.
+
+### Timer alert
+
+Open the window first, then drive it. `start`/`stop` toggle threshold
+monitoring (which streams challenge timers from the bridge `watch` mode);
+`test` plays the configured alert sound.
+
+```bash
+python -m automation.cli open-widget timer_alert
+python -m automation.cli timer-alert-action test    # play the alert sound
+python -m automation.cli timer-alert-action start   # begin monitoring
+python -m automation.cli timer-alert-action stop
+```
+
+> Note: each bridge invocation pays a one-time-per-MTGO-session cold attach
+> (~2-3 min) while MTGOSDK injects its diagnostic server into the MTGO client;
+> subsequent calls in the same MTGO session are fast.
+
 ## Video capture (recording a transition)
 
 `start-video` / `stop-video` record the main window on a **background thread**,

--- a/automation/cli.py
+++ b/automation/cli.py
@@ -285,6 +285,20 @@ def cmd_open_widget(client: AutomationClient, args: argparse.Namespace) -> int:
     return 0 if result.get("opened") else 1
 
 
+def cmd_refresh_collection(client: AutomationClient, args: argparse.Namespace) -> int:
+    """Trigger a collection refresh + export from the MTGO bridge."""
+    result = client.refresh_collection(force=not args.no_force)
+    print(format_output(result, args.json))
+    return 0 if result.get("triggered") else 1
+
+
+def cmd_timer_alert_action(client: AutomationClient, args: argparse.Namespace) -> int:
+    """Drive the open Timer Alert window (start/stop/test)."""
+    result = client.timer_alert_action(args.action)
+    print(format_output(result, args.json))
+    return 0 if result.get("ok") else 1
+
+
 def cmd_get_deck_notes(client: AutomationClient, args: argparse.Namespace) -> int:
     """Get the current deck notes cards."""
     result = client.get_deck_notes()
@@ -496,6 +510,24 @@ Notes:
     # get-builder-results
     subparsers.add_parser("get-builder-results", help="Get builder search result count")
 
+    # refresh-collection
+    p = subparsers.add_parser(
+        "refresh-collection",
+        help="Trigger a collection refresh + export from the MTGO bridge",
+    )
+    p.add_argument(
+        "--no-force",
+        action="store_true",
+        help="Honor the cache freshness window instead of forcing a fetch",
+    )
+
+    # timer-alert-action
+    p = subparsers.add_parser(
+        "timer-alert-action",
+        help="Drive the open Timer Alert window (start/stop/test)",
+    )
+    p.add_argument("action", choices=["start", "stop", "test"], help="Action to perform")
+
     # open-widget
     p = subparsers.add_parser("open-widget", help="Open a widget window")
     p.add_argument(
@@ -621,6 +653,8 @@ Notes:
         "get-scroll-pos": cmd_get_scroll_pos,
         "get-builder-results": cmd_get_builder_results,
         "get-builder-top-item": cmd_get_builder_top_item,
+        "refresh-collection": cmd_refresh_collection,
+        "timer-alert-action": cmd_timer_alert_action,
         "open-widget": cmd_open_widget,
         "screenshot-window": cmd_screenshot_window,
         "get-deck-notes": cmd_get_deck_notes,

--- a/automation/client.py
+++ b/automation/client.py
@@ -306,6 +306,19 @@ class AutomationClient:
         """
         return self._send_command("open_widget", widget_name=widget_name)
 
+    def refresh_collection(self, force: bool = True) -> dict[str, Any]:
+        """Trigger a collection refresh + export from the MTGO bridge.
+
+        Drives the real ``refresh_collection_from_bridge`` controller path (background
+        fetch + ``collection_full_trade_*.json`` export). Returns immediately with the
+        resolved ``save_dir``; poll that directory and ``get_status`` for the result.
+        """
+        return self._send_command("refresh_collection", force=force)
+
+    def timer_alert_action(self, action: str) -> dict[str, Any]:
+        """Drive the open Timer Alert window: 'start', 'stop', or 'test'."""
+        return self._send_command("timer_alert_action", action=action)
+
     def get_card_images_loaded(self, zone: str = "main") -> dict[str, Any]:
         """Count how many card panels in a zone have loaded card face images.
 

--- a/automation/server/__init__.py
+++ b/automation/server/__init__.py
@@ -99,6 +99,8 @@ class AutomationServer(
             "get_builder_top_item": self._handle_get_builder_top_item,
             "scroll_builder_results": self._handle_scroll_builder_results,
             "open_widget": self._handle_open_widget,
+            "refresh_collection": self._handle_refresh_collection,
+            "timer_alert_action": self._handle_timer_alert_action,
             "get_card_images_loaded": self._handle_get_card_images_loaded,
             "get_deck_notes": self._handle_get_deck_notes,
             "set_current_deck": self._handle_set_current_deck,

--- a/automation/server/introspection.py
+++ b/automation/server/introspection.py
@@ -179,6 +179,41 @@ class IntrospectionMixin(_Base):
         method()
         return {"opened": True, "widget": widget_name}
 
+    def _handle_refresh_collection(self, force: bool = True) -> dict[str, Any]:
+        """Trigger a collection refresh + export through the real controller path.
+
+        Drives ``AppController.refresh_collection_from_bridge`` (the same code the
+        "Load Collection" toolbar menu item runs), which fetches a snapshot from the
+        MTGO bridge on a background thread and writes a ``collection_full_trade_*.json``
+        export into the deck save directory. Returns immediately; poll ``save_dir`` for
+        the new file and ``get_status`` for the success/failure message.
+        """
+        controller = getattr(self.frame, "controller", None)
+        if controller is None:
+            return {"triggered": False, "error": "Controller not available"}
+        save_dir = getattr(controller, "deck_save_dir", None)
+        controller.refresh_collection_from_bridge(force=force)
+        return {"triggered": True, "save_dir": str(save_dir) if save_dir else None}
+
+    def _handle_timer_alert_action(self, action: str) -> dict[str, Any]:
+        """Drive the open Timer Alert window (start/stop monitoring, test alert)."""
+        win = getattr(self.frame, "timer_window", None)
+        if win is None:
+            return {"ok": False, "error": "Timer alert window is not open"}
+        method_name = {
+            "start": "start_monitoring",
+            "stop": "stop_monitoring",
+            "test": "test_alert",
+        }.get(action)
+        if method_name is None:
+            return {"ok": False, "error": f"Unknown action: {action}"}
+        method = getattr(win, method_name, None)
+        if method is None:
+            return {"ok": False, "error": f"Method not found: {method_name}"}
+        method()
+        status = win.status_text.GetValue() if hasattr(win, "status_text") else None
+        return {"ok": True, "action": action, "status": status}
+
     def _handle_close_app(self) -> dict[str, Any]:
         """Close the application after sending the response."""
         # Schedule Close on the next event-loop iteration so the response is

--- a/dotnet/MTGOBridge/Program.cs
+++ b/dotnet/MTGOBridge/Program.cs
@@ -695,9 +695,13 @@ static async Task RunWatchLoopAsync(
         cts.Cancel();
     };
 
-    // MTGOSDK shares a single remoting channel, so the two loops must never call
-    // it concurrently. The fast loop grabs this without blocking and skips its SDK
-    // read (reusing the cached timers) whenever the slow currency scan holds it.
+    // The SDK transport is concurrency-safe, but reads are marshalled onto MTGO's
+    // UI thread server-side, so a long currency scan blocks timer reads anyway
+    // (measured: a concurrent scan stalls the timer loop entirely). The lock keeps
+    // the timer loop responsive instead — it grabs the lock without blocking and
+    // reuses cached timers if the (rare, idle-only) currency scan holds it. The
+    // currency loop additionally pauses while a timer is active, so in steady state
+    // during an event the two never contend.
     using var sdkLock = new SemaphoreSlim(1, 1);
     var cache = new WatchCache();
 
@@ -755,6 +759,7 @@ static async Task RunChallengeTimerLoopAsync(
             try
             {
                 cache.Timers = GetChallengeTimers();
+                cache.HasActiveTimer = cache.Timers.Count > 0;
             }
             catch (Exception ex)
             {
@@ -809,6 +814,9 @@ static async Task RunCurrencyRefreshLoopAsync(
     TimeSpan interval,
     CancellationToken ct)
 {
+    // How often to re-check the active-timer flag while paused.
+    var pausePoll = TimeSpan.FromSeconds(5);
+
     // Let the timer loop take (and warm) the SDK first so its initial reading
     // isn't queued behind a full currency scan.
     try
@@ -822,6 +830,23 @@ static async Task RunCurrencyRefreshLoopAsync(
 
     while (!ct.IsCancellationRequested)
     {
+        // Pause while a challenge timer is being tracked. A currency scan blocks
+        // the timer's reads on MTGO's UI thread (concurrent SDK calls don't help —
+        // they queue server-side), so we simply don't scan while an event is live.
+        // Resume once no timer is active.
+        if (cache.HasActiveTimer)
+        {
+            try
+            {
+                await Task.Delay(pausePoll, ct);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+            continue;
+        }
+
         await sdkLock.WaitAsync(ct);
         try
         {
@@ -1274,6 +1299,7 @@ sealed class WatchCache
     private volatile IReadOnlyList<ChallengeTimerSnapshot> _timers =
         Array.Empty<ChallengeTimerSnapshot>();
     private volatile CurrencySnapshot? _currency;
+    private volatile bool _hasActiveTimer;
     private readonly TaskCompletionSource _primed =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -1281,6 +1307,16 @@ sealed class WatchCache
     {
         get => _timers;
         set => _timers = value;
+    }
+
+    // True while at least one challenge timer is being tracked. The currency loop
+    // watches this and pauses: the SDK serialises reads on MTGO's UI thread, so a
+    // multi-second currency scan would otherwise block fresh timer reads. Pausing
+    // gives the timer exclusive, uninterrupted access whenever an event is live.
+    public bool HasActiveTimer
+    {
+        get => _hasActiveTimer;
+        set => _hasActiveTimer = value;
     }
 
     public CurrencySnapshot? Currency

--- a/dotnet/MTGOBridge/Program.cs
+++ b/dotnet/MTGOBridge/Program.cs
@@ -675,9 +675,17 @@ static T SafeGet<T>(object? target, string propertyName, T defaultValue = defaul
     }
 }
 
-static async Task RunWatchLoopAsync(JsonSerializerOptions options, TimeSpan? interval = null)
+static async Task RunWatchLoopAsync(
+    JsonSerializerOptions options,
+    TimeSpan? timerInterval = null,
+    TimeSpan? currencyInterval = null)
 {
-    interval ??= TimeSpan.FromMilliseconds(500);
+    // The challenge-timer read is cheap and needs second-level freshness; the
+    // currency read scans the whole frozen collection (seconds, remote) and
+    // changes slowly — leagues run well over an hour — so the two are split into
+    // independent loops at very different cadences instead of one combined tick.
+    timerInterval ??= TimeSpan.FromMilliseconds(500);
+    currencyInterval ??= TimeSpan.FromMinutes(10);
     Console.OutputEncoding = Encoding.UTF8;
 
     using var cts = new CancellationTokenSource();
@@ -687,41 +695,150 @@ static async Task RunWatchLoopAsync(JsonSerializerOptions options, TimeSpan? int
         cts.Cancel();
     };
 
-    while (!cts.IsCancellationRequested)
+    // MTGOSDK shares a single remoting channel, so the two loops must never call
+    // it concurrently. The fast loop grabs this without blocking and skips its SDK
+    // read (reusing the cached timers) whenever the slow currency scan holds it.
+    using var sdkLock = new SemaphoreSlim(1, 1);
+    var cache = new WatchCache();
+
+    // Task.Run so each loop gets its own thread: the SDK reads are synchronous
+    // blocking calls, and SemaphoreSlim.WaitAsync completes synchronously on a
+    // free lock, so without this the first loop would run inline (through its
+    // slow first scan) before the second ever started.
+    var currencyTask = Task.Run(
+        () => RunCurrencyRefreshLoopAsync(sdkLock, cache, currencyInterval.Value, cts.Token),
+        cts.Token);
+    var timerTask = Task.Run(
+        () => RunChallengeTimerLoopAsync(options, sdkLock, cache, timerInterval.Value, cts.Token),
+        cts.Token);
+
+    try
     {
-        WatchSnapshot snapshot;
+        // If either loop exits (cancellation or fatal error), tear the other down.
+        await Task.WhenAny(currencyTask, timerTask);
+    }
+    finally
+    {
+        cts.Cancel();
         try
         {
-            var timers = GetChallengeTimers();
-            var currency = GetCurrencySnapshot();
-            snapshot = new WatchSnapshot(DateTimeOffset.UtcNow, timers, currency, null);
+            await Task.WhenAll(currencyTask, timerTask);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on shutdown.
+        }
+    }
+}
+
+// Drives output cadence. Emits one snapshot per tick carrying fresh challenge
+// timers plus the most recently cached currency. Uses a non-blocking lock
+// acquisition so a long currency scan never stalls timer output: if the lock is
+// busy it reuses the previous timer reading for that tick.
+static async Task RunChallengeTimerLoopAsync(
+    JsonSerializerOptions options,
+    SemaphoreSlim sdkLock,
+    WatchCache cache,
+    TimeSpan interval,
+    CancellationToken ct)
+{
+    var primed = false;
+    while (!ct.IsCancellationRequested)
+    {
+        string? error = null;
+        // Until the first reading lands, block for the lock so the timer loop owns
+        // the cold attach; afterwards use a non-blocking grab so the periodic
+        // currency scan can never stall timer output (it reuses cached timers).
+        var gotLock = primed ? await sdkLock.WaitAsync(0, ct) : await TryAcquireAsync(sdkLock, ct);
+        if (gotLock)
+        {
+            try
+            {
+                cache.Timers = GetChallengeTimers();
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+            }
+            finally
+            {
+                // Prime after the first acquired attempt (success or failure) so
+                // the cold attach is paid here and the currency loop can proceed.
+                if (!primed)
+                {
+                    primed = true;
+                    cache.MarkPrimed();
+                }
+                sdkLock.Release();
+            }
+        }
+
+        var snapshot = new WatchSnapshot(DateTimeOffset.UtcNow, cache.Timers, cache.Currency, error);
+        Console.WriteLine(JsonSerializer.Serialize(snapshot, options));
+
+        try
+        {
+            await Task.Delay(interval, ct);
+        }
+        catch (TaskCanceledException)
+        {
+            break;
+        }
+    }
+}
+
+// Blocking lock acquisition that reports cancellation as a bool instead of throwing.
+static async Task<bool> TryAcquireAsync(SemaphoreSlim sdkLock, CancellationToken ct)
+{
+    try
+    {
+        await sdkLock.WaitAsync(ct);
+        return true;
+    }
+    catch (OperationCanceledException)
+    {
+        return false;
+    }
+}
+
+// Refreshes the cached currency on a coarse cadence. Holds the SDK lock for the
+// duration of the (slow) scan; the timer loop keeps emitting meanwhile.
+static async Task RunCurrencyRefreshLoopAsync(
+    SemaphoreSlim sdkLock,
+    WatchCache cache,
+    TimeSpan interval,
+    CancellationToken ct)
+{
+    // Let the timer loop take (and warm) the SDK first so its initial reading
+    // isn't queued behind a full currency scan.
+    try
+    {
+        await cache.Primed.WaitAsync(ct);
+    }
+    catch (OperationCanceledException)
+    {
+        return;
+    }
+
+    while (!ct.IsCancellationRequested)
+    {
+        await sdkLock.WaitAsync(ct);
+        try
+        {
+            cache.Currency = GetCurrencySnapshot();
         }
         catch (Exception ex)
         {
-            CurrencySnapshot fallbackCurrency;
-            try
-            {
-                fallbackCurrency = GetCurrencySnapshot();
-            }
-            catch (Exception innerEx)
-            {
-                fallbackCurrency = new CurrencySnapshot(null, null, null, innerEx.Message);
-            }
-
-            snapshot = new WatchSnapshot(
-                DateTimeOffset.UtcNow,
-                Array.Empty<ChallengeTimerSnapshot>(),
-                fallbackCurrency,
-                ex.Message
-            );
+            cache.Currency = new CurrencySnapshot(null, null, null, ex.Message);
         }
-
-        var line = JsonSerializer.Serialize(snapshot, options);
-        Console.WriteLine(line);
+        finally
+        {
+            sdkLock.Release();
+        }
 
         try
         {
-            await Task.Delay(interval.Value, cts.Token);
+            await Task.Delay(interval, ct);
         }
         catch (TaskCanceledException)
         {
@@ -1148,6 +1265,37 @@ public sealed record WatchSnapshot(
     CurrencySnapshot? Currency,
     string? Error
 );
+
+// Shared between the watch loops: the timer loop publishes fresh timers and reads
+// the currency the currency loop publishes. Fields are volatile because the loops
+// run on different tasks; record/list references are assigned atomically.
+sealed class WatchCache
+{
+    private volatile IReadOnlyList<ChallengeTimerSnapshot> _timers =
+        Array.Empty<ChallengeTimerSnapshot>();
+    private volatile CurrencySnapshot? _currency;
+    private readonly TaskCompletionSource _primed =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public IReadOnlyList<ChallengeTimerSnapshot> Timers
+    {
+        get => _timers;
+        set => _timers = value;
+    }
+
+    public CurrencySnapshot? Currency
+    {
+        get => _currency;
+        set => _currency = value;
+    }
+
+    // Completes once the timer loop has taken its first SDK reading. The currency
+    // loop waits on this so the (slow, cold) initial SDK attach is paid by the
+    // priority timer read instead of the currency scan monopolising startup.
+    public Task Primed => _primed.Task;
+
+    public void MarkPrimed() => _primed.TrySetResult();
+}
 
 public sealed record CollectionCard(int Id, string Name, int Quantity);
 

--- a/dotnet/MTGOBridge/Program.cs
+++ b/dotnet/MTGOBridge/Program.cs
@@ -309,24 +309,31 @@ static CurrencySnapshot GetCurrencySnapshot()
 static HistorySnapshot GetHistorySnapshot()
 {
     bool historyLoaded = false;
-    string? error = null;
 
-    // ReadGameHistory() returns the full list - use it directly instead of accessing .Items!
-    var rawItems = HistoryManager.ReadGameHistory();
-    if (rawItems == null)
+    // ReadGameHistory() can throw from inside MTGOSDK (e.g. a RuntimeBinderException
+    // when the remote dynamic type drifts from the SDK's expectations). Guard it so a
+    // single failing snapshot returns a structured error instead of crashing the whole
+    // process and corrupting the JSON contract the Python side parses.
+    try
     {
-        return new HistorySnapshot(historyLoaded, Array.Empty<HistoryEntry>(), "History items is null");
-    }
+        // ReadGameHistory() returns the full list - use it directly instead of accessing .Items!
+        var rawItems = HistoryManager.ReadGameHistory();
+        if (rawItems == null)
+        {
+            return new HistorySnapshot(historyLoaded, Array.Empty<HistoryEntry>(), "History items is null");
+        }
 
-    // Process in parallel - each MapHistoryItem call uses reflection anyway
-    // so parallelizing this should give a good speedup
-    var items = rawItems
-        .Select(item => MapHistoryItem(item))
-        .Where(entry => entry != null)
-        .Cast<HistoryEntry>()
-        .ToList();
-    foreach(var item in rawItems) Console.WriteLine(item.GetType().Name);
-    return new HistorySnapshot(historyLoaded, items, error);
+        var items = rawItems
+            .Select(item => MapHistoryItem(item))
+            .Where(entry => entry != null)
+            .Cast<HistoryEntry>()
+            .ToList();
+        return new HistorySnapshot(historyLoaded, items, null);
+    }
+    catch (Exception ex)
+    {
+        return new HistorySnapshot(historyLoaded, Array.Empty<HistoryEntry>(), ex.Message);
+    }
 }
 
 static HistoryEntry? MapHistoryItem(object? item)

--- a/services/collection_service/bridge_refresh.py
+++ b/services/collection_service/bridge_refresh.py
@@ -70,7 +70,10 @@ class BridgeRefreshMixin(_Base):
                         on_error("Bridge returned empty collection")
                     return
 
-                cards = collection_data.get("cards", [])
+                # The bridge snapshot exposes the card list under "items"
+                # (C# CollectionSnapshot.Items); keep "cards" as a fallback for
+                # any legacy/alternate payload shape.
+                cards = collection_data.get("items") or collection_data.get("cards") or []
                 if not cards:
                     if on_error:
                         on_error("No cards in collection data")

--- a/tests/test_collection_service.py
+++ b/tests/test_collection_service.py
@@ -734,6 +734,34 @@ def test_refresh_from_bridge_force_exports_and_succeeds(collection_service, tmp_
     assert "collection_full_trade_" in saved_path.name
 
 
+def test_refresh_from_bridge_items_shape_exports_and_succeeds(collection_service, tmp_path):
+    """The real bridge snapshot exposes cards under "items" (CollectionSnapshot.Items).
+
+    Regression for the key mismatch where the worker read "cards" while
+    ``get_collection_snapshot`` returns the collection dict keyed by "items",
+    causing a full snapshot to be discarded as "No cards in collection data".
+    """
+    cards = [{"id": 12, "name": "Birds of Paradise", "quantity": 1}]
+    fetch = Mock(return_value={"id": 0, "name": "Collection", "items": cards})
+    successes: list[tuple] = []
+    errors: list[str] = []
+
+    _run_refresh_and_wait(
+        collection_service,
+        tmp_path,
+        force=True,
+        on_success=lambda path, c: successes.append((path, c)),
+        on_error=errors.append,
+        fetch_collection=fetch,
+    )
+
+    assert errors == []
+    assert len(successes) == 1
+    saved_path, saved_cards = successes[0]
+    assert saved_cards == cards
+    assert saved_path.exists()
+
+
 def test_refresh_from_bridge_empty_collection_routes_to_error(collection_service, tmp_path):
     """An empty dict from the bridge routes to on_error."""
     fetch = Mock(return_value={})

--- a/tests/test_mtgo_bridge_client.py
+++ b/tests/test_mtgo_bridge_client.py
@@ -10,6 +10,7 @@ import pytest
 
 from services.mtgo_bridge_service import client as mtgo_bridge_client
 from services.mtgo_bridge_service import commands as bridge_commands
+from services.mtgo_bridge_service import discovery as bridge_discovery
 from services.mtgo_bridge_service import watch as bridge_watch
 
 
@@ -59,7 +60,10 @@ def test_resolve_bridge_env_missing_file_falls_back(monkeypatch, tmp_path: Path)
     # the default candidates. With no candidates available, returns None.
     missing = tmp_path / "does_not_exist.exe"
     monkeypatch.setenv("MTGO_BRIDGE_PATH", str(missing))
-    monkeypatch.setattr(mtgo_bridge_client, "_default_bridge_candidates", lambda: [])
+    # _resolve_bridge_path lives in the discovery module and reads that module's
+    # own _default_bridge_candidates global, so the patch must target discovery
+    # (patching the client re-export has no effect once the bridge is built on disk).
+    monkeypatch.setattr(bridge_discovery, "_default_bridge_candidates", lambda: [])
     assert mtgo_bridge_client._resolve_bridge_path(None) is None
 
 


### PR DESCRIPTION
## Why

Ground-up smoke test of MTGO functionality after the dev machine's OS reinstall. The .NET/MTGOSDK bridge and toolchain were entirely missing; I rebuilt them, confirmed live SDK access against a running MTGO client, and drove the **timer alert** + **collection export** features through the automation harness. That surfaced three real bugs plus a watch-loop performance overhaul.

## Bugs fixed

1. **Collection export was fully broken.** The bridge snapshot exposes its card list under `items` (C# `CollectionSnapshot.Items`), but the refresh worker read `cards`, discarding every snapshot as *"No cards in collection data"*. Now reads `items` (with a `cards` fallback). Verified end-to-end: a **2,257-entry export** writes from the live client.
2. **`history` crashed the whole bridge process.** An unguarded `ReadGameHistory` (RuntimeBinderException inside MTGOSDK) plus a leftover debug `Console.WriteLine` that polluted the JSON stdout contract. Wrapped in try/catch to return a structured error like every other snapshot method.
3. **A test only passed because no bridge exe existed.** `test_resolve_bridge_env_missing_file_falls_back` patched the candidate lookup on the wrong module; fixed to patch `discovery`.

## Watch loop overhaul (timer responsiveness)

The `watch` loop recomputed currency every tick; the currency read scans the full frozen collection over the remoting channel (~40s warm, ~200s cold), dragging the challenge-timer cadence to ~40s/snapshot — too coarse for a 5:00 threshold.

- **Split into two loops**: a timer loop (~500ms) and a currency loop (10 min). A `SemaphoreSlim` serialises SDK access; a "primed" gate lets the timer take the first reading before the currency loop starts; each loop runs on its own thread.
- **Concurrency investigated** (per review): the MTGOSDK TCP transport is multiplexed/concurrency-safe, **but** reads are marshalled onto MTGO's UI thread server-side, so a concurrent currency scan still blocks timer reads. Measured directly — running the loops lock-free, the timer loop **stalled entirely** once a concurrent scan began. So true concurrency is not achievable.
- **Currency pauses while a challenge timer is active.** During a live event the timer gets exclusive, uninterrupted ~per-tick access with **zero staleness**; currency only scans during idle periods. Verified with a simulated active timer: paused → zero timer-lock contention and zero scans; idle → scans normally.

## Harness updates

- `refresh-collection` — runs the real controller export path
- `timer-alert-action start|stop|test` — drives the Timer Alert window
- regression test using the real `items` snapshot shape
- README documents both commands + the SDK cold-attach cost

## SDK access status (MTGOSDK 0.8.5.20250901)

collection ✅ · currency ✅ (280 tix / 92 chests) · watch/timers ✅ · trade/logfiles ✅ · username ⚠️ (fallback) · history ❌ (upstream SDK crash, now contained)

## Tests

76 targeted tests pass (`tests/test_collection_service.py`, `tests/test_mtgo_bridge_client.py`). The bridge build/run is Windows-only (.NET 9 + live MTGO client) and not exercised in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)