### PR TITLE
refactor(card-table): extract table_columns + table_dnd helpers (#803)

### DIFF
--- a/widgets/panels/card_table_panel/table_columns.py
+++ b/widgets/panels/card_table_panel/table_columns.py
@@ -1,0 +1,114 @@
+"""Pure column/cell-text helpers for :class:`DeckTableView`.
+
+These functions hold the stateless math behind the table view's cells and
+column widths so it can be unit-tested without any wx grid wiring:
+
+* :func:`cell_text` formats one cell's display string from a card + metadata.
+* :func:`fit_to_width` computes the Type/Text column widths that make the whole
+  row fit the visible viewport, shrinking proportionally to each column's
+  available room. It takes the natural widths (from autosize), the client
+  width and the column indices and returns the new sizes for the view to
+  apply — it never touches the grid itself.
+
+Everything here is wx-independent (it only consumes the metadata dict and a few
+ints) so it stays directly testable off-Windows where wx is unimportable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from widgets.panels.card_table_panel.sorting import (
+    COL_COLOR,
+    COL_MANA,
+    COL_NAME,
+    COL_TEXT,
+    COL_TYPE,
+    card_colors,
+    card_mana_value,
+    card_type_line,
+)
+
+# Safety cap on raw oracle text stored in cells. The inline-symbol renderer
+# does pixel-precise ellipsis truncation, but storing massive strings still
+# costs memory in the grid table.
+_MAX_TEXT_CHARS = 400
+
+# Natural-width caps applied during AutoSize. fit_to_width then shrinks
+# further so the whole row fits the visible viewport.
+_MAX_TYPE_WIDTH = 220
+_MAX_TEXT_WIDTH = 540
+_MIN_TYPE_WIDTH = 70
+_MIN_TEXT_WIDTH = 100
+
+# Per-column natural-width caps so a single huge value can't dominate.
+COLUMN_WIDTH_CAPS: dict[str, int] = {COL_TYPE: _MAX_TYPE_WIDTH, COL_TEXT: _MAX_TEXT_WIDTH}
+
+
+def cell_text(card: dict[str, Any], meta: Any, col_id: str) -> str:
+    """Display string for ``card``'s ``col_id`` cell using its ``meta``."""
+    if col_id == COL_NAME:
+        qty = card.get("qty", 1)
+        return f"{qty}× {card['name']}"
+    if col_id == COL_MANA:
+        cost = meta.get("mana_cost")
+        if cost:
+            return cost
+        mv = card_mana_value(meta)
+        if mv == 0 and "land" in (card_type_line(meta) or "").lower():
+            return ""
+        return f"{{{int(mv)}}}"
+    if col_id == COL_TYPE:
+        return card_type_line(meta)
+    if col_id == COL_TEXT:
+        text = (meta.get("oracle_text") or "").replace("\n", " ")
+        if len(text) > _MAX_TEXT_CHARS:
+            return text[: _MAX_TEXT_CHARS - 1] + "…"
+        return text
+    if col_id == COL_COLOR:
+        cols = card_colors(meta)
+        if not cols:
+            return "{C}"
+        return "".join(f"{{{c}}}" for c in cols)
+    return ""
+
+
+def fit_to_width(
+    natural_widths: dict[int, int],
+    available: int,
+    type_idx: int,
+    text_idx: int,
+) -> dict[int, int]:
+    """Type/Text widths that shrink the row to fit ``available`` px.
+
+    Starts from ``natural_widths`` (the autosize baseline) and distributes the
+    overflow between the Type and Text columns proportionally to the room each
+    has above its minimum. Other columns (mana, name, color) are never shrunk.
+
+    Returns a mapping of column index -> new size for *only* the columns that
+    change. An empty mapping means no shrink is needed (and the caller should
+    restore the natural widths). The grid is never mutated here.
+    """
+    if not natural_widths or available <= 0:
+        return {}
+    total = sum(natural_widths.values())
+    overflow = total - available
+    if overflow <= 0:
+        return {}
+    type_size = natural_widths.get(type_idx, 0)
+    text_size = natural_widths.get(text_idx, 0)
+    type_room = max(0, type_size - _MIN_TYPE_WIDTH)
+    text_room = max(0, text_size - _MIN_TEXT_WIDTH)
+    total_room = type_room + text_room
+    if total_room <= 0:
+        return {}
+    take = min(overflow, total_room)
+    # Text has more filler than type, so distribute proportionally to room.
+    text_take = int(round(take * text_room / total_room))
+    type_take = take - text_take
+    result: dict[int, int] = {}
+    if text_size:
+        result[text_idx] = text_size - text_take
+    if type_size:
+        result[type_idx] = type_size - type_take
+    return result

--- a/widgets/panels/card_table_panel/table_dnd.py
+++ b/widgets/panels/card_table_panel/table_dnd.py
@@ -1,0 +1,190 @@
+"""Drag-to-reorder controller for :class:`DeckTableView`.
+
+A sibling to :class:`MarqueeController`: the table view forwards its grid-window
+mouse events here and this owns the drag-to-reorder gesture's state machine,
+mouse capture and the wx.Overlay insertion line. A reorder rearranges rows
+visually only — zone quantities never change, so the rearranged order lives in
+the view's ``_rows`` until the next sort / set_cards (issue #779).
+
+The view supplies a target ``grid``/``grid_window`` plus a small set of
+callbacks so the controller can read the live row list, map a name set to its
+visual order, hand off a cross-zone drop, and ask the view to re-populate after
+a within-zone reorder. The controller keeps the row list itself (the same
+coupling :mod:`marquee` accepts) so the view delegates the whole gesture.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import wx
+import wx.grid as gridlib
+
+from utils.constants import DARK_ACCENT
+
+# Pointer travel (logical px) before a primed press becomes an active drag, so a
+# plain click that wobbles slightly still selects rather than reorders.
+_DRAG_THRESHOLD = 4
+
+
+class TableDragController:
+    """Drives one table view's drag-to-reorder gesture.
+
+    The view supplies:
+
+    * ``grid`` / ``grid_window`` — the wx grid and its inner window (the surface
+      rows are drawn on and the one that owns mouse capture + the overlay).
+    * ``rows()`` — the live display-order list of card dicts.
+    * ``names_in_visual_order(names)`` — ``names`` in current top-to-bottom order.
+    * ``on_zone_transfer(names, screen_point)`` — optional; move ``names`` to the
+      other zone, returning True if it handled the drop.
+    * ``on_reorder(new_rows)`` — apply a within-zone reorder; the view stores the
+      new order and re-populates the grid.
+    """
+
+    def __init__(
+        self,
+        grid: gridlib.Grid,
+        grid_window: wx.Window,
+        *,
+        rows: Callable[[], list[dict[str, Any]]],
+        names_in_visual_order: Callable[[set[str]], list[str]],
+        on_reorder: Callable[[list[dict[str, Any]]], None],
+        on_zone_transfer: Callable[[list[str], wx.Point], bool] | None = None,
+    ) -> None:
+        self._grid = grid
+        self._grid_window = grid_window
+        self._rows = rows
+        self._names_in_visual_order = names_in_visual_order
+        self._on_reorder = on_reorder
+        self._on_zone_transfer = on_zone_transfer
+
+        # Drag-to-reorder state. ``_press`` is the logical press point (set once
+        # a drag is primed); ``_active`` flips once the pointer clears the
+        # threshold; ``_names`` is the dragged set in visual order; ``_drop_row``
+        # is the current insertion index.
+        self._press: wx.Point | None = None
+        self._active = False
+        self._names: list[str] = []
+        self._drop_row: int | None = None
+        # Insertion-line feedback is drawn over the native grid with an overlay so
+        # it survives the grid's own repaints without us owning its paint cycle.
+        self._overlay = wx.Overlay()
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    # ----- lifecycle -----
+    def prime(self, press_logical: wx.Point, selected_names: set[str]) -> None:
+        """Prime a potential drag (begins once the pointer moves past threshold)."""
+        self._press = press_logical
+        self._names = self._names_in_visual_order(selected_names)
+        if not self._grid_window.HasCapture():
+            self._grid_window.CaptureMouse()
+
+    def update(self, client_point: wx.Point) -> None:
+        """Advance the drag from a motion event while the button is held.
+
+        Returns nothing; once a primed press clears the threshold the drag goes
+        active and the insertion line tracks the cursor.
+        """
+        if self._press is None:
+            return
+        x, y = self._grid.CalcUnscrolledPosition(client_point)
+        if not self._active and (
+            abs(x - self._press.x) > _DRAG_THRESHOLD or abs(y - self._press.y) > _DRAG_THRESHOLD
+        ):
+            self._active = True
+        if self._active:
+            self._drop_row = self._drop_row_at(y)
+            self._draw_drop_line(self._drop_row)
+
+    def finish(self, client_point: wx.Point) -> None:
+        """Commit an active drag: zone-transfer the cards or reorder in place."""
+        # A drop over the other zone's pane moves the cards there; otherwise it's
+        # a within-zone reorder.
+        transferred = False
+        if self._on_zone_transfer is not None:
+            transferred = self._on_zone_transfer(
+                self._names, self._grid_window.ClientToScreen(client_point)
+            )
+        if not transferred:
+            _x, y = self._grid.CalcUnscrolledPosition(client_point)
+            self._perform_drop(self._drop_row_at(y))
+        self.reset()
+
+    @property
+    def primed(self) -> bool:
+        return self._press is not None
+
+    def clear_press(self) -> None:
+        """Drop a primed-but-not-active press (a plain click that never moved)."""
+        self._press = None
+        self._names = []
+
+    def reset(self) -> None:
+        """Tear the gesture down and clear the overlay."""
+        self._press = None
+        self._active = False
+        self._names = []
+        self._drop_row = None
+        self._overlay.Reset()
+        self._grid_window.Refresh()
+
+    # ----- internals -----
+    def _drop_row_at(self, y_logical: int) -> int:
+        """Insertion row index for a drop at logical y (before the row whose
+        midpoint sits below the cursor)."""
+        rows = self._rows()
+        n = len(rows)
+        for idx in range(n):
+            rect = self._grid.CellToRect(idx, 0)
+            if y_logical < rect.y + rect.height / 2:
+                return idx
+        return n
+
+    def _perform_drop(self, insert_row: int) -> None:
+        """Reorder the rows so the dragged rows land at ``insert_row``.
+
+        Visual rearrangement only; zone quantities are untouched and nothing is
+        reported upward. The new order is handed to ``on_reorder``.
+        """
+        if not self._names:
+            return
+        rows = self._rows()
+        dragged = set(self._names)
+        before = sum(1 for c in rows[:insert_row] if c["name"] in dragged)
+        insert_row -= before
+        order = {name: i for i, name in enumerate(self._names)}
+        moved = sorted(
+            (c for c in rows if c["name"] in dragged),
+            key=lambda c: order.get(c["name"], 0),
+        )
+        if not moved:
+            return
+        kept = [c for c in rows if c["name"] not in dragged]
+        insert_row = max(0, min(len(kept), insert_row))
+        self._on_reorder(kept[:insert_row] + moved + kept[insert_row:])
+
+    def _draw_drop_line(self, insert_row: int) -> None:
+        """Draw the insertion line over the grid at ``insert_row`` via overlay."""
+        rows = self._rows()
+        n = len(rows)
+        if n == 0:
+            return
+        if insert_row < n:
+            rect = self._grid.CellToRect(insert_row, 0)
+            logical_y = rect.y
+        else:
+            rect = self._grid.CellToRect(n - 1, 0)
+            logical_y = rect.GetBottom()
+        _x, device_y = self._grid.CalcScrolledPosition(0, logical_y)
+        dc = wx.ClientDC(self._grid_window)
+        odc = wx.DCOverlay(self._overlay, dc)
+        odc.Clear()
+        dc.SetPen(wx.Pen(wx.Colour(*DARK_ACCENT), 3))
+        width = self._grid_window.GetClientSize().GetWidth()
+        dc.DrawLine(0, device_y, width, device_y)
+        del odc

--- a/widgets/panels/card_table_panel/table_view.py
+++ b/widgets/panels/card_table_panel/table_view.py
@@ -26,7 +26,7 @@ from typing import Any
 import wx
 import wx.grid as gridlib
 
-from utils.constants import DARK_ACCENT, DARK_ALT, DARK_BG, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
+from utils.constants import DARK_ALT, DARK_BG, DARK_PANEL, LIGHT_TEXT, SUBDUED_TEXT
 from widgets.mana_icon_factory import ManaIconFactory
 from widgets.panels.card_table_panel.marquee import MarqueeController
 from widgets.panels.card_table_panel.sorting import (
@@ -40,11 +40,14 @@ from widgets.panels.card_table_panel.sorting import (
     TABLE_ACTION_SUB,
     TABLE_COLUMNS,
     action_slot_at,
-    card_colors,
-    card_mana_value,
-    card_type_line,
     sort_table_rows,
 )
+from widgets.panels.card_table_panel.table_columns import (
+    COLUMN_WIDTH_CAPS,
+    cell_text,
+    fit_to_width,
+)
+from widgets.panels.card_table_panel.table_dnd import TableDragController
 from widgets.panels.card_table_panel.table_renderers import (
     _ACTIONS_COL_WIDTH,
     _ActionCellRenderer,
@@ -54,21 +57,9 @@ from widgets.panels.card_table_panel.table_renderers import (
     _ManaIconCellRenderer,
 )
 
-# Safety cap on raw oracle text stored in cells. The inline-symbol renderer
-# does pixel-precise ellipsis truncation, but storing massive strings still
-# costs memory in the grid table.
-_MAX_TEXT_CHARS = 400
-
 # Mana/color icons are sized larger than text icons (by 4px) so they fill the
 # row height without top/bottom padding.
 _CELL_ICON_SIZE_BONUS = 4
-
-# Natural-width caps applied during AutoSize. _fit_to_width then shrinks
-# further so the whole row fits the visible viewport.
-_MAX_TYPE_WIDTH = 220
-_MAX_TEXT_WIDTH = 540
-_MIN_TYPE_WIDTH = 70
-_MIN_TEXT_WIDTH = 100
 
 _COLUMN_LABELS: dict[str, str] = {
     COL_MANA: "Mana",
@@ -125,17 +116,10 @@ class DeckTableView(wx.Panel):
         # (possibly multi-) selection, so an echoed None can't wipe the set.
         self._suppress_set_selected: bool = False
         self._marquee_base: set[str] | None = None
-        # Drag-to-reorder state. A reorder rearranges rows visually only — zone
-        # quantities never change, so it stays inside the view (issue #779). The
-        # arranged order lives in self._rows until the next sort / set_cards.
-        self._drag_press: wx.Point | None = None
-        self._drag_active = False
-        self._drag_names: list[str] = []
-        self._drop_row: int | None = None
+        # Drag-to-reorder state lives in the controller (issue #779); a reorder
+        # rearranges rows visually only, so the arranged order lands back in
+        # self._rows via the on_reorder callback until the next sort / set_cards.
         self._manual_overrides = False
-        # Insertion-line feedback is drawn over the native grid with an overlay so
-        # it survives the grid's own repaints without us owning its paint cycle.
-        self._drop_overlay = wx.Overlay()
         # Natural widths populated by _autosize_columns; _fit_to_width starts
         # from these so resizing the panel wider re-expands the columns.
         self._natural_widths: dict[int, int] = {}
@@ -212,6 +196,14 @@ class DeckTableView(wx.Panel):
             on_select=self._marquee_select,
             on_finish=self._marquee_finish,
         )
+        self._drag = TableDragController(
+            self.grid,
+            grid_window,
+            rows=lambda: self._rows,
+            names_in_visual_order=self._names_in_visual_order,
+            on_reorder=self._apply_reorder,
+            on_zone_transfer=self._on_zone_transfer,
+        )
 
         self.grid.Bind(gridlib.EVT_GRID_LABEL_LEFT_CLICK, self._on_header_click)
         self.grid.Bind(gridlib.EVT_GRID_SELECT_CELL, self._on_cell_select)
@@ -229,7 +221,7 @@ class DeckTableView(wx.Panel):
         # any manual reorder / in-flight drag (the new content re-sorts).
         self._needs_autosize = True
         self._manual_overrides = False
-        self._reset_drag()
+        self._drag.reset()
         self._refresh()
 
     def set_selected(self, name: str | None) -> None:
@@ -279,38 +271,11 @@ class DeckTableView(wx.Panel):
             for row_idx, card in enumerate(self._rows):
                 meta = self._get_metadata(card["name"]) or {}
                 for col_idx, col_id in enumerate(TABLE_COLUMNS):
-                    self.grid.SetCellValue(row_idx, col_idx, self._cell_text(card, meta, col_id))
+                    self.grid.SetCellValue(row_idx, col_idx, cell_text(card, meta, col_id))
             self._apply_selection_highlight()
             self._update_sort_indicator()
         finally:
             self.grid.EndBatch()
-
-    @staticmethod
-    def _cell_text(card: dict[str, Any], meta: Any, col_id: str) -> str:
-        if col_id == COL_NAME:
-            qty = card.get("qty", 1)
-            return f"{qty}× {card['name']}"
-        if col_id == COL_MANA:
-            cost = meta.get("mana_cost")
-            if cost:
-                return cost
-            mv = card_mana_value(meta)
-            if mv == 0 and "land" in (card_type_line(meta) or "").lower():
-                return ""
-            return f"{{{int(mv)}}}"
-        if col_id == COL_TYPE:
-            return card_type_line(meta)
-        if col_id == COL_TEXT:
-            text = (meta.get("oracle_text") or "").replace("\n", " ")
-            if len(text) > _MAX_TEXT_CHARS:
-                return text[: _MAX_TEXT_CHARS - 1] + "…"
-            return text
-        if col_id == COL_COLOR:
-            cols = card_colors(meta)
-            if not cols:
-                return "{C}"
-            return "".join(f"{{{c}}}" for c in cols)
-        return ""
 
     def _autosize_columns(self) -> None:
         """Auto-size columns to their content, then fit-to-width.
@@ -320,12 +285,11 @@ class DeckTableView(wx.Panel):
         results are stored in ``_natural_widths`` so :meth:`_fit_to_width` can
         re-expand columns when the viewport grows.
         """
-        caps: dict[str, int] = {COL_TYPE: _MAX_TYPE_WIDTH, COL_TEXT: _MAX_TEXT_WIDTH}
         self._natural_widths = {}
         for idx, col_id in enumerate(TABLE_COLUMNS):
             self.grid.AutoSizeColumn(idx, setAsMin=False)
             size = self.grid.GetColSize(idx)
-            cap = caps.get(col_id)
+            cap = COLUMN_WIDTH_CAPS.get(col_id)
             if cap is not None and size > cap:
                 size = cap
             self._natural_widths[idx] = size
@@ -336,7 +300,8 @@ class DeckTableView(wx.Panel):
 
         Starts from ``_natural_widths`` so a panel resize re-expands the
         columns back toward their natural widths. Other columns (mana, name,
-        color) are never shrunk.
+        color) are never shrunk. The proportional-shrink math lives in
+        :func:`table_columns.fit_to_width`; this only applies the result.
         """
         if not self._natural_widths:
             return
@@ -347,29 +312,14 @@ class DeckTableView(wx.Panel):
         # Reserve room for the fixed actions column so the data columns shrink
         # to fit beside it rather than pushing it off-screen.
         available = self.grid.GetClientSize().GetWidth() - _ACTIONS_COL_WIDTH
-        if available <= 0:
-            return
-        total = sum(self._natural_widths.values())
-        overflow = total - available
-        if overflow <= 0:
-            return
-        type_idx = TABLE_COLUMNS.index(COL_TYPE)
-        text_idx = TABLE_COLUMNS.index(COL_TEXT)
-        type_size = self._natural_widths.get(type_idx, 0)
-        text_size = self._natural_widths.get(text_idx, 0)
-        type_room = max(0, type_size - _MIN_TYPE_WIDTH)
-        text_room = max(0, text_size - _MIN_TEXT_WIDTH)
-        total_room = type_room + text_room
-        if total_room <= 0:
-            return
-        take = min(overflow, total_room)
-        # Text has more filler than type, so distribute proportionally to room.
-        text_take = int(round(take * text_room / total_room))
-        type_take = take - text_take
-        if text_size:
-            self.grid.SetColSize(text_idx, text_size - text_take)
-        if type_size:
-            self.grid.SetColSize(type_idx, type_size - type_take)
+        sizes = fit_to_width(
+            self._natural_widths,
+            available,
+            TABLE_COLUMNS.index(COL_TYPE),
+            TABLE_COLUMNS.index(COL_TEXT),
+        )
+        for idx, size in sizes.items():
+            self.grid.SetColSize(idx, size)
 
     def _on_panel_resize(self, event: wx.SizeEvent) -> None:
         event.Skip()
@@ -436,15 +386,8 @@ class DeckTableView(wx.Panel):
         if self._marquee.active:
             self._marquee.update(event.GetPosition())
             return
-        if self._drag_press is not None and event.LeftIsDown():
-            x, y = self.grid.CalcUnscrolledPosition(event.GetPosition())
-            if not self._drag_active and (
-                abs(x - self._drag_press.x) > 4 or abs(y - self._drag_press.y) > 4
-            ):
-                self._drag_active = True
-            if self._drag_active:
-                self._drop_row = self._drop_row_at(y)
-                self._draw_drop_line(self._drop_row)
+        if self._drag.primed and event.LeftIsDown():
+            self._drag.update(event.GetPosition())
             return
         if self._selected_names or self._on_hover is None:
             event.Skip()
@@ -508,10 +451,7 @@ class DeckTableView(wx.Panel):
             self._notify_selection(card)
 
         # Prime a potential drag-to-reorder (begins once the pointer moves).
-        self._drag_press = wx.Point(x, y)
-        self._drag_names = self._names_in_visual_order(self._selected_names)
-        if not self._grid_window.HasCapture():
-            self._grid_window.CaptureMouse()
+        self._drag.prime(wx.Point(x, y), self._selected_names)
 
     def _on_grid_left_up(self, event: wx.MouseEvent) -> None:
         if self._marquee.active:
@@ -519,93 +459,30 @@ class DeckTableView(wx.Panel):
             return
         if self._grid_window.HasCapture():
             self._grid_window.ReleaseMouse()
-        if self._drag_active:
-            # A drop over the other zone's pane moves the cards there; otherwise
-            # it's a within-zone reorder.
-            transferred = False
-            if self._on_zone_transfer is not None:
-                transferred = self._on_zone_transfer(
-                    self._drag_names, self._grid_window.ClientToScreen(event.GetPosition())
-                )
-            if not transferred:
-                x, y = self.grid.CalcUnscrolledPosition(event.GetPosition())
-                self._perform_drop(self._drop_row_at(y))
-            self._reset_drag()
+        if self._drag.active:
+            self._drag.finish(event.GetPosition())
             return
-        self._drag_press = None
-        self._drag_names = []
+        self._drag.clear_press()
         event.Skip()
 
     def _on_grid_capture_lost(self, _event: wx.MouseCaptureLostEvent) -> None:
         self._marquee.cancel()
-        self._reset_drag()
+        self._drag.reset()
 
     # ----- drag-to-reorder -----
     def _names_in_visual_order(self, names: set[str]) -> list[str]:
         """Return ``names`` in current top-to-bottom row order."""
         return [card["name"] for card in self._rows if card["name"] in names]
 
-    def _drop_row_at(self, y_logical: int) -> int:
-        """Insertion row index for a drop at logical y (before the row whose
-        midpoint sits below the cursor)."""
-        n = len(self._rows)
-        for idx in range(n):
-            rect = self.grid.CellToRect(idx, 0)
-            if y_logical < rect.y + rect.height / 2:
-                return idx
-        return n
-
-    def _perform_drop(self, insert_row: int) -> None:
-        """Reorder ``self._rows`` so the dragged rows land at ``insert_row``.
+    def _apply_reorder(self, new_rows: list[dict[str, Any]]) -> None:
+        """Adopt a drag-reordered row list and re-render (issue #779).
 
         Visual rearrangement only; zone quantities are untouched and nothing is
         reported upward. Persists until the next sort / set_cards.
         """
-        if not self._drag_names:
-            return
-        dragged = set(self._drag_names)
-        before = sum(1 for c in self._rows[:insert_row] if c["name"] in dragged)
-        insert_row -= before
-        order = {name: i for i, name in enumerate(self._drag_names)}
-        moved = sorted(
-            (c for c in self._rows if c["name"] in dragged),
-            key=lambda c: order.get(c["name"], 0),
-        )
-        if not moved:
-            return
-        kept = [c for c in self._rows if c["name"] not in dragged]
-        insert_row = max(0, min(len(kept), insert_row))
-        self._rows = kept[:insert_row] + moved + kept[insert_row:]
+        self._rows = new_rows
         self._manual_overrides = True
         self._populate_grid()
-
-    def _draw_drop_line(self, insert_row: int) -> None:
-        """Draw the insertion line over the grid at ``insert_row`` via overlay."""
-        n = len(self._rows)
-        if n == 0:
-            return
-        if insert_row < n:
-            rect = self.grid.CellToRect(insert_row, 0)
-            logical_y = rect.y
-        else:
-            rect = self.grid.CellToRect(n - 1, 0)
-            logical_y = rect.GetBottom()
-        _x, device_y = self.grid.CalcScrolledPosition(0, logical_y)
-        dc = wx.ClientDC(self._grid_window)
-        odc = wx.DCOverlay(self._drop_overlay, dc)
-        odc.Clear()
-        dc.SetPen(wx.Pen(wx.Colour(*DARK_ACCENT), 3))
-        width = self._grid_window.GetClientSize().GetWidth()
-        dc.DrawLine(0, device_y, width, device_y)
-        del odc
-
-    def _reset_drag(self) -> None:
-        self._drag_press = None
-        self._drag_active = False
-        self._drag_names = []
-        self._drop_row = None
-        self._drop_overlay.Reset()
-        self._grid_window.Refresh()
 
     def _notify_selection_for_set(self) -> None:
         if len(self._selected_names) == 1:


### PR DESCRIPTION
Closes #803

Behaviour-preserving decomposition of `DeckTableView` (`widgets/panels/card_table_panel/table_view.py`, 660 LOC) into two cohesive helper modules, following the package's existing helper-module style (`sorting.py`, `table_renderers.py`, `marquee.py`) rather than the frame/handlers/properties/protocol mixin pattern. As the issue directs, the mixin/protocol split is *not* imposed here — that pattern applies to the `CardTablePanel` container, not these view widgets.

## Files added
- **`table_columns.py`** (114 LOC) — pure, wx-independent column/cell-text math:
  - `cell_text(card, meta, col_id)` — the former static `_cell_text` formatting.
  - `fit_to_width(natural_widths, available, type_idx, text_idx)` — the autosize-cap + proportional-shrink computation. It **returns** the new Type/Text sizes for the view to apply and never touches the grid, so it is directly unit-testable off-Windows.
  - `COLUMN_WIDTH_CAPS` plus the width/char constants moved out of the view.
- **`table_dnd.py`** (190 LOC) — `TableDragController`, a drag-to-reorder + drop-line controller mirroring `MarqueeController`: the `_drag_*`/`_drop_row` state machine (`prime`/`update`/`finish`/`reset`/`clear_press`), mouse-capture priming, the `wx.Overlay` insertion line (`_draw_drop_line`), `_drop_row_at`, the reorder (`_perform_drop`), and the cross-zone handoff. The view forwards `grid_window` mouse events to it and gets the reordered row list back via an `on_reorder` callback (the same view-coupling `marquee.py` accepts).

## Files changed
- **`table_view.py`** — 660 -> 537 LOC. Constructs the new controller alongside `MarqueeController`; delegates the cell-text, fit-to-width and the whole drag gesture; keeps grid setup, selection model, marquee glue and event binding. Capture release on left-up stays in the view (it is shared with the marquee path), matching prior ordering.

## Verification (off-Windows; wx is not importable here, CI runs the wx tests on Windows)
- `python -m py_compile` on all three changed files and the whole `card_table_panel` package — passes.
- `ruff check` — all checks passed.
- `black --check` — all three files unchanged.
- `git grep` confirms no dangling references to the moved symbols (`_cell_text`, `_perform_drop`, `_draw_drop_line`, `_reset_drag`, `_drop_row_at`); the only hits for those names are in `grid_view.py`, a separate view widget with its own independent drag implementation.

## Notes / scope
- The view still owns `_on_grid_left_down` (action-click routing + selection toggling + drag priming interleave there, so it is not a clean event-boundary cut, exactly as the issue cautioned) and the mouse-capture *release* in `_on_grid_left_up`, since capture is shared with the marquee path.
- Final LOC (537) is above the issue's ~430 estimate: the remaining file is grid construction + selection + marquee glue + event wiring, which the issue itself flagged as the borderline, non-extractable core. The two genuinely separable clusters named in the plan were both extracted.
- No public API, wx event wiring, module singletons, or atexit/thread cleanup were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)