### PR TITLE
refactor(card-table): split frame.py into toolbar mixin + placeholder helpers (#801)

### DIFF
--- a/widgets/panels/card_table_panel/frame.py
+++ b/widgets/panels/card_table_panel/frame.py
@@ -7,14 +7,16 @@ from typing import Any
 
 import wx
 
-from services.deck_service.printing import DATE_MODES as PRINTING_DATE_MODES
-from services.deck_service.printing import PRINTING_MODES
-from utils.constants import DARK_ACCENT, DARK_ALT, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+from utils.constants import DARK_PANEL, SUBDUED_TEXT
 from utils.i18n import translate as _i18n_translate
 from widgets.mana_icon_factory import ManaIconFactory
 from widgets.panels.card_table_panel.grid_view import DeckGridView
 from widgets.panels.card_table_panel.handlers import CardTablePanelHandlersMixin
 from widgets.panels.card_table_panel.pile_view import DeckPileView
+from widgets.panels.card_table_panel.placeholders import (
+    build_empty_state,
+    build_loading_state,
+)
 from widgets.panels.card_table_panel.properties import CardTablePanelPropertiesMixin
 from widgets.panels.card_table_panel.sorting import (
     COL_COLOR,
@@ -27,20 +29,7 @@ from widgets.panels.card_table_panel.sorting import (
     PILE_SORT_TYPE,
 )
 from widgets.panels.card_table_panel.table_view import DeckTableView
-from widgets.wx_layout import relayout
-
-_EMPTY_STATE_HEADING_SIZE = 13
-_EMPTY_STATE_HINT_SIZE = 10
-_EMPTY_STATE_HEADING_GAP = 6
-
-_ZONE_EMPTY_HEADING = {
-    "main": "No deck loaded",
-    "side": "Sideboard is empty",
-    "out": "No cards out",
-}
-_ZONE_EMPTY_HINT = {
-    "main": "Select a deck from the list, or load one from file",
-}
+from widgets.panels.card_table_panel.toolbar import CardTablePanelToolbarMixin
 
 # Simplebook page indices (alphabetical-by-mode after the bookend states).
 _PAGE_EMPTY = 0
@@ -52,7 +41,12 @@ _PAGE_LOADING = 4
 VIEW_MODES = ("grid", "table", "pile")
 
 
-class CardTablePanel(CardTablePanelHandlersMixin, CardTablePanelPropertiesMixin, wx.Panel):
+class CardTablePanel(
+    CardTablePanelToolbarMixin,
+    CardTablePanelHandlersMixin,
+    CardTablePanelPropertiesMixin,
+    wx.Panel,
+):
     GRID_COLUMNS = 4
     # Minimum columns the workspace must be able to show — this is the *floor*
     # that sets the deck workspace's minimum width, not the displayed count.
@@ -156,7 +150,7 @@ class CardTablePanel(CardTablePanelHandlersMixin, CardTablePanelPropertiesMixin,
         self._content_book.SetBackgroundColour(DARK_PANEL)
 
         # Page 0: empty state.
-        self._empty_state = self._build_empty_state(self._content_book, zone)
+        self._empty_state = build_empty_state(self._content_book, zone)
         self._content_book.AddPage(self._empty_state, "empty")
 
         # Page 1: grid view — a single custom-drawn canvas (no per-card native
@@ -209,7 +203,7 @@ class CardTablePanel(CardTablePanelHandlersMixin, CardTablePanelPropertiesMixin,
         self._content_book.AddPage(self.pile_view, "pile")
 
         # Page 4: loading state.
-        self._loading_state = self._build_loading_state(self._content_book)
+        self._loading_state = build_loading_state(self._content_book)
         self._content_book.AddPage(self._loading_state, "loading")
 
         outer.Add(self._content_book, 1, wx.EXPAND)
@@ -277,67 +271,6 @@ class CardTablePanel(CardTablePanelHandlersMixin, CardTablePanelPropertiesMixin,
     def _t(self, key: str) -> str:
         return _i18n_translate(self._locale, key)
 
-    def _column_label(self, col_id: str) -> str:
-        return self._t(f"tabs.view.col.{col_id}")
-
-    def _refresh_view_mode_buttons(self) -> None:
-        for mode, btn in self._view_mode_buttons.items():
-            active = mode == self.view_mode
-            btn.SetBackgroundColour(wx.Colour(*(DARK_ACCENT if active else DARK_ALT)))
-            btn.SetForegroundColour(wx.Colour(*LIGHT_TEXT))
-            btn.Refresh()
-
-    def _update_pile_sort_button_visibility(self) -> None:
-        self.pile_sort_button.Show(self.view_mode == "pile")
-        relayout(self)
-
-    def _on_view_button(self, mode: str) -> None:
-        self.set_view_mode(mode)
-
-    def _open_pile_sort_menu(self, _event: wx.CommandEvent) -> None:
-        menu = wx.Menu()
-        items = (
-            (PILE_SORT_MV, self._t("tabs.view.pile_sort.mv")),
-            (PILE_SORT_COLOR, self._t("tabs.view.pile_sort.color")),
-            (PILE_SORT_TYPE, self._t("tabs.view.pile_sort.type")),
-        )
-        for sort_mode, label in items:
-            item = menu.AppendCheckItem(wx.ID_ANY, label)
-            item.Check(sort_mode == self.pile_sort)
-            menu.Bind(wx.EVT_MENU, lambda _evt, m=sort_mode: self.set_pile_sort(m), item)
-        self.PopupMenu(menu, self.pile_sort_button.GetPosition())
-        menu.Destroy()
-
-    def _open_printing_menu(self, _event: wx.CommandEvent) -> None:
-        """Show the printing-selection menu and dispatch the chosen mode."""
-        menu = wx.Menu()
-        for mode in PRINTING_MODES:
-            item = menu.Append(wx.ID_ANY, self._t(f"tabs.view.printing.{mode}"))
-            menu.Bind(wx.EVT_MENU, lambda _evt, m=mode: self._on_printing_choice(m), item)
-        anchor = self.printing_button or self
-        self.PopupMenu(menu, anchor.GetPosition())
-        menu.Destroy()
-
-    def _on_printing_choice(self, mode: str) -> None:
-        if self._on_printing_mode is None:
-            return
-        when: str | None = None
-        if mode in PRINTING_DATE_MODES:
-            dialog = wx.TextEntryDialog(
-                self,
-                self._t("tabs.view.printing.date_prompt"),
-                self._t("tabs.view.printing.date_title"),
-            )
-            try:
-                if dialog.ShowModal() != wx.ID_OK:
-                    return
-                when = dialog.GetValue().strip()
-            finally:
-                dialog.Destroy()
-            if not when:
-                return
-        self._on_printing_mode(mode, when)
-
     def _switch_content_page(self) -> None:
         if not self.cards:
             target = _PAGE_EMPTY
@@ -380,73 +313,6 @@ class CardTablePanel(CardTablePanelHandlersMixin, CardTablePanelPropertiesMixin,
         if self._on_zone_transfer:
             return self._on_zone_transfer(self.zone, names, screen_point)
         return False
-
-    @staticmethod
-    def _build_loading_state(parent: wx.Window) -> wx.Panel:
-        panel = wx.Panel(parent)
-        panel.SetBackgroundColour(DARK_PANEL)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        panel.SetSizer(sizer)
-
-        sizer.AddStretchSpacer(2)
-        label = wx.StaticText(panel, label="")
-        label.SetForegroundColour(wx.Colour(*SUBDUED_TEXT))
-        label.SetFont(
-            wx.Font(
-                _EMPTY_STATE_HEADING_SIZE,
-                wx.FONTFAMILY_SWISS,
-                wx.FONTSTYLE_NORMAL,
-                wx.FONTWEIGHT_NORMAL,
-            )
-        )
-        sizer.Add(label, 0, wx.ALIGN_CENTER_HORIZONTAL)
-        sizer.AddStretchSpacer(3)
-        panel._label = label  # type: ignore[attr-defined]
-        return panel
-
-    @staticmethod
-    def _build_empty_state(parent: wx.Window, zone: str) -> wx.Panel:
-        panel = wx.Panel(parent)
-        panel.SetBackgroundColour(DARK_PANEL)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        panel.SetSizer(sizer)
-
-        heading_text = _ZONE_EMPTY_HEADING.get(zone, "")
-        hint_text = _ZONE_EMPTY_HINT.get(zone, "")
-
-        sizer.AddStretchSpacer(2)
-
-        if heading_text:
-            heading = wx.StaticText(panel, label=heading_text)
-            heading.SetForegroundColour(wx.Colour(*SUBDUED_TEXT))
-            heading_font = wx.Font(
-                _EMPTY_STATE_HEADING_SIZE,
-                wx.FONTFAMILY_SWISS,
-                wx.FONTSTYLE_NORMAL,
-                wx.FONTWEIGHT_NORMAL,
-            )
-            heading.SetFont(heading_font)
-            sizer.Add(
-                heading,
-                0,
-                wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM,
-                _EMPTY_STATE_HEADING_GAP,
-            )
-
-        if hint_text:
-            hint = wx.StaticText(panel, label=hint_text)
-            hint.SetForegroundColour(wx.Colour(*(max(c - 40, 0) for c in SUBDUED_TEXT)))
-            hint_font = wx.Font(
-                _EMPTY_STATE_HINT_SIZE,
-                wx.FONTFAMILY_SWISS,
-                wx.FONTSTYLE_NORMAL,
-                wx.FONTWEIGHT_NORMAL,
-            )
-            hint.SetFont(hint_font)
-            sizer.Add(hint, 0, wx.ALIGN_CENTER_HORIZONTAL)
-
-        sizer.AddStretchSpacer(3)
-        return panel
 
 
 # Re-export sort-mode tokens for callers that want to programmatically set

--- a/widgets/panels/card_table_panel/placeholders.py
+++ b/widgets/panels/card_table_panel/placeholders.py
@@ -1,0 +1,95 @@
+"""Static placeholder builders for the card table panel's bookend states.
+
+These are pure, stateless ``wx`` construction helpers (empty-state and
+loading-state panels) with their own constant tables. They are intentionally
+free functions with no coupling to :class:`CardTablePanel` instance state — the
+only contract is that :func:`build_loading_state` stashes the heading
+``wx.StaticText`` on the returned panel as ``panel._label`` so
+``handlers.show_loading`` can update it via ``self._loading_state._label``.
+"""
+
+from __future__ import annotations
+
+import wx
+
+from utils.constants import DARK_PANEL, SUBDUED_TEXT
+
+_EMPTY_STATE_HEADING_SIZE = 13
+_EMPTY_STATE_HINT_SIZE = 10
+_EMPTY_STATE_HEADING_GAP = 6
+
+_ZONE_EMPTY_HEADING = {
+    "main": "No deck loaded",
+    "side": "Sideboard is empty",
+    "out": "No cards out",
+}
+_ZONE_EMPTY_HINT = {
+    "main": "Select a deck from the list, or load one from file",
+}
+
+
+def build_loading_state(parent: wx.Window) -> wx.Panel:
+    panel = wx.Panel(parent)
+    panel.SetBackgroundColour(DARK_PANEL)
+    sizer = wx.BoxSizer(wx.VERTICAL)
+    panel.SetSizer(sizer)
+
+    sizer.AddStretchSpacer(2)
+    label = wx.StaticText(panel, label="")
+    label.SetForegroundColour(wx.Colour(*SUBDUED_TEXT))
+    label.SetFont(
+        wx.Font(
+            _EMPTY_STATE_HEADING_SIZE,
+            wx.FONTFAMILY_SWISS,
+            wx.FONTSTYLE_NORMAL,
+            wx.FONTWEIGHT_NORMAL,
+        )
+    )
+    sizer.Add(label, 0, wx.ALIGN_CENTER_HORIZONTAL)
+    sizer.AddStretchSpacer(3)
+    panel._label = label  # type: ignore[attr-defined]
+    return panel
+
+
+def build_empty_state(parent: wx.Window, zone: str) -> wx.Panel:
+    panel = wx.Panel(parent)
+    panel.SetBackgroundColour(DARK_PANEL)
+    sizer = wx.BoxSizer(wx.VERTICAL)
+    panel.SetSizer(sizer)
+
+    heading_text = _ZONE_EMPTY_HEADING.get(zone, "")
+    hint_text = _ZONE_EMPTY_HINT.get(zone, "")
+
+    sizer.AddStretchSpacer(2)
+
+    if heading_text:
+        heading = wx.StaticText(panel, label=heading_text)
+        heading.SetForegroundColour(wx.Colour(*SUBDUED_TEXT))
+        heading_font = wx.Font(
+            _EMPTY_STATE_HEADING_SIZE,
+            wx.FONTFAMILY_SWISS,
+            wx.FONTSTYLE_NORMAL,
+            wx.FONTWEIGHT_NORMAL,
+        )
+        heading.SetFont(heading_font)
+        sizer.Add(
+            heading,
+            0,
+            wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM,
+            _EMPTY_STATE_HEADING_GAP,
+        )
+
+    if hint_text:
+        hint = wx.StaticText(panel, label=hint_text)
+        hint.SetForegroundColour(wx.Colour(*(max(c - 40, 0) for c in SUBDUED_TEXT)))
+        hint_font = wx.Font(
+            _EMPTY_STATE_HINT_SIZE,
+            wx.FONTFAMILY_SWISS,
+            wx.FONTSTYLE_NORMAL,
+            wx.FONTWEIGHT_NORMAL,
+        )
+        hint.SetFont(hint_font)
+        sizer.Add(hint, 0, wx.ALIGN_CENTER_HORIZONTAL)
+
+    sizer.AddStretchSpacer(3)
+    return panel

--- a/widgets/panels/card_table_panel/protocol.py
+++ b/widgets/panels/card_table_panel/protocol.py
@@ -33,6 +33,21 @@ class CardTablePanelProto(Protocol):
     table_view: DeckTableView
     pile_view: DeckPileView
 
+    # Toolbar surface (created in ``CardTablePanel.__init__``) reached by the
+    # toolbar mixin.
+    _locale: str | None
+    _view_mode_buttons: dict[str, wx.Button]
+    pile_sort_button: wx.Button
+    printing_button: wx.Button | None
+    _on_pile_sort_change: Callable[[str, str], None] | None
+    _on_printing_mode: Callable[[str, str | None], None] | None
+
+    def _t(self, key: str) -> str: ...
+
+    def set_view_mode(self, mode: str, *, persist: bool = ...) -> None: ...
+
+    def set_pile_sort(self, sort_mode: str, *, persist: bool = ...) -> None: ...
+
     def _switch_content_page(self) -> None: ...
 
     def _notify_selection(self, card: dict[str, Any] | None) -> None: ...

--- a/widgets/panels/card_table_panel/toolbar.py
+++ b/widgets/panels/card_table_panel/toolbar.py
@@ -1,0 +1,99 @@
+"""Toolbar / menu interaction mixin for the card table panel.
+
+This is the actively-growing toolbar surface — the view-mode buttons, the
+pile-sort menu, and the printing-selection dropdown (issue #792). Keeping it in
+one mixin lets the printing-dropdown concern (which imports
+``PRINTING_MODES`` / ``PRINTING_DATE_MODES``) live in a single place rather than
+threaded through the construction core in ``frame.py``.
+
+Kept as a mixin (no ``__init__``); :class:`CardTablePanel` owns all instance
+state the methods here reach through ``self``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import wx
+
+from services.deck_service.printing import DATE_MODES as PRINTING_DATE_MODES
+from services.deck_service.printing import PRINTING_MODES
+from utils.constants import DARK_ACCENT, DARK_ALT, LIGHT_TEXT
+from widgets.panels.card_table_panel.sorting import (
+    PILE_SORT_COLOR,
+    PILE_SORT_MV,
+    PILE_SORT_TYPE,
+)
+from widgets.wx_layout import relayout
+
+if TYPE_CHECKING:
+    from widgets.panels.card_table_panel.protocol import CardTablePanelProto
+
+    _Base = CardTablePanelProto
+else:
+    _Base = object
+
+
+class CardTablePanelToolbarMixin(_Base):
+    """View-mode buttons, pile-sort menu, and printing dropdown for the panel."""
+
+    def _column_label(self, col_id: str) -> str:
+        return self._t(f"tabs.view.col.{col_id}")
+
+    def _refresh_view_mode_buttons(self) -> None:
+        for mode, btn in self._view_mode_buttons.items():
+            active = mode == self.view_mode
+            btn.SetBackgroundColour(wx.Colour(*(DARK_ACCENT if active else DARK_ALT)))
+            btn.SetForegroundColour(wx.Colour(*LIGHT_TEXT))
+            btn.Refresh()
+
+    def _update_pile_sort_button_visibility(self) -> None:
+        self.pile_sort_button.Show(self.view_mode == "pile")
+        relayout(self)
+
+    def _on_view_button(self, mode: str) -> None:
+        self.set_view_mode(mode)
+
+    def _open_pile_sort_menu(self, _event: wx.CommandEvent) -> None:
+        menu = wx.Menu()
+        items = (
+            (PILE_SORT_MV, self._t("tabs.view.pile_sort.mv")),
+            (PILE_SORT_COLOR, self._t("tabs.view.pile_sort.color")),
+            (PILE_SORT_TYPE, self._t("tabs.view.pile_sort.type")),
+        )
+        for sort_mode, label in items:
+            item = menu.AppendCheckItem(wx.ID_ANY, label)
+            item.Check(sort_mode == self.pile_sort)
+            menu.Bind(wx.EVT_MENU, lambda _evt, m=sort_mode: self.set_pile_sort(m), item)
+        self.PopupMenu(menu, self.pile_sort_button.GetPosition())
+        menu.Destroy()
+
+    def _open_printing_menu(self, _event: wx.CommandEvent) -> None:
+        """Show the printing-selection menu and dispatch the chosen mode."""
+        menu = wx.Menu()
+        for mode in PRINTING_MODES:
+            item = menu.Append(wx.ID_ANY, self._t(f"tabs.view.printing.{mode}"))
+            menu.Bind(wx.EVT_MENU, lambda _evt, m=mode: self._on_printing_choice(m), item)
+        anchor = self.printing_button or self
+        self.PopupMenu(menu, anchor.GetPosition())
+        menu.Destroy()
+
+    def _on_printing_choice(self, mode: str) -> None:
+        if self._on_printing_mode is None:
+            return
+        when: str | None = None
+        if mode in PRINTING_DATE_MODES:
+            dialog = wx.TextEntryDialog(
+                self,
+                self._t("tabs.view.printing.date_prompt"),
+                self._t("tabs.view.printing.date_title"),
+            )
+            try:
+                if dialog.ShowModal() != wx.ID_OK:
+                    return
+                when = dialog.GetValue().strip()
+            finally:
+                dialog.Destroy()
+            if not when:
+                return
+        self._on_printing_mode(mode, when)


### PR DESCRIPTION
Closes #801

Behavior-preserving decomposition of `widgets/panels/card_table_panel/frame.py` (was 465 LOC) following the package's existing frame/handlers/properties/protocol mixin convention. Code was moved, not rewritten — public API, wx event wiring, and instance-state ownership are unchanged.

## Split

| File | Before | After | Contents |
|------|-------:|------:|----------|
| `frame.py` | 465 | 331 | class definition + mixin composition, `__init__` widget/Simplebook construction, public view-state API (`active_view`/`set_view_mode`/`set_pile_sort`/`begin_marquee_at_screen`), `_switch_content_page`, `_t`, and the `_handle_view_*` selection/zone-transfer bridge |
| `toolbar.py` (new) | — | 99 | `CardTablePanelToolbarMixin`: `_refresh_view_mode_buttons`, `_update_pile_sort_button_visibility`, `_on_view_button`, `_open_pile_sort_menu`, `_open_printing_menu`, `_on_printing_choice` (incl. date-entry dialog), `_column_label`. Owns the `PRINTING_MODES` / `DATE_MODES` imports so the printing-dropdown concern (#792) lives in one place |
| `placeholders.py` (new) | — | 95 | `build_empty_state` / `build_loading_state` free functions plus the `_EMPTY_STATE_*` / `_ZONE_EMPTY_*` constant tables (was `@staticmethod` on the panel) |
| `protocol.py` | 38 | 51 | extended `CardTablePanelProto` with the toolbar mixin's self-surface |

## Conventions followed
- `CardTablePanelToolbarMixin` is composed **first** in the MRO; `wx.Panel` stays **last**. All instance state stays initialized on the concrete `CardTablePanel.__init__` — the mixin has no `__init__` and reaches state via `self`.
- `protocol.py` updated for the new cross-mixin self-surface the toolbar reaches: `_locale`, `_view_mode_buttons`, `pile_sort_button`, `printing_button`, `_on_pile_sort_change`, `_on_printing_mode`, plus `_t`, `set_view_mode`, `set_pile_sort`.
- `_t` kept on the frame (used by both `__init__` and the menus).
- `build_loading_state` preserves the dynamically-assigned `panel._label` (with its `type: ignore`) that `handlers.show_loading` consumes via `self._loading_state._label`.
- wx event-binding lambda closures (`m=mode`/`sort`/`printing`) moved intact.

## Verification (off-Windows; wx not importable here, CI runs the wx tests on Windows)
- `python -m py_compile` on all four changed files — OK (plus siblings `__init__`/`handlers`/`properties`).
- `ruff check` on the four files — all checks passed.
- `black --check` on the four files — all unchanged (already formatted).
- `git grep` confirms no dangling references to the moved `_build_empty_state`/`_build_loading_state` static methods, the moved constant tables, or the toolbar methods outside `frame.py`/`toolbar.py`. No external module imports `frame` directly — all go through the package `__init__`, whose `CardTablePanel` surface is unchanged.

## Skipped
Nothing from the proposed plan was skipped; the split was implemented as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)