### PR TITLE
refactor(card-table): extract pile_geometry + image-cache from pile_view (#799)

### DIFF
--- a/widgets/panels/card_table_panel/grid_view.py
+++ b/widgets/panels/card_table_panel/grid_view.py
@@ -66,7 +66,7 @@ from widgets.panels.card_table_panel.card_render import (
     resolve_card_color,
 )
 from widgets.panels.card_table_panel.marquee import RUBBER_AUTOSCROLL_PX, MarqueeController
-from widgets.panels.card_table_panel.pile_view import _ImageCache
+from widgets.panels.card_table_panel.pile_image_cache import _ImageCache
 from widgets.panels.card_table_panel.scrolling import scroll_by_wheel
 
 # Match the grid sizer's old geometry: DECK_CARD_WIDTH×HEIGHT cells with a

--- a/widgets/panels/card_table_panel/pile_geometry.py
+++ b/widgets/panels/card_table_panel/pile_geometry.py
@@ -1,0 +1,72 @@
+"""Pure pile-layout geometry for the deck pile view.
+
+These are widget-free, DC-free functions over plain integers/lists so the pile
+view's spatial math is unit-testable without a live ``wx`` window. ``DeckPileView``
+imports them and the module-level constants below; the math is identical to the
+inline methods it previously carried (issue #799).
+
+A pile is a vertical stack: the bottom card is drawn full-height and each card
+above it shows only a ``_NAME_STRIP_HEIGHT`` slice at the top. Pile x-positions
+are width-independent (they depend only on the pile index), so a pure resize
+never moves a card horizontally.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import wx
+
+from utils.constants import DECK_CARD_HEIGHT, DECK_CARD_WIDTH
+
+# Match the grid view's card size and inter-card gap so the two views feel
+# visually consistent.
+_CARD_WIDTH = DECK_CARD_WIDTH
+_CARD_HEIGHT = DECK_CARD_HEIGHT
+_NAME_STRIP_HEIGHT = 32  # visible portion of stacked-above cards
+_PILE_GAP = 8  # gap between piles (matches grid view's GRID_GAP)
+_PILE_PAD = 6  # padding inside a pile column
+_PILE_TOP = _PILE_PAD  # top inset for the first card in a pile
+
+
+def pile_height(member_count: int) -> int:
+    if member_count <= 0:
+        return _CARD_HEIGHT
+    return _CARD_HEIGHT + (member_count - 1) * _NAME_STRIP_HEIGHT
+
+
+def pile_x(pile_index: int) -> int:
+    return _PILE_GAP + pile_index * (_CARD_WIDTH + _PILE_GAP)
+
+
+def card_rect(pile_index: int, member_index: int, total: int) -> wx.Rect:
+    x = pile_x(pile_index)
+    # Bottom card sits at the bottom of the stack; cards higher in the
+    # member list are visually above it (only their name strip showing).
+    bottom_y = _PILE_TOP + pile_height(total) - _CARD_HEIGHT
+    y = bottom_y - (total - 1 - member_index) * _NAME_STRIP_HEIGHT
+    return wx.Rect(x, y, _CARD_WIDTH, _CARD_HEIGHT)
+
+
+def content_size(piles: list[tuple[str, list[dict[str, Any]]]]) -> wx.Size:
+    """The true content extent of ``piles`` (NOT the wx-inflated virtual size)."""
+    if not piles:
+        return wx.Size(100, 100)
+    max_members = max(len(members) for _, members in piles)
+    height = _PILE_TOP + pile_height(max_members) + _PILE_PAD * 2
+    width = (_CARD_WIDTH + _PILE_GAP) * len(piles) + _PILE_GAP
+    return wx.Size(width, height)
+
+
+def pile_index_at(piles: list[tuple[str, list[dict[str, Any]]]], logical_x: int) -> int | None:
+    if not piles:
+        return None
+    # Snap to nearest pile column.
+    best_idx = 0
+    best_dist = abs(pile_x(0) + _CARD_WIDTH // 2 - logical_x)
+    for idx in range(1, len(piles)):
+        d = abs(pile_x(idx) + _CARD_WIDTH // 2 - logical_x)
+        if d < best_dist:
+            best_idx = idx
+            best_dist = d
+    return best_idx

--- a/widgets/panels/card_table_panel/pile_image_cache.py
+++ b/widgets/panels/card_table_panel/pile_image_cache.py
@@ -1,0 +1,162 @@
+"""Threaded scaled-bitmap cache for the deck pile view.
+
+Lifts ``DeckPileView``'s image plumbing — the tiny LRU bitmap cache plus the
+background-thread loader that resolves a card's art path, scales it to the deck
+card size, applies the rounded-corner alpha, and converts to a ``wx.Bitmap`` —
+into one reusable collaborator (issue #799). The pile view owns an instance and
+talks to it through ``self``; the cache talks back through the callables it is
+constructed with.
+
+Behaviour is identical to the inline version it replaces:
+
+* ``put(name, None)`` marks a name as "loading" so a second pass over the same
+  piles does not respawn a thread for it.
+* The ``image_gen`` counter is bumped on every spawned load exactly as before
+  (it guards stale async loads; kept coherent now the loader lives here).
+* Loads run on daemon threads and marshal their result back onto the GUI thread
+  with ``wx.CallAfter`` so the cache mutation and canvas patch happen on the
+  main thread.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from threading import Thread
+
+import wx
+from PIL import Image as PilImage
+
+from utils.constants import (
+    DECK_CARD_CORNER_RADIUS,
+    DECK_CARD_HEIGHT,
+    DECK_CARD_WIDTH,
+)
+from utils.image_effects import apply_rounded_corner_alpha
+
+_CARD_WIDTH = DECK_CARD_WIDTH
+_CARD_HEIGHT = DECK_CARD_HEIGHT
+
+
+class _ImageCache:
+    """Tiny LRU-ish cache of scaled card-image bitmaps keyed by name."""
+
+    def __init__(self, max_entries: int = 256) -> None:
+        self._cache: dict[str, wx.Bitmap | None] = {}
+        self._max_entries = max_entries
+
+    def get(self, name: str) -> wx.Bitmap | None:
+        return self._cache.get(name)
+
+    def has(self, name: str) -> bool:
+        return name in self._cache
+
+    def put(self, name: str, bitmap: wx.Bitmap | None) -> None:
+        if len(self._cache) >= self._max_entries:
+            # Drop an arbitrary entry — pile contents change infrequently.
+            self._cache.pop(next(iter(self._cache)))
+        self._cache[name] = bitmap
+
+
+class ScaledBitmapCache:
+    """Owns the bitmap cache and the threaded loader for a card view.
+
+    The owning widget supplies:
+
+    * ``get_card_image(name, size)`` / ``get_printing_image(name)`` — the same
+      resolvers the view already holds (the printing resolver may be ``None``).
+    * ``is_alive()`` — guards a ``wx.CallAfter`` arriving after the window died.
+    * ``on_loaded(name)`` — called on the GUI thread once a name's bitmap has
+      been stored, so the view can patch just the piles holding it.
+    """
+
+    def __init__(
+        self,
+        *,
+        get_card_image: Callable[[str, str], Path | None],
+        get_printing_image: Callable[[str], Path | None] | None,
+        is_alive: Callable[[], bool],
+        on_loaded: Callable[[str], None],
+        max_entries: int = 256,
+    ) -> None:
+        self._cache = _ImageCache(max_entries)
+        self._get_card_image = get_card_image
+        self._get_printing_image = get_printing_image
+        self._is_alive = is_alive
+        self._on_loaded = on_loaded
+        self.image_gen = 0
+
+    # ----- cache access -----
+    def get(self, name: str) -> wx.Bitmap | None:
+        return self._cache.get(name)
+
+    def has(self, name: str) -> bool:
+        return self._cache.has(name)
+
+    def put(self, name: str, bitmap: wx.Bitmap | None) -> None:
+        self._cache.put(name, bitmap)
+
+    # ----- loading -----
+    def prefetch(self, names: list[str]) -> None:
+        """Spawn loads for any ``names`` not already cached or loading."""
+        seen: set[str] = set()
+        for name in names:
+            if name in seen or self._cache.has(name):
+                continue
+            seen.add(name)
+            self._cache.put(name, None)  # mark as loading
+            self._spawn(name)
+
+    def refresh(self, name: str) -> None:
+        """Drop ``name``'s cached art and reload it (e.g. its printing changed).
+
+        Bypasses the prefetch cached-bitmap skip so a printing swap actually
+        re-renders rather than reusing the previous art (issue #792).
+        """
+        self._cache.put(name, None)
+        self._spawn(name)
+
+    def _spawn(self, name: str) -> None:
+        self.image_gen += 1
+        gen = self.image_gen
+        Thread(target=self._image_worker, args=(gen, name), daemon=True).start()
+
+    def _image_worker(self, gen: int, name: str) -> None:
+        try:
+            path: Path | None = None
+            if self._get_printing_image is not None:
+                try:
+                    path = self._get_printing_image(name)
+                except Exception:
+                    path = None
+                if path and not path.exists():
+                    path = None
+            if path is None:
+                path = self._get_card_image(name, "normal")
+            if not path or not path.exists():
+                wx.CallAfter(self._image_loaded, name, None)
+                return
+            img = PilImage.open(str(path)).convert("RGB")
+            w, h = img.size
+            scale = min(_CARD_WIDTH / w, _CARD_HEIGHT / h)
+            img = img.resize((max(1, int(w * scale)), max(1, int(h * scale))), PilImage.LANCZOS)
+            wx.CallAfter(self._image_loaded, name, img)
+        except Exception:
+            wx.CallAfter(self._image_loaded, name, None)
+
+    def _image_loaded(self, name: str, pil_img: PilImage.Image | None) -> None:
+        try:
+            if not self._is_alive():
+                return
+        except RuntimeError:
+            return
+        if pil_img is None:
+            self._cache.put(name, None)
+        else:
+            w, h = pil_img.size
+            wx_img = wx.Image(w, h)
+            wx_img.SetData(pil_img.tobytes())
+            wx_img = apply_rounded_corner_alpha(wx_img, DECK_CARD_CORNER_RADIUS)
+            self._cache.put(name, wx_img.ConvertToBitmap())
+        # A single card's art changed — let the view patch just the piles holding it.
+        self._on_loaded(name)

--- a/widgets/panels/card_table_panel/pile_view.py
+++ b/widgets/panels/card_table_panel/pile_view.py
@@ -26,12 +26,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from threading import Thread
 from time import perf_counter
 from typing import Any
 
 import wx
-from PIL import Image as PilImage
 
 from utils.constants import (
     CARD_VIEW_SCROLL_RATE,
@@ -40,53 +38,32 @@ from utils.constants import (
     DARK_BG,
     DARK_PANEL,
     DECK_CARD_CORNER_RADIUS,
-    DECK_CARD_HEIGHT,
-    DECK_CARD_WIDTH,
     LIGHT_TEXT,
     SUBDUED_TEXT,
 )
-from utils.image_effects import apply_rounded_corner_alpha
+from widgets.panels.card_table_panel import pile_geometry as geom
 from widgets.panels.card_table_panel import scroll_perf
 from widgets.panels.card_table_panel.marquee import RUBBER_AUTOSCROLL_PX, MarqueeController
+from widgets.panels.card_table_panel.pile_image_cache import ScaledBitmapCache
 from widgets.panels.card_table_panel.scrolling import scroll_by_wheel
 from widgets.panels.card_table_panel.sorting import (
     PILE_SORT_MV,
     group_into_piles,
 )
 
-# Match the grid view's card size and inter-card gap so the two views feel
-# visually consistent.
-_CARD_WIDTH = DECK_CARD_WIDTH
-_CARD_HEIGHT = DECK_CARD_HEIGHT
-_NAME_STRIP_HEIGHT = 32  # visible portion of stacked-above cards
-_PILE_GAP = 8  # gap between piles (matches grid view's GRID_GAP)
-_PILE_PAD = 6  # padding inside a pile column
-_PILE_TOP = _PILE_PAD  # top inset for the first card in a pile
+# Geometry constants live in pile_geometry; re-exported here so existing
+# importers (e.g. tests/ui/test_pile_view_selection.py) keep working unchanged.
+_CARD_WIDTH = geom._CARD_WIDTH
+_CARD_HEIGHT = geom._CARD_HEIGHT
+_NAME_STRIP_HEIGHT = geom._NAME_STRIP_HEIGHT
+_PILE_GAP = geom._PILE_GAP
+_PILE_PAD = geom._PILE_PAD
+_PILE_TOP = geom._PILE_TOP
 
 # Above this virtual width/height (px) we skip the cached full-content bitmap
 # and draw directly (culled), so a pathological pile can't allocate a huge
 # canvas. Comfortably clears any real deck zone.
 _MAX_CANVAS_PX = 20000
-
-
-class _ImageCache:
-    """Tiny LRU-ish cache of scaled card-image bitmaps keyed by name."""
-
-    def __init__(self, max_entries: int = 256) -> None:
-        self._cache: dict[str, wx.Bitmap | None] = {}
-        self._max_entries = max_entries
-
-    def get(self, name: str) -> wx.Bitmap | None:
-        return self._cache.get(name)
-
-    def has(self, name: str) -> bool:
-        return name in self._cache
-
-    def put(self, name: str, bitmap: wx.Bitmap | None) -> None:
-        if len(self._cache) >= self._max_entries:
-            # Drop an arbitrary entry — pile contents change infrequently.
-            self._cache.pop(next(iter(self._cache)))
-        self._cache[name] = bitmap
 
 
 class DeckPileView(wx.ScrolledWindow):
@@ -151,8 +128,16 @@ class DeckPileView(wx.ScrolledWindow):
         self._drag_uids: list[int] = []
         self._drag_pos: wx.Point | None = None
 
-        self._image_cache = _ImageCache()
-        self._image_gen = 0
+        # The scaled-bitmap cache owns its own LRU store and the threaded
+        # loader (including the image-generation guard). It reaches back into
+        # the view through the callables below: the resolvers it loads art with,
+        # an aliveness check for late CallAfters, and the on-loaded patch hook.
+        self._image_cache = ScaledBitmapCache(
+            get_card_image=self._get_card_image,
+            get_printing_image=self._get_printing_image,
+            is_alive=lambda: bool(self),
+            on_loaded=self._patch_card_on_canvas,
+        )
         # Full-content bitmap of every pile (card art only). Scrolling blits a
         # sub-rect of this instead of re-drawing every copy's alpha bitmap, so a
         # wheel notch costs one viewport copy. Rebuilt on content change; the
@@ -217,10 +202,7 @@ class DeckPileView(wx.ScrolledWindow):
                 break
         if stored is None:
             return
-        self._image_cache.put(stored, None)
-        self._image_gen += 1
-        gen = self._image_gen
-        Thread(target=self._image_worker, args=(gen, stored), daemon=True).start()
+        self._image_cache.refresh(stored)
         self.Refresh()
 
     def set_selected(self, name: str | None) -> None:
@@ -268,36 +250,24 @@ class DeckPileView(wx.ScrolledWindow):
         self._prefetch_images()
         self.Refresh()
 
+    # Pile spatial math lives in pile_geometry (pure, widget-free); these thin
+    # delegators keep the call sites and the test-facing method names stable.
     def _pile_height(self, member_count: int) -> int:
-        if member_count <= 0:
-            return _CARD_HEIGHT
-        return _CARD_HEIGHT + (member_count - 1) * _NAME_STRIP_HEIGHT
+        return geom.pile_height(member_count)
 
     def _update_virtual_size(self) -> None:
         # Pile contents/positions changed — the cached image is stale.
         self._invalidate_canvas()
-        if not self._piles:
-            self._content_size = wx.Size(100, 100)
-            self.SetVirtualSize((100, 100))
-            return
-        max_members = max(len(members) for _, members in self._piles)
-        height = _PILE_TOP + self._pile_height(max_members) + _PILE_PAD * 2
-        width = (_CARD_WIDTH + _PILE_GAP) * len(self._piles) + _PILE_GAP
         # Canvas tracks the true content extent; the scroll/virtual size may be
         # inflated to the client by wx, but the canvas must not be (see __init__).
-        self._content_size = wx.Size(width, height)
-        self.SetVirtualSize((width, height))
+        self._content_size = geom.content_size(self._piles)
+        self.SetVirtualSize(self._content_size)
 
     def _pile_x(self, pile_index: int) -> int:
-        return _PILE_GAP + pile_index * (_CARD_WIDTH + _PILE_GAP)
+        return geom.pile_x(pile_index)
 
     def _card_rect(self, pile_index: int, member_index: int, total: int) -> wx.Rect:
-        x = self._pile_x(pile_index)
-        # Bottom card sits at the bottom of the stack; cards higher in the
-        # member list are visually above it (only their name strip showing).
-        bottom_y = _PILE_TOP + self._pile_height(total) - _CARD_HEIGHT
-        y = bottom_y - (total - 1 - member_index) * _NAME_STRIP_HEIGHT
-        return wx.Rect(x, y, _CARD_WIDTH, _CARD_HEIGHT)
+        return geom.card_rect(pile_index, member_index, total)
 
     def _hit_test(self, point: wx.Point) -> tuple[int, int, dict[str, Any]] | None:
         """Return (pile_index, member_index, entry) for the topmost card at point."""
@@ -319,57 +289,10 @@ class DeckPileView(wx.ScrolledWindow):
 
     # ----- image loading -----
     def _prefetch_images(self) -> None:
-        seen: set[str] = set()
-        for _label, members in self._piles:
-            for entry in members:
-                name = entry["name"]
-                if name in seen or self._image_cache.has(name):
-                    continue
-                seen.add(name)
-                self._image_cache.put(name, None)  # mark as loading
-                self._image_gen += 1
-                gen = self._image_gen
-                Thread(target=self._image_worker, args=(gen, name), daemon=True).start()
-
-    def _image_worker(self, gen: int, name: str) -> None:
-        try:
-            path: Path | None = None
-            if self._get_printing_image is not None:
-                try:
-                    path = self._get_printing_image(name)
-                except Exception:
-                    path = None
-                if path and not path.exists():
-                    path = None
-            if path is None:
-                path = self._get_card_image(name, "normal")
-            if not path or not path.exists():
-                wx.CallAfter(self._image_loaded, name, None)
-                return
-            img = PilImage.open(str(path)).convert("RGB")
-            w, h = img.size
-            scale = min(_CARD_WIDTH / w, _CARD_HEIGHT / h)
-            img = img.resize((max(1, int(w * scale)), max(1, int(h * scale))), PilImage.LANCZOS)
-            wx.CallAfter(self._image_loaded, name, img)
-        except Exception:
-            wx.CallAfter(self._image_loaded, name, None)
-
-    def _image_loaded(self, name: str, pil_img: PilImage.Image | None) -> None:
-        try:
-            if not self:
-                return
-        except RuntimeError:
-            return
-        if pil_img is None:
-            self._image_cache.put(name, None)
-        else:
-            w, h = pil_img.size
-            wx_img = wx.Image(w, h)
-            wx_img.SetData(pil_img.tobytes())
-            wx_img = apply_rounded_corner_alpha(wx_img, DECK_CARD_CORNER_RADIUS)
-            self._image_cache.put(name, wx_img.ConvertToBitmap())
-        # A single card's art changed — patch just the piles holding it.
-        self._patch_card_on_canvas(name)
+        # The cache de-dups names and skips anything already cached/loading.
+        self._image_cache.prefetch(
+            [entry["name"] for _label, members in self._piles for entry in members]
+        )
 
     # ----- paint -----
     def _on_paint(self, _event: wx.PaintEvent) -> None:
@@ -893,14 +816,4 @@ class DeckPileView(wx.ScrolledWindow):
         self._update_virtual_size()
 
     def _pile_index_at(self, logical_x: int) -> int | None:
-        if not self._piles:
-            return None
-        # Snap to nearest pile column.
-        best_idx = 0
-        best_dist = abs(self._pile_x(0) + _CARD_WIDTH // 2 - logical_x)
-        for idx in range(1, len(self._piles)):
-            d = abs(self._pile_x(idx) + _CARD_WIDTH // 2 - logical_x)
-            if d < best_dist:
-                best_idx = idx
-                best_dist = d
-        return best_idx
+        return geom.pile_index_at(self._piles, logical_x)


### PR DESCRIPTION
Closes #799

Behavior-preserving decomposition of `widgets/panels/card_table_panel/pile_view.py` (906 LOC). I took the **two low-risk pure extractions the issue explicitly recommends doing first** and deferred the painter/input mixin split (see "Intentionally skipped" below).

## Files added/changed
- **Added** `pile_geometry.py` (~72 LOC): pure, widget-free, DC-free layout math — `pile_height` / `pile_x` / `card_rect` / `content_size` / `pile_index_at` plus the `_CARD_*` / `_NAME_STRIP_HEIGHT` / `_PILE_*` constants as free functions. Now unit-testable without a live widget.
- **Added** `pile_image_cache.py` (~162 LOC): lifts `_ImageCache` and the threaded loader (`prefetch` / `_image_worker` / `_image_loaded` / `refresh`) plus the `image_gen` counter into a reusable `ScaledBitmapCache`. The view drives it through injected callables (`get_card_image`, `get_printing_image`, `is_alive`, `on_loaded`).
- **Changed** `pile_view.py`: **906 -> 819 LOC**. Geometry methods (`_pile_height` / `_pile_x` / `_card_rect` / `_pile_index_at`) become thin delegators to `pile_geometry`; image plumbing is replaced by a `ScaledBitmapCache` instance. Geometry constants are re-exported so existing importers (`tests/ui/test_pile_view_selection.py` imports `_NAME_STRIP_HEIGHT`) keep working unchanged. No public API, runtime behavior, or wx event wiring changed.
- **Changed** `grid_view.py`: its `_ImageCache` import now points at the new shared `pile_image_cache` module instead of `pile_view`, removing the awkward grid->pile_view module dependency (the issue named `_ImageCache` a "candidate shared module with grid_view").

## Behavior preservation notes
- The `is_alive=lambda: bool(self)` callback is invoked inside the cache's `try/except RuntimeError`, so the dead-C++-object guard from the original `_image_loaded` is preserved identically.
- The `image_gen` bump-on-spawn semantics are kept exactly (it was incremented but never compared in the original; that is unchanged, not "fixed").
- The empty-pile virtual-size case still yields `wx.Size(100, 100)` and `SetVirtualSize` of the same.
- `refresh_image`'s "mark None, respawn, Refresh" flow is preserved via `ScaledBitmapCache.refresh`.

## Intentionally skipped (per the issue's own recommendation)
The `pile_painter.py` / `pile_input.py` **mixin split was deliberately deferred**. The issue flags it as the risky part — heavy shared mutable state (`_piles`, `_selected_uids`, `_hover_uid`, `_canvas`/`_content_size`, `_drag_*`) read/written across paint, input and drop code; real wx coupling (mouse capture, `EVT_MOUSE_CAPTURE_LOST`, `BG_STYLE_PAINT` + `AutoBufferedPaintDC`, the canvas-blit-vs-direct-draw branch); and the `_suppress_set_selected` re-entrancy guard — and recommends doing it later, ideally symmetrically with `grid_view` so both views share seams. A smaller correct change was preferred over a large risky one.

## Verification (off-Windows; wx not importable here, CI runs the wx tests on Windows)
- `python -m py_compile` on all four changed files: OK
- `ruff check` on all four: All checks passed
- `black --check` on all four: would be left unchanged
- `git grep` confirms no dangling references to moved symbols (`pile_view._ImageCache` now has zero importers; the only `_ImageCache` import is the updated grid_view -> `pile_image_cache`).
- AST check confirms `DeckPileView` and all test-facing method/constant names (`_NAME_STRIP_HEIGHT`, `_card_rect`, `_on_left_down`, `_marquee_select`, `_autoscroll_towards`, `_notify_selection_changed`, `_on_wheel`, etc.) are still present.

Draft PR — not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
