### PR TITLE
refactor(app-frame): split app_frame.py handler into toolbar-menu + window-layout + deck-render + residual mixins

### DIFF
--- a/widgets/frames/app_frame/frame/__init__.py
+++ b/widgets/frames/app_frame/frame/__init__.py
@@ -32,11 +32,14 @@ from widgets.frames.app_frame.handlers import (
     ChildWindowHandlers,
     DataLoadingHandlers,
     DeckContentHandlers,
+    DeckRenderHandlers,
     DeckResearchHandlers,
     SideboardGuideEntryHandlers,
     SideboardGuideImportExportHandlers,
     SideboardGuidePersistenceHandlers,
     SideboardGuideRecordHandlers,
+    ToolbarMenuHandlers,
+    WindowLayoutHandlers,
 )
 from widgets.frames.app_frame.properties import AppFramePropertiesMixin
 from widgets.frames.identify_opponent import MTGOpponentDeckSpy
@@ -57,6 +60,9 @@ if TYPE_CHECKING:
 
 class AppFrame(
     AppFrameHandlersMixin,
+    ToolbarMenuHandlers,
+    WindowLayoutHandlers,
+    DeckRenderHandlers,
     AppFramePropertiesMixin,
     DeckResearchHandlers,
     DeckContentHandlers,

--- a/widgets/frames/app_frame/handlers/__init__.py
+++ b/widgets/frames/app_frame/handlers/__init__.py
@@ -5,6 +5,7 @@ from widgets.frames.app_frame.handlers.card_tables import CardTablesHandler
 from widgets.frames.app_frame.handlers.child_windows import ChildWindowHandlers
 from widgets.frames.app_frame.handlers.data_loading import DataLoadingHandlers
 from widgets.frames.app_frame.handlers.deck_content import DeckContentHandlers
+from widgets.frames.app_frame.handlers.deck_render import DeckRenderHandlers
 from widgets.frames.app_frame.handlers.research import DeckResearchHandlers
 from widgets.frames.app_frame.handlers.sideboard_guide_entries import (
     SideboardGuideEntryHandlers,
@@ -18,6 +19,8 @@ from widgets.frames.app_frame.handlers.sideboard_guide_persistence import (
 from widgets.frames.app_frame.handlers.sideboard_guide_record import (
     SideboardGuideRecordHandlers,
 )
+from widgets.frames.app_frame.handlers.toolbar_menu import ToolbarMenuHandlers
+from widgets.frames.app_frame.handlers.window_layout import WindowLayoutHandlers
 
 __all__ = [
     "AppFrameHandlersMixin",
@@ -25,9 +28,12 @@ __all__ = [
     "ChildWindowHandlers",
     "DataLoadingHandlers",
     "DeckContentHandlers",
+    "DeckRenderHandlers",
     "DeckResearchHandlers",
     "SideboardGuideEntryHandlers",
     "SideboardGuideImportExportHandlers",
     "SideboardGuidePersistenceHandlers",
     "SideboardGuideRecordHandlers",
+    "ToolbarMenuHandlers",
+    "WindowLayoutHandlers",
 ]

--- a/widgets/frames/app_frame/handlers/app_frame.py
+++ b/widgets/frames/app_frame/handlers/app_frame.py
@@ -1,26 +1,18 @@
-"""Event handlers, menu builders, session/window persistence, and deck rendering for the main application frame."""
+"""Session restore, auxiliary window openers, and debounce-timer helpers for the main application frame."""
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import wx
-from loguru import logger
 
-from utils.constants import APP_FRAME_MIN_SIZE, APP_FRAME_SIZE
-from utils.i18n import LOCALE_LABELS
 from utils.runtime_flags import is_automation_enabled
 from widgets.dialogs.help_dialog import show_help
-from widgets.dialogs.image_download_dialog import show_image_download_dialog
 from widgets.dialogs.tutorial_dialog import show_tutorial
-from widgets.frames.app_frame.handlers.deck_formatting import simple_summary_html
 from widgets.frames.app_frame.handlers.session_logic import should_show_tutorial
 from widgets.frames.mana_keyboard import open_mana_keyboard
-from widgets.wx_layout import set_shown
 
 if TYPE_CHECKING:
-    from services.image_service import CardImageRequest
     from widgets.frames.app_frame.protocol import AppFrameProto
 
     _Base = AppFrameProto
@@ -29,143 +21,11 @@ else:
 
 
 class AppFrameHandlersMixin(_Base):
-    """Menu, session, window, filter, and deck-rendering handlers for :class:`AppFrame`.
+    """Session restore, auxiliary openers, and debounce-timer handlers for :class:`AppFrame`.
 
     Kept as a mixin (no ``__init__``) so :class:`AppFrame` remains the single
     source of truth for instance-state initialization.
     """
-
-    def _open_toolbar_settings_menu(self, anchor: wx.Window) -> None:
-        menu = wx.Menu()
-        self._append_menu_item(
-            menu,
-            self._t("toolbar.load_collection"),
-            lambda: self.controller.refresh_collection_from_bridge(force=True),
-        )
-        self._append_menu_item(
-            menu,
-            self._t("toolbar.download_card_images"),
-            lambda: show_image_download_dialog(
-                self,
-                self.image_cache,
-                self.image_downloader,
-                self.controller.BULK_DATA_CACHE,
-                self._set_status,
-            ),
-        )
-        self._append_menu_item(
-            menu,
-            self._t("toolbar.update_card_database"),
-            lambda: self.controller.force_bulk_data_update(),
-        )
-        self._append_menu_item(
-            menu,
-            self._t("toolbar.export_diagnostics"),
-            self._open_feedback_dialog,
-        )
-        self._append_menu_item(
-            menu,
-            self._t("toolbar.show_tutorial"),
-            self._open_tutorial,
-        )
-        self._append_menu_item(
-            menu,
-            self._t("toolbar.help"),
-            self._open_help,
-        )
-        self._append_menu_item(
-            menu,
-            self._t("toolbar.comp_rules"),
-            self._open_rules_browser,
-        )
-        menu.AppendSeparator()
-        self._append_radio_submenu(
-            menu,
-            self._t("app.menu.deck_data_source"),
-            (
-                ("both", self._t("app.choice.source.both")),
-                ("mtggoldfish", self._t("app.choice.source.mtggoldfish")),
-                ("mtgo", self._t("app.choice.source.mtgo")),
-            ),
-            current_value=self.controller.get_deck_data_source(),
-            on_select=self._apply_deck_source,
-        )
-        self._append_radio_submenu(
-            menu,
-            self._t("app.menu.language"),
-            tuple((locale, LOCALE_LABELS[locale]) for locale in self._language_values),
-            current_value=self.locale,
-            on_select=self._apply_language,
-        )
-        self._append_radio_submenu(
-            menu,
-            self._t("app.menu.average_method"),
-            (
-                ("karsten", self._t("app.choice.average_method.karsten")),
-                ("arithmetic", self._t("app.choice.average_method.arithmetic")),
-            ),
-            current_value=self.controller.get_average_method(),
-            on_select=self._apply_average_method,
-        )
-        self._append_radio_submenu(
-            menu,
-            self._t("app.menu.average_hours"),
-            tuple(
-                (str(h), self._t(f"app.choice.average_hours.{h}")) for h in (12, 24, 36, 48, 60, 72)
-            ),
-            current_value=str(self.controller.get_average_hours()),
-            on_select=lambda v: self._apply_average_hours(int(v)),
-        )
-        anchor.PopupMenu(menu)
-        menu.Destroy()
-
-    def _append_menu_item(
-        self, menu: wx.Menu, label: str, handler: Callable[[], None]
-    ) -> wx.MenuItem:
-        item = menu.Append(wx.ID_ANY, label)
-        menu.Bind(wx.EVT_MENU, lambda _evt, cb=handler: cb(), item)
-        return item
-
-    def _append_radio_submenu(
-        self,
-        menu: wx.Menu,
-        label: str,
-        options: tuple[tuple[str, str], ...],
-        *,
-        current_value: str,
-        on_select: Callable[[str], None],
-    ) -> None:
-        submenu = wx.Menu()
-        for value, item_label in options:
-            item = submenu.AppendRadioItem(wx.ID_ANY, item_label)
-            item.Check(value == current_value)
-            submenu.Bind(wx.EVT_MENU, lambda _evt, selected=value, cb=on_select: cb(selected), item)
-        menu.AppendSubMenu(submenu, label)
-
-    def _apply_deck_source(self, source: str) -> None:
-        self.controller.set_deck_data_source(source)
-        self._schedule_settings_save()
-
-    def _apply_language(self, locale: str) -> None:
-        self.locale = locale
-        self.controller.set_language(locale)
-        self._set_status("app.status.language_changed")
-        self._schedule_settings_save()
-
-    def _apply_average_method(self, method: str) -> None:
-        self.controller.set_average_method(method)
-        self._schedule_settings_save()
-
-    def _apply_average_hours(self, hours: int) -> None:
-        self.controller.set_average_hours(hours)
-        self._schedule_settings_save()
-
-    def _handle_image_downloaded(self, request: CardImageRequest) -> None:
-        self.card_inspector_panel.handle_image_downloaded(request)
-        self.main_table.refresh_card_image(request.card_name)
-        self.side_table.refresh_card_image(request.card_name)
-        if self.out_table:
-            self.out_table.refresh_card_image(request.card_name)
 
     # ------------------------------------------------------------------ Left panel helpers -------------------------------------------------
     def _show_left_panel(self, mode: str, force: bool = False) -> None:
@@ -242,125 +102,6 @@ class AppFrameHandlersMixin(_Base):
             self.deck_notes_panel.load_notes_for_current()
             self._load_guide_for_current()
 
-    # ------------------------------------------------------------------ Window persistence ---------------------------------------------------
-    def _save_window_settings(self) -> None:
-        pos = self.GetPosition()
-        size = self.GetSize()
-        self.controller.save_settings(
-            window_size=(size.width, size.height), screen_pos=(pos.x, pos.y)
-        )
-
-    def _apply_window_preferences(self) -> None:
-        state = self.controller.session_manager.restore_session_state(self.controller.zone_cards)
-
-        # Restore the collapsed/expanded state of the side panels before sizing,
-        # so the recomputed minimum reflects what is actually shown.
-        if state.get("left_collapsed"):
-            self._set_left_collapsed(True, persist=False)
-        if state.get("inspector_collapsed"):
-            self._set_inspector_collapsed(True, persist=False)
-
-        area = self._target_display_client_area()
-
-        # On a display too small to host the preferred size, maximize to use the
-        # full usable area. Also collapse the (tall) inspector by default the
-        # first time we hit such a screen, so the layout fits without the card
-        # image forcing the window taller than the display (the user can expand
-        # it again — its toggle persists from then on).
-        too_small = APP_FRAME_SIZE[0] > area.width or APP_FRAME_SIZE[1] > area.height
-        if too_small:
-            if "inspector_collapsed" not in state:
-                self._set_inspector_collapsed(True, persist=False)
-            self.Maximize(True)
-            return
-
-        size = state.get("window_size") or APP_FRAME_SIZE
-        try:
-            width = min(int(size[0]), area.width)
-            height = min(int(size[1]), area.height)
-        except (TypeError, ValueError):
-            logger.debug("Ignoring invalid saved window size")
-            width, height = APP_FRAME_SIZE
-        self.SetSize(wx.Size(width, height))
-
-        pos = state.get("screen_pos")
-        if pos:
-            try:
-                x = max(area.x, min(int(pos[0]), area.x + area.width - width))
-                y = max(area.y, min(int(pos[1]), area.y + area.height - height))
-                self.SetPosition(wx.Point(x, y))
-            except (TypeError, ValueError):
-                logger.debug("Ignoring invalid saved window position")
-                self.Centre(wx.BOTH)
-        else:
-            self.Centre(wx.BOTH)
-
-    def _target_display_client_area(self) -> wx.Rect:
-        """Usable area (excluding the taskbar) of the display hosting the frame."""
-        index = wx.Display.GetFromWindow(self)
-        if index == wx.NOT_FOUND:
-            index = 0
-        try:
-            return wx.Display(index).GetClientArea()
-        except (RuntimeError, AssertionError):
-            return wx.Display(0).GetClientArea()
-
-    def _apply_min_size(self) -> None:
-        """Set the frame's minimum size to the larger of the hard floor and the
-        current content minimum.
-
-        Recomputed whenever a side panel is collapsed/expanded so that, e.g.,
-        collapsing the tall inspector lets the window shrink below the inspector's
-        natural height, while expanding it raises the floor again.
-        """
-        if not self.root_panel or not self.root_panel.GetSizer():
-            self.SetMinSize(APP_FRAME_MIN_SIZE)
-            return
-        self.root_panel.Layout()
-        min_size = self.root_panel.GetSizer().GetMinSize()
-        try:
-            min_size = self.ClientToWindowSize(min_size)
-        except AttributeError:
-            pass
-        self.SetMinSize(
-            wx.Size(
-                max(APP_FRAME_MIN_SIZE[0], min_size.GetWidth()),
-                max(APP_FRAME_MIN_SIZE[1], min_size.GetHeight()),
-            )
-        )
-
-    # ------------------------------------------------------------------ Collapsible side panels ---------------------------------------------
-    def toggle_left_panel(self) -> None:
-        self._set_left_collapsed(not self._left_collapsed)
-
-    def toggle_inspector(self) -> None:
-        self._set_inspector_collapsed(not self._inspector_collapsed)
-
-    def _set_left_collapsed(self, collapsed: bool, *, persist: bool = True) -> None:
-        self._left_collapsed = collapsed
-        if self.left_toggle_btn:
-            # ▶ invites expanding (panel hidden to the left); ◀ invites collapsing.
-            self.left_toggle_btn.SetLabel("▶" if collapsed else "◀")
-        self._relayout_after_toggle(self.left_panel_window, not collapsed)
-        if persist:
-            self.controller.save_settings(left_collapsed=collapsed)
-
-    def _set_inspector_collapsed(self, collapsed: bool, *, persist: bool = True) -> None:
-        self._inspector_collapsed = collapsed
-        if self.inspector_toggle_btn:
-            # ◀ invites expanding (panel hidden to the right); ▶ invites collapsing.
-            self.inspector_toggle_btn.SetLabel("◀" if collapsed else "▶")
-        self._relayout_after_toggle(self.inspector_panel, not collapsed)
-        if persist:
-            self.controller.save_settings(inspector_collapsed=collapsed)
-
-    def _relayout_after_toggle(self, panel: wx.Window | None, shown: bool) -> None:
-        if self.root_panel:
-            # set_shown repaints the whole frame so the toggled panel never
-            # leaves ghost pixels over the toolbar (see widgets.wx_layout).
-            set_shown(panel, shown, relayout_from=self.root_panel)
-        self._apply_min_size()
-
     def _schedule_settings_save(self) -> None:
         if self._save_timer is None:
             self._save_timer = wx.Timer(self)
@@ -382,71 +123,3 @@ class AppFrameHandlersMixin(_Base):
 
     def _flush_deck_filters(self, _event: wx.TimerEvent) -> None:
         self._apply_deck_filters()
-
-    def fetch_archetypes(self, force: bool = False) -> None:
-        if force:
-            # An explicit reload must always refresh the deck list, even if the
-            # refreshed archetype list is byte-for-byte identical. Clearing the
-            # dedup signature lets _on_archetypes_loaded reload decks again.
-            self._last_archetype_reload_sig = None
-        self.research_panel.set_loading_state()
-        self.controller.deck_repo.clear_decks_list()
-        self.deck_list.Clear()
-        self._clear_deck_display()
-        self.daily_average_button.Disable()
-        self.copy_button.Disable()
-        self.save_button.Disable()
-
-        self.controller.fetch_archetypes(
-            on_success=lambda archetypes: wx.CallAfter(self._on_archetypes_loaded, archetypes),
-            on_error=lambda error: wx.CallAfter(self._on_archetypes_error, error),
-            on_status=lambda *a, **kw: wx.CallAfter(self._set_status, *a, **kw),
-            force=force,
-        )
-
-    def _clear_deck_display(self) -> None:
-        self.controller.deck_repo.set_current_deck(None)
-        self.summary_text.SetPage(simple_summary_html(self._t("app.status.select_archetype")))
-        self.zone_cards = {"main": [], "side": [], "out": []}
-        self.main_table.set_cards([])
-        self.side_table.set_cards([])
-        if self.out_table:
-            self.out_table.set_cards(self.zone_cards["out"])
-        self.controller.deck_repo.set_current_deck_text("")
-        self._update_stats("")
-        self.deck_notes_panel.clear()
-        self.sideboard_guide_panel.clear()
-        self.card_inspector_panel.reset()
-        self.card_panel.clear()
-
-    def _render_current_deck(self) -> None:
-        self.main_table.set_cards(self.zone_cards["main"])
-        self.side_table.set_cards(self.zone_cards["side"])
-        if self.out_table:
-            self.out_table.set_cards(self.zone_cards["out"])
-        deck_text = self.controller.deck_repo.get_current_deck_text()
-        if deck_text:
-            self._update_stats(deck_text)
-            self.copy_button.Enable(True)
-            self.save_button.Enable(True)
-        self.deck_notes_panel.load_notes_for_current()
-        self._load_guide_for_current()
-        self._pending_deck_restore = False
-
-    def _render_pending_deck(self) -> None:
-        if not self.controller.card_repo.is_card_data_ready():
-            return
-        if self._pending_deck_restore or self._has_deck_loaded():
-            self._render_current_deck()
-
-    def _populate_archetype_list(self) -> None:
-        archetype_names = ["Any"] + [
-            item.get("name", "Unknown") for item in self.filtered_archetypes
-        ]
-        self.research_panel.populate_archetypes(archetype_names)
-
-    def _on_deck_download_success(self, content: str) -> None:
-        self.present_deck_text(content)
-
-    def _update_stats(self, deck_text: str) -> None:
-        self.deck_stats_panel.update_stats(deck_text, self.zone_cards)

--- a/widgets/frames/app_frame/handlers/deck_render.py
+++ b/widgets/frames/app_frame/handlers/deck_render.py
@@ -1,0 +1,100 @@
+"""Deck-display rendering, archetype listing, and stats updates for :class:`AppFrame`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import wx
+
+from widgets.frames.app_frame.handlers.deck_formatting import simple_summary_html
+
+if TYPE_CHECKING:
+    from services.image_service import CardImageRequest
+    from widgets.frames.app_frame.protocol import AppFrameProto
+
+    _Base = AppFrameProto
+else:
+    _Base = object
+
+
+class DeckRenderHandlers(_Base):
+    """Render the loaded deck into the tables/inspector and keep stats in sync.
+
+    Kept as a mixin (no ``__init__``) so :class:`AppFrame` remains the single
+    source of truth for instance-state initialization.
+    """
+
+    def _handle_image_downloaded(self, request: CardImageRequest) -> None:
+        self.card_inspector_panel.handle_image_downloaded(request)
+        self.main_table.refresh_card_image(request.card_name)
+        self.side_table.refresh_card_image(request.card_name)
+        if self.out_table:
+            self.out_table.refresh_card_image(request.card_name)
+
+    def fetch_archetypes(self, force: bool = False) -> None:
+        if force:
+            # An explicit reload must always refresh the deck list, even if the
+            # refreshed archetype list is byte-for-byte identical. Clearing the
+            # dedup signature lets _on_archetypes_loaded reload decks again.
+            self._last_archetype_reload_sig = None
+        self.research_panel.set_loading_state()
+        self.controller.deck_repo.clear_decks_list()
+        self.deck_list.Clear()
+        self._clear_deck_display()
+        self.daily_average_button.Disable()
+        self.copy_button.Disable()
+        self.save_button.Disable()
+
+        self.controller.fetch_archetypes(
+            on_success=lambda archetypes: wx.CallAfter(self._on_archetypes_loaded, archetypes),
+            on_error=lambda error: wx.CallAfter(self._on_archetypes_error, error),
+            on_status=lambda *a, **kw: wx.CallAfter(self._set_status, *a, **kw),
+            force=force,
+        )
+
+    def _clear_deck_display(self) -> None:
+        self.controller.deck_repo.set_current_deck(None)
+        self.summary_text.SetPage(simple_summary_html(self._t("app.status.select_archetype")))
+        self.zone_cards = {"main": [], "side": [], "out": []}
+        self.main_table.set_cards([])
+        self.side_table.set_cards([])
+        if self.out_table:
+            self.out_table.set_cards(self.zone_cards["out"])
+        self.controller.deck_repo.set_current_deck_text("")
+        self._update_stats("")
+        self.deck_notes_panel.clear()
+        self.sideboard_guide_panel.clear()
+        self.card_inspector_panel.reset()
+        self.card_panel.clear()
+
+    def _render_current_deck(self) -> None:
+        self.main_table.set_cards(self.zone_cards["main"])
+        self.side_table.set_cards(self.zone_cards["side"])
+        if self.out_table:
+            self.out_table.set_cards(self.zone_cards["out"])
+        deck_text = self.controller.deck_repo.get_current_deck_text()
+        if deck_text:
+            self._update_stats(deck_text)
+            self.copy_button.Enable(True)
+            self.save_button.Enable(True)
+        self.deck_notes_panel.load_notes_for_current()
+        self._load_guide_for_current()
+        self._pending_deck_restore = False
+
+    def _render_pending_deck(self) -> None:
+        if not self.controller.card_repo.is_card_data_ready():
+            return
+        if self._pending_deck_restore or self._has_deck_loaded():
+            self._render_current_deck()
+
+    def _populate_archetype_list(self) -> None:
+        archetype_names = ["Any"] + [
+            item.get("name", "Unknown") for item in self.filtered_archetypes
+        ]
+        self.research_panel.populate_archetypes(archetype_names)
+
+    def _on_deck_download_success(self, content: str) -> None:
+        self.present_deck_text(content)
+
+    def _update_stats(self, deck_text: str) -> None:
+        self.deck_stats_panel.update_stats(deck_text, self.zone_cards)

--- a/widgets/frames/app_frame/handlers/toolbar_menu.py
+++ b/widgets/frames/app_frame/handlers/toolbar_menu.py
@@ -1,0 +1,151 @@
+"""Toolbar settings menu builders and preference setters for :class:`AppFrame`."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import wx
+
+from utils.i18n import LOCALE_LABELS
+from widgets.dialogs.image_download_dialog import show_image_download_dialog
+
+if TYPE_CHECKING:
+    from widgets.frames.app_frame.protocol import AppFrameProto
+
+    _Base = AppFrameProto
+else:
+    _Base = object
+
+
+class ToolbarMenuHandlers(_Base):
+    """Toolbar overflow menu and the preference setters its entries invoke.
+
+    Kept as a mixin (no ``__init__``) so :class:`AppFrame` remains the single
+    source of truth for instance-state initialization.
+    """
+
+    def _open_toolbar_settings_menu(self, anchor: wx.Window) -> None:
+        menu = wx.Menu()
+        self._append_menu_item(
+            menu,
+            self._t("toolbar.load_collection"),
+            lambda: self.controller.refresh_collection_from_bridge(force=True),
+        )
+        self._append_menu_item(
+            menu,
+            self._t("toolbar.download_card_images"),
+            lambda: show_image_download_dialog(
+                self,
+                self.image_cache,
+                self.image_downloader,
+                self.controller.BULK_DATA_CACHE,
+                self._set_status,
+            ),
+        )
+        self._append_menu_item(
+            menu,
+            self._t("toolbar.update_card_database"),
+            lambda: self.controller.force_bulk_data_update(),
+        )
+        self._append_menu_item(
+            menu,
+            self._t("toolbar.export_diagnostics"),
+            self._open_feedback_dialog,
+        )
+        self._append_menu_item(
+            menu,
+            self._t("toolbar.show_tutorial"),
+            self._open_tutorial,
+        )
+        self._append_menu_item(
+            menu,
+            self._t("toolbar.help"),
+            self._open_help,
+        )
+        self._append_menu_item(
+            menu,
+            self._t("toolbar.comp_rules"),
+            self._open_rules_browser,
+        )
+        menu.AppendSeparator()
+        self._append_radio_submenu(
+            menu,
+            self._t("app.menu.deck_data_source"),
+            (
+                ("both", self._t("app.choice.source.both")),
+                ("mtggoldfish", self._t("app.choice.source.mtggoldfish")),
+                ("mtgo", self._t("app.choice.source.mtgo")),
+            ),
+            current_value=self.controller.get_deck_data_source(),
+            on_select=self._apply_deck_source,
+        )
+        self._append_radio_submenu(
+            menu,
+            self._t("app.menu.language"),
+            tuple((locale, LOCALE_LABELS[locale]) for locale in self._language_values),
+            current_value=self.locale,
+            on_select=self._apply_language,
+        )
+        self._append_radio_submenu(
+            menu,
+            self._t("app.menu.average_method"),
+            (
+                ("karsten", self._t("app.choice.average_method.karsten")),
+                ("arithmetic", self._t("app.choice.average_method.arithmetic")),
+            ),
+            current_value=self.controller.get_average_method(),
+            on_select=self._apply_average_method,
+        )
+        self._append_radio_submenu(
+            menu,
+            self._t("app.menu.average_hours"),
+            tuple(
+                (str(h), self._t(f"app.choice.average_hours.{h}")) for h in (12, 24, 36, 48, 60, 72)
+            ),
+            current_value=str(self.controller.get_average_hours()),
+            on_select=lambda v: self._apply_average_hours(int(v)),
+        )
+        anchor.PopupMenu(menu)
+        menu.Destroy()
+
+    def _append_menu_item(
+        self, menu: wx.Menu, label: str, handler: Callable[[], None]
+    ) -> wx.MenuItem:
+        item = menu.Append(wx.ID_ANY, label)
+        menu.Bind(wx.EVT_MENU, lambda _evt, cb=handler: cb(), item)
+        return item
+
+    def _append_radio_submenu(
+        self,
+        menu: wx.Menu,
+        label: str,
+        options: tuple[tuple[str, str], ...],
+        *,
+        current_value: str,
+        on_select: Callable[[str], None],
+    ) -> None:
+        submenu = wx.Menu()
+        for value, item_label in options:
+            item = submenu.AppendRadioItem(wx.ID_ANY, item_label)
+            item.Check(value == current_value)
+            submenu.Bind(wx.EVT_MENU, lambda _evt, selected=value, cb=on_select: cb(selected), item)
+        menu.AppendSubMenu(submenu, label)
+
+    def _apply_deck_source(self, source: str) -> None:
+        self.controller.set_deck_data_source(source)
+        self._schedule_settings_save()
+
+    def _apply_language(self, locale: str) -> None:
+        self.locale = locale
+        self.controller.set_language(locale)
+        self._set_status("app.status.language_changed")
+        self._schedule_settings_save()
+
+    def _apply_average_method(self, method: str) -> None:
+        self.controller.set_average_method(method)
+        self._schedule_settings_save()
+
+    def _apply_average_hours(self, hours: int) -> None:
+        self.controller.set_average_hours(hours)
+        self._schedule_settings_save()

--- a/widgets/frames/app_frame/handlers/window_layout.py
+++ b/widgets/frames/app_frame/handlers/window_layout.py
@@ -1,0 +1,144 @@
+"""Window persistence, sizing, and collapsible-panel layout for :class:`AppFrame`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import wx
+from loguru import logger
+
+from utils.constants import APP_FRAME_MIN_SIZE, APP_FRAME_SIZE
+from widgets.wx_layout import set_shown
+
+if TYPE_CHECKING:
+    from widgets.frames.app_frame.protocol import AppFrameProto
+
+    _Base = AppFrameProto
+else:
+    _Base = object
+
+
+class WindowLayoutHandlers(_Base):
+    """Window persistence, display-aware sizing, and side-panel collapse toggles.
+
+    Kept as a mixin (no ``__init__``) so :class:`AppFrame` remains the single
+    source of truth for instance-state initialization.
+    """
+
+    def _save_window_settings(self) -> None:
+        pos = self.GetPosition()
+        size = self.GetSize()
+        self.controller.save_settings(
+            window_size=(size.width, size.height), screen_pos=(pos.x, pos.y)
+        )
+
+    def _apply_window_preferences(self) -> None:
+        state = self.controller.session_manager.restore_session_state(self.controller.zone_cards)
+
+        # Restore the collapsed/expanded state of the side panels before sizing,
+        # so the recomputed minimum reflects what is actually shown.
+        if state.get("left_collapsed"):
+            self._set_left_collapsed(True, persist=False)
+        if state.get("inspector_collapsed"):
+            self._set_inspector_collapsed(True, persist=False)
+
+        area = self._target_display_client_area()
+
+        # On a display too small to host the preferred size, maximize to use the
+        # full usable area. Also collapse the (tall) inspector by default the
+        # first time we hit such a screen, so the layout fits without the card
+        # image forcing the window taller than the display (the user can expand
+        # it again — its toggle persists from then on).
+        too_small = APP_FRAME_SIZE[0] > area.width or APP_FRAME_SIZE[1] > area.height
+        if too_small:
+            if "inspector_collapsed" not in state:
+                self._set_inspector_collapsed(True, persist=False)
+            self.Maximize(True)
+            return
+
+        size = state.get("window_size") or APP_FRAME_SIZE
+        try:
+            width = min(int(size[0]), area.width)
+            height = min(int(size[1]), area.height)
+        except (TypeError, ValueError):
+            logger.debug("Ignoring invalid saved window size")
+            width, height = APP_FRAME_SIZE
+        self.SetSize(wx.Size(width, height))
+
+        pos = state.get("screen_pos")
+        if pos:
+            try:
+                x = max(area.x, min(int(pos[0]), area.x + area.width - width))
+                y = max(area.y, min(int(pos[1]), area.y + area.height - height))
+                self.SetPosition(wx.Point(x, y))
+            except (TypeError, ValueError):
+                logger.debug("Ignoring invalid saved window position")
+                self.Centre(wx.BOTH)
+        else:
+            self.Centre(wx.BOTH)
+
+    def _target_display_client_area(self) -> wx.Rect:
+        """Usable area (excluding the taskbar) of the display hosting the frame."""
+        index = wx.Display.GetFromWindow(self)
+        if index == wx.NOT_FOUND:
+            index = 0
+        try:
+            return wx.Display(index).GetClientArea()
+        except (RuntimeError, AssertionError):
+            return wx.Display(0).GetClientArea()
+
+    def _apply_min_size(self) -> None:
+        """Set the frame's minimum size to the larger of the hard floor and the
+        current content minimum.
+
+        Recomputed whenever a side panel is collapsed/expanded so that, e.g.,
+        collapsing the tall inspector lets the window shrink below the inspector's
+        natural height, while expanding it raises the floor again.
+        """
+        if not self.root_panel or not self.root_panel.GetSizer():
+            self.SetMinSize(APP_FRAME_MIN_SIZE)
+            return
+        self.root_panel.Layout()
+        min_size = self.root_panel.GetSizer().GetMinSize()
+        try:
+            min_size = self.ClientToWindowSize(min_size)
+        except AttributeError:
+            pass
+        self.SetMinSize(
+            wx.Size(
+                max(APP_FRAME_MIN_SIZE[0], min_size.GetWidth()),
+                max(APP_FRAME_MIN_SIZE[1], min_size.GetHeight()),
+            )
+        )
+
+    # ------------------------------------------------------------------ Collapsible side panels ---------------------------------------------
+    def toggle_left_panel(self) -> None:
+        self._set_left_collapsed(not self._left_collapsed)
+
+    def toggle_inspector(self) -> None:
+        self._set_inspector_collapsed(not self._inspector_collapsed)
+
+    def _set_left_collapsed(self, collapsed: bool, *, persist: bool = True) -> None:
+        self._left_collapsed = collapsed
+        if self.left_toggle_btn:
+            # ▶ invites expanding (panel hidden to the left); ◀ invites collapsing.
+            self.left_toggle_btn.SetLabel("▶" if collapsed else "◀")
+        self._relayout_after_toggle(self.left_panel_window, not collapsed)
+        if persist:
+            self.controller.save_settings(left_collapsed=collapsed)
+
+    def _set_inspector_collapsed(self, collapsed: bool, *, persist: bool = True) -> None:
+        self._inspector_collapsed = collapsed
+        if self.inspector_toggle_btn:
+            # ◀ invites expanding (panel hidden to the right); ▶ invites collapsing.
+            self.inspector_toggle_btn.SetLabel("◀" if collapsed else "▶")
+        self._relayout_after_toggle(self.inspector_panel, not collapsed)
+        if persist:
+            self.controller.save_settings(inspector_collapsed=collapsed)
+
+    def _relayout_after_toggle(self, panel: wx.Window | None, shown: bool) -> None:
+        if self.root_panel:
+            # set_shown repaints the whole frame so the toggled panel never
+            # leaves ghost pixels over the toolbar (see widgets.wx_layout).
+            set_shown(panel, shown, relayout_from=self.root_panel)
+        self._apply_min_size()


### PR DESCRIPTION
Closes #802

## Summary

Decomposes `widgets/frames/app_frame/handlers/app_frame.py` (452 LOC) — the residual catch-all handler mixin whose docstring listed four unrelated jobs — into three focused topic mixins plus a smaller residual, following the package's established topic-split-mixin convention (topic mixins composed into `AppFrame` over `AppFrameProto`, with `wx.Frame` last in the MRO and all instance state owned by the concrete class).

This is a **behavior-preserving** refactor: methods were moved verbatim, not rewritten. No runtime behavior, public APIs, or wx event-wiring semantics change. All instance state still lives on `AppFrame` and is reached via `self` through `AppFrameProto`.

## Files

Added:
- `widgets/frames/app_frame/handlers/toolbar_menu.py` (151) — `ToolbarMenuHandlers`: `_open_toolbar_settings_menu`, the `_append_menu_item`/`_append_radio_submenu` builders, and the `_apply_deck_source`/`_apply_language`/`_apply_average_method`/`_apply_average_hours` setters.
- `widgets/frames/app_frame/handlers/window_layout.py` (144) — `WindowLayoutHandlers`: `_save_window_settings`, `_apply_window_preferences`, `_target_display_client_area`, `_apply_min_size`, and the collapse toggles (`toggle_*`/`_set_*_collapsed`/`_relayout_after_toggle`). Kept together because `_apply_window_preferences` calls `_set_*_collapsed` and `_relayout_after_toggle` calls `_apply_min_size`.
- `widgets/frames/app_frame/handlers/deck_render.py` (100) — `DeckRenderHandlers`: `fetch_archetypes`, `_clear_deck_display`, `_render_current_deck`/`_render_pending_deck`, `_populate_archetype_list`, `_on_deck_download_success`, `_update_stats`, `_handle_image_downloaded`.

Changed:
- `widgets/frames/app_frame/handlers/app_frame.py` — now the **residual** `AppFrameHandlersMixin` (452 -> 125 LOC): session restore (`_restore_session_state`/`_show_left_panel`), aux openers (`_open_full_mana_keyboard`/`_open_tutorial`/`_open_help`/`_open_rules_browser`), and both debounce timers (`_schedule_settings_save`/`_flush_pending_settings`/`_schedule_filter_debounce`/`_flush_deck_filters`). The two `wx.Timer`s share the single `EVT_TIMER` dispatch surface, so per the issue they stay together in the residual file.
- `widgets/frames/app_frame/handlers/__init__.py` — export and re-export the three new mixins.
- `widgets/frames/app_frame/frame/__init__.py` — register `ToolbarMenuHandlers`, `WindowLayoutHandlers`, `DeckRenderHandlers` in `AppFrame`'s MRO (inserted ahead of the other handler mixins, `wx.Frame` still last).

LOC: 452 -> 125 (residual) + 151 + 144 + 100 = 520 total (small delta from per-file docstrings/imports).

## Style choice

These handler mixins use the package's existing protocol-collaborator style (`_Base = AppFrameProto` under `TYPE_CHECKING`), identical to the original `app_frame.py` and the sibling handler mixins. No new view-level `protocol.py` was introduced (that lighter view-collaborator guidance applies to the `card_table_panel` scrolled-window views, which are untouched here).

## Verification (off-Windows; wx not importable here — CI runs the wx suite on Windows)

- `python -m py_compile` on all six changed/added files: passed.
- `ruff check` on changed files and the whole `widgets/frames/app_frame/` package: All checks passed.
- `black --check` on changed files: all would be left unchanged.
- `git grep` confirms each of the 34 moved methods is defined exactly once across the handlers package (no duplicates, none dropped), and the residual file has no stale imports.
- External references to `AppFrameHandlersMixin._restore_session_state` (a test comment and `session_logic.py` docstring) remain accurate since that method stayed in the residual mixin.

## Skipped

Nothing skipped. The issue noted `_handle_image_downloaded`/deck-render methods *could* alternatively fold into the existing `deck_content.py`; I kept them in a dedicated `deck_render.py` as the primary proposal lists, which is the lower-risk pure move (no merge into another mixin's class body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)