### PR TITLE
refactor(image-service): split downloader.py into bulk-metadata + local-resolver + image-writer mixins

### DIFF
--- a/services/image_service/__init__.py
+++ b/services/image_service/__init__.py
@@ -5,7 +5,10 @@ Split by responsibility into internal modules:
 - ``schemas``: constants, msgspec decoders, :class:`CardImageRequest`
 - ``path_resolver``: stored-path normalization helpers
 - ``disk_cache``: :class:`CardImageCache` (SQLite + filesystem)
-- ``downloader``: :class:`BulkImageDownloader` + high-level convenience helpers
+- ``downloader``: :class:`BulkImageDownloader` (composed) + high-level helpers
+- ``bulk_metadata``: bulk-metadata lifecycle for the downloader (mixin)
+- ``local_resolver``: local image-index resolution + API fallbacks (mixin)
+- ``image_writer``: per-face image fetch/write/cache record (mixin)
 - ``bulk_data``: bulk data freshness checks and metadata downloads (mixin)
 - ``printing_index``: printing index build/load functions + mixin
 - ``metadata``: on-demand printings metadata lookups (mixin)

--- a/services/image_service/bulk_metadata.py
+++ b/services/image_service/bulk_metadata.py
@@ -1,0 +1,147 @@
+"""Bulk-metadata lifecycle for :class:`BulkImageDownloader`.
+
+Talks to the Scryfall bulk-data metadata endpoint, the ``bulk_data_meta`` SQLite
+row, and the on-disk bulk file: freshness checks plus the streamed atomic
+download.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from services.image_service.schemas import BULK_DATA_URL, UTC
+from utils.atomic_io import atomic_write_stream
+from utils.constants import (
+    BULK_DATA_CACHE_FRESHNESS_SECONDS,
+    BYTES_PER_MB,
+    SCRYFALL_BULK_STREAM_TIMEOUT_SECONDS,
+    SCRYFALL_DOWNLOAD_CHUNK_SIZE,
+    SCRYFALL_REQUEST_TIMEOUT_SECONDS,
+    SQLITE_CONNECTION_TIMEOUT_SECONDS,
+)
+
+if TYPE_CHECKING:
+    from services.image_service.downloader_protocol import BulkImageDownloaderProto
+
+    _Base = BulkImageDownloaderProto
+else:
+    _Base = object
+
+
+class BulkMetadataMixin(_Base):
+    """Bulk-data metadata fetch, freshness check, and streamed download."""
+
+    def _fetch_bulk_metadata(self) -> dict[str, Any]:
+        logger.info("Fetching bulk data metadata from Scryfall...")
+        resp = self.session.get(BULK_DATA_URL, timeout=SCRYFALL_REQUEST_TIMEOUT_SECONDS)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _get_cached_bulk_data_record(self) -> tuple[str | None, str | None]:
+        with sqlite3.connect(self.cache.db_path, timeout=SQLITE_CONNECTION_TIMEOUT_SECONDS) as conn:
+            row = conn.execute(
+                "SELECT downloaded_at, bulk_data_uri FROM bulk_data_meta WHERE id = 1"
+            ).fetchone()
+        if row:
+            return row[0], row[1]
+        return None, None
+
+    def is_bulk_data_outdated(
+        self, max_staleness_seconds: int | None = None
+    ) -> tuple[bool, dict[str, Any]]:
+        # Lazy import so monkeypatches of ``BULK_DATA_CACHE`` on the schemas
+        # module are honoured by tests.
+        from services.image_service import schemas as _schemas
+
+        metadata = self._fetch_bulk_metadata()
+        download_uri = metadata.get("download_uri")
+        updated_at = metadata.get("updated_at")
+
+        if not _schemas.BULK_DATA_CACHE.exists():
+            return True, metadata
+
+        cached_updated, cached_uri = self._get_cached_bulk_data_record()
+        if updated_at and download_uri and cached_updated and cached_uri:
+            if updated_at == cached_updated and download_uri == cached_uri:
+                return False, metadata
+            return True, metadata
+
+        # Fallback to age-based check when the vendor metadata lacks timestamps/URIs
+        threshold = max_staleness_seconds or BULK_DATA_CACHE_FRESHNESS_SECONDS
+        try:
+            age_seconds = datetime.now().timestamp() - _schemas.BULK_DATA_CACHE.stat().st_mtime
+            if age_seconds < threshold:
+                return False, metadata
+        except OSError:
+            pass
+
+        return True, metadata
+
+    def download_bulk_metadata(self, force: bool = False) -> tuple[bool, str]:
+        from services.image_service import schemas as _schemas
+
+        try:
+            metadata = self._fetch_bulk_metadata()
+        except Exception as exc:
+            logger.exception("Failed to fetch bulk data metadata")
+            return False, f"Error: {exc}"
+
+        download_uri = metadata.get("download_uri")
+        if not download_uri:
+            return False, "No download URI in bulk data response"
+
+        remote_updated_at = metadata.get("updated_at")
+        cached_updated, cached_uri = self._get_cached_bulk_data_record()
+        cache_matches = (
+            not force
+            and _schemas.BULK_DATA_CACHE.exists()
+            and remote_updated_at
+            and cached_updated == remote_updated_at
+            and cached_uri == download_uri
+        )
+        if cache_matches:
+            logger.info("Using cached bulk data (vendor metadata is current)")
+            return True, "Using cached bulk data"
+
+        try:
+            logger.info(f"Downloading bulk data from {download_uri}")
+            logger.info(f"Size: {metadata.get('size', 0) / BYTES_PER_MB:.1f} MB")
+
+            # Download with progress
+            resp = self.session.get(
+                download_uri, stream=True, timeout=SCRYFALL_BULK_STREAM_TIMEOUT_SECONDS
+            )
+            resp.raise_for_status()
+
+            atomic_write_stream(
+                _schemas.BULK_DATA_CACHE,
+                resp.iter_content(chunk_size=SCRYFALL_DOWNLOAD_CHUNK_SIZE),
+            )
+
+            # Update database metadata (defer card count to avoid parsing 500MB file)
+            with sqlite3.connect(
+                self.cache.db_path, timeout=SQLITE_CONNECTION_TIMEOUT_SECONDS
+            ) as conn:
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO bulk_data_meta (id, downloaded_at, total_cards, bulk_data_uri)
+                    VALUES (1, ?, ?, ?)
+                """,
+                    (
+                        remote_updated_at or datetime.now(UTC).isoformat(),
+                        0,
+                        download_uri,
+                    ),
+                )
+                conn.commit()
+
+            logger.info("Bulk data downloaded successfully")
+            return True, "Bulk data downloaded"
+
+        except Exception as exc:
+            logger.exception("Failed to download bulk data")
+            return False, f"Error: {exc}"

--- a/services/image_service/downloader.py
+++ b/services/image_service/downloader.py
@@ -1,50 +1,55 @@
 """Scryfall request loop and bulk fetch.
 
 Contains:
-- :class:`BulkImageDownloader` — fetches metadata and individual card images
+- :class:`BulkImageDownloader` — fetches metadata and individual card images,
+  composed from three responsibility-specific mixins:
+
+  - :class:`~services.image_service.bulk_metadata.BulkMetadataMixin` — bulk-data
+    metadata lifecycle (Scryfall metadata fetch, freshness check, streamed
+    atomic download).
+  - :class:`~services.image_service.local_resolver.LocalResolverMixin` — local
+    name -> image index plus the ``/cards/named`` and ``/cards/search`` fallbacks.
+  - :class:`~services.image_service.image_writer.ImageWriterMixin` — per-face
+    layout dispatch, fetch, atomic write and cache record.
+
 - Top-level helpers used by scripts and widgets: :func:`get_cache`,
   :func:`get_card_image`, :func:`download_bulk_images`, :func:`get_cache_stats`.
 """
 
 from __future__ import annotations
 
-import sqlite3
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import requests
 from loguru import logger
 
+from services.image_service.bulk_metadata import BulkMetadataMixin
 from services.image_service.disk_cache import CardImageCache
-from services.image_service.schemas import (
-    BULK_DATA_URL,
-    SCRYFALL_CARD_NAMED_URL,
-    SCRYFALL_CARD_SEARCH_URL,
-    UTC,
-    BulkCardImage,
-)
-from utils.atomic_io import (
-    atomic_write_bytes,
-    atomic_write_stream,
-    locked_path,
-)
+from services.image_service.image_writer import ImageWriterMixin
+from services.image_service.local_resolver import LocalResolverMixin
+from services.image_service.schemas import BulkCardImage
+from utils.atomic_io import locked_path
 from utils.constants import (
-    BULK_DATA_CACHE_FRESHNESS_SECONDS,
-    BYTES_PER_MB,
-    SCRYFALL_BULK_STREAM_TIMEOUT_SECONDS,
-    SCRYFALL_DOWNLOAD_CHUNK_SIZE,
     SCRYFALL_DOWNLOAD_PROGRESS_INTERVAL,
     SCRYFALL_MAX_DOWNLOAD_WORKERS,
-    SCRYFALL_REQUEST_TIMEOUT_SECONDS,
-    SQLITE_CONNECTION_TIMEOUT_SECONDS,
 )
 
 
-class BulkImageDownloader:
-    """High-throughput bulk image downloader using Scryfall data."""
+class BulkImageDownloader(
+    BulkMetadataMixin,
+    LocalResolverMixin,
+    ImageWriterMixin,
+):
+    """High-throughput bulk image downloader using Scryfall data.
+
+    Composed from :class:`BulkMetadataMixin`, :class:`LocalResolverMixin` and
+    :class:`ImageWriterMixin`. All shared instance state — ``session``,
+    ``cache`` and the lazily-built local image index — is initialized here on
+    the concrete class; the mixins reach it via ``self``.
+    """
 
     def __init__(self, cache: CardImageCache, max_workers: int = SCRYFALL_MAX_DOWNLOAD_WORKERS):
         self.cache = cache
@@ -58,35 +63,6 @@ class BulkImageDownloader:
         self._local_image_index_mtime: float | None = None
         self._local_image_index_lock = threading.Lock()
 
-    def _fetch_bulk_metadata(self) -> dict[str, Any]:
-        logger.info("Fetching bulk data metadata from Scryfall...")
-        resp = self.session.get(BULK_DATA_URL, timeout=SCRYFALL_REQUEST_TIMEOUT_SECONDS)
-        resp.raise_for_status()
-        return resp.json()
-
-    def fetch_card_by_name(self, name: str, set_code: str | None = None) -> dict[str, Any]:
-        params = {"exact": name}
-        if set_code:
-            params["set"] = set_code.lower()
-        resp = self.session.get(
-            SCRYFALL_CARD_NAMED_URL, params=params, timeout=SCRYFALL_REQUEST_TIMEOUT_SECONDS
-        )
-        resp.raise_for_status()
-        return resp.json()
-
-    def fetch_printings_by_name(self, name: str) -> list[dict[str, Any]]:
-        params = {"q": f'!"{name}"', "unique": "prints", "order": "released"}
-        results: list[dict[str, Any]] = []
-        url: str | None = SCRYFALL_CARD_SEARCH_URL
-        while url:
-            resp = self.session.get(url, params=params, timeout=SCRYFALL_REQUEST_TIMEOUT_SECONDS)
-            resp.raise_for_status()
-            payload = resp.json()
-            results.extend(payload.get("data", []))
-            url = payload.get("next_page")
-            params = None
-        return results
-
     def download_card_image_by_name(
         self, name: str, size: str = "normal", set_code: str | None = None
     ) -> tuple[bool, str]:
@@ -94,332 +70,6 @@ class BulkImageDownloader:
         if card is None:
             card = self.fetch_card_by_name(name, set_code=set_code)
         return self._download_single_image(card, size)
-
-    def _resolve_card_locally(self, name: str, set_code: str | None = None) -> BulkCardImage | None:
-        """Resolve a card's image metadata from the locally-cached bulk data.
-
-        Returns ``None`` on any miss (no bulk data, name absent, or no
-        matching printing for the requested set) so callers fall back to the
-        Scryfall ``/cards/named`` API.
-        """
-        index = self._get_local_image_index()
-        if not index:
-            return None
-        entries = index.get((name or "").strip().lower())
-        if not entries:
-            return None
-        if set_code:
-            wanted = set_code.strip().lower()
-            for entry in entries:
-                if (entry.set or "").strip().lower() == wanted:
-                    return entry
-            # Requested a specific printing we don't have locally; defer to the
-            # API so the correct set printing is fetched.
-            return None
-        return entries[0]
-
-    def _get_local_image_index(self) -> dict[str, list[BulkCardImage]] | None:
-        """Lazily build (and cache) the name -> image-record index.
-
-        The index is rebuilt when the on-disk bulk data file changes. Building
-        parses the full bulk file once; subsequent lookups are in-memory.
-        """
-        from services.image_service import schemas as _schemas
-        from services.image_service.printing_index import _collect_face_aliases
-        from services.image_service.schemas import _bulk_card_images_decoder
-
-        bulk_path = _schemas.BULK_DATA_CACHE
-        if not bulk_path.exists():
-            return None
-
-        try:
-            mtime = bulk_path.stat().st_mtime
-        except OSError:
-            return None
-
-        with self._local_image_index_lock:
-            if self._local_image_index is not None and self._local_image_index_mtime == mtime:
-                return self._local_image_index
-
-            try:
-                with locked_path(bulk_path):
-                    raw = bulk_path.read_bytes()
-                cards = _bulk_card_images_decoder.decode(raw)
-            except Exception as exc:
-                logger.warning(f"Failed to build local image index from bulk data: {exc}")
-                self._local_image_index = {}
-                self._local_image_index_mtime = mtime
-                return self._local_image_index
-
-            index: dict[str, list[BulkCardImage]] = {}
-            for card in cards:
-                name = (card.name or "").strip()
-                if not name or not card.id:
-                    continue
-                key = name.lower()
-                index.setdefault(key, []).append(card)
-                # Alias individual face names (and split halves) so that deck
-                # entries that reference a single face still resolve locally,
-                # mirroring Scryfall's exact-name face matching.
-                for alias in _collect_face_aliases(card, name):
-                    alias_key = alias.lower()
-                    if alias_key != key:
-                        index.setdefault(alias_key, []).append(card)
-            self._local_image_index = index
-            self._local_image_index_mtime = mtime
-            logger.debug(f"Built local image index ({len(index)} names) from bulk data")
-            return self._local_image_index
-
-    def _get_cached_bulk_data_record(self) -> tuple[str | None, str | None]:
-        with sqlite3.connect(self.cache.db_path, timeout=SQLITE_CONNECTION_TIMEOUT_SECONDS) as conn:
-            row = conn.execute(
-                "SELECT downloaded_at, bulk_data_uri FROM bulk_data_meta WHERE id = 1"
-            ).fetchone()
-        if row:
-            return row[0], row[1]
-        return None, None
-
-    def is_bulk_data_outdated(
-        self, max_staleness_seconds: int | None = None
-    ) -> tuple[bool, dict[str, Any]]:
-        # Lazy import so monkeypatches of ``BULK_DATA_CACHE`` on the schemas
-        # module are honoured by tests.
-        from services.image_service import schemas as _schemas
-
-        metadata = self._fetch_bulk_metadata()
-        download_uri = metadata.get("download_uri")
-        updated_at = metadata.get("updated_at")
-
-        if not _schemas.BULK_DATA_CACHE.exists():
-            return True, metadata
-
-        cached_updated, cached_uri = self._get_cached_bulk_data_record()
-        if updated_at and download_uri and cached_updated and cached_uri:
-            if updated_at == cached_updated and download_uri == cached_uri:
-                return False, metadata
-            return True, metadata
-
-        # Fallback to age-based check when the vendor metadata lacks timestamps/URIs
-        threshold = max_staleness_seconds or BULK_DATA_CACHE_FRESHNESS_SECONDS
-        try:
-            age_seconds = datetime.now().timestamp() - _schemas.BULK_DATA_CACHE.stat().st_mtime
-            if age_seconds < threshold:
-                return False, metadata
-        except OSError:
-            pass
-
-        return True, metadata
-
-    def download_bulk_metadata(self, force: bool = False) -> tuple[bool, str]:
-        from services.image_service import schemas as _schemas
-
-        try:
-            metadata = self._fetch_bulk_metadata()
-        except Exception as exc:
-            logger.exception("Failed to fetch bulk data metadata")
-            return False, f"Error: {exc}"
-
-        download_uri = metadata.get("download_uri")
-        if not download_uri:
-            return False, "No download URI in bulk data response"
-
-        remote_updated_at = metadata.get("updated_at")
-        cached_updated, cached_uri = self._get_cached_bulk_data_record()
-        cache_matches = (
-            not force
-            and _schemas.BULK_DATA_CACHE.exists()
-            and remote_updated_at
-            and cached_updated == remote_updated_at
-            and cached_uri == download_uri
-        )
-        if cache_matches:
-            logger.info("Using cached bulk data (vendor metadata is current)")
-            return True, "Using cached bulk data"
-
-        try:
-            logger.info(f"Downloading bulk data from {download_uri}")
-            logger.info(f"Size: {metadata.get('size', 0) / BYTES_PER_MB:.1f} MB")
-
-            # Download with progress
-            resp = self.session.get(
-                download_uri, stream=True, timeout=SCRYFALL_BULK_STREAM_TIMEOUT_SECONDS
-            )
-            resp.raise_for_status()
-
-            atomic_write_stream(
-                _schemas.BULK_DATA_CACHE,
-                resp.iter_content(chunk_size=SCRYFALL_DOWNLOAD_CHUNK_SIZE),
-            )
-
-            # Update database metadata (defer card count to avoid parsing 500MB file)
-            with sqlite3.connect(
-                self.cache.db_path, timeout=SQLITE_CONNECTION_TIMEOUT_SECONDS
-            ) as conn:
-                conn.execute(
-                    """
-                    INSERT OR REPLACE INTO bulk_data_meta (id, downloaded_at, total_cards, bulk_data_uri)
-                    VALUES (1, ?, ?, ?)
-                """,
-                    (
-                        remote_updated_at or datetime.now(UTC).isoformat(),
-                        0,
-                        download_uri,
-                    ),
-                )
-                conn.commit()
-
-            logger.info("Bulk data downloaded successfully")
-            return True, "Bulk data downloaded"
-
-        except Exception as exc:
-            logger.exception("Failed to download bulk data")
-            return False, f"Error: {exc}"
-
-    def _download_single_image(
-        self, card: dict[str, Any], size: str = "normal"
-    ) -> tuple[bool, str]:
-        uuid = card.get("id")
-        name = card.get("name", "Unknown")
-
-        if not uuid:
-            return False, f"No UUID for {name}"
-
-        card_faces = card.get("card_faces") or []
-        if card_faces:
-            return self._download_multi_face_card(card, card_faces, size)
-
-        success, message, _ = self._download_face_asset(
-            uuid=uuid,
-            face_index=0,
-            name=name,
-            image_uris=card.get("image_uris") or {},
-            size=size,
-            card=card,
-        )
-        return success, message
-
-    def _download_multi_face_card(
-        self, card: dict[str, Any], faces: list[dict[str, Any]], size: str
-    ) -> tuple[bool, str]:
-        uuid = card.get("id")
-        if not uuid:
-            return False, "Missing UUID for multi-face card"
-
-        # Single-image layouts (split, flip, adventure, prepare) carry one
-        # physical image at the top level; per-face image_uris are empty.
-        # Two-image layouts (transform, modal_dfc, reversible_card) put the
-        # image_uris on each face. Dispatch by presence rather than by layout
-        # name so future Scryfall layouts with the same shape work without code
-        # changes.
-        if not any((face.get("image_uris") or {}) for face in faces):
-            return self._download_single_image_multi_face(card, size)
-
-        downloaded = 0
-        front_path: Path | None = None
-        for idx, face in enumerate(faces):
-            face_name = face.get("name") or card.get("name", "Unknown")
-            image_uris = face.get("image_uris") or {}
-            success, _, file_path = self._download_face_asset(
-                uuid=uuid,
-                face_index=idx,
-                name=face_name,
-                image_uris=image_uris,
-                size=size,
-                card=card,
-            )
-            if success:
-                downloaded += 1
-                if idx == 0:
-                    front_path = file_path
-
-        # Store combined display name pointing to the front face
-        combined_name = card.get("name")
-        if combined_name and front_path:
-            self.cache.add_image(
-                uuid=uuid,
-                name=combined_name,
-                set_code=card.get("set", ""),
-                collector_number=card.get("collector_number", ""),
-                image_size=size,
-                file_path=front_path,
-                scryfall_uri=card.get("scryfall_uri"),
-                artist=card.get("artist"),
-                face_index=-1,
-            )
-
-        if downloaded == 0:
-            return False, f"No downloadable faces for {card.get('name', 'Unknown')}"
-        return True, f"Downloaded {downloaded} faces for {card.get('name', 'Unknown')}"
-
-    def _download_single_image_multi_face(
-        self, card: dict[str, Any], size: str
-    ) -> tuple[bool, str]:
-        uuid = card.get("id") or ""
-        combined_name = card.get("name", "Unknown")
-        image_uris = card.get("image_uris") or {}
-
-        success, message, _ = self._download_face_asset(
-            uuid=uuid,
-            face_index=0,
-            name=combined_name,
-            image_uris=image_uris,
-            size=size,
-            card=card,
-        )
-        return success, message
-
-    def _download_face_asset(
-        self,
-        uuid: str,
-        face_index: int,
-        name: str,
-        image_uris: dict[str, Any],
-        size: str,
-        card: dict[str, Any],
-    ) -> tuple[bool, str, Path | None]:
-        if self.cache.is_cached(uuid, size, face_index=face_index):
-            path = self.cache.get_image_by_uuid(uuid, size, face_index=face_index)
-            return True, f"Already cached: {name}", path
-
-        image_url = image_uris.get(size) or image_uris.get("normal")
-        if not image_url:
-            return False, f"No {size} image for {name}", None
-
-        try:
-            resp = self.session.get(image_url, timeout=SCRYFALL_REQUEST_TIMEOUT_SECONDS)
-            resp.raise_for_status()
-        except Exception as exc:
-            logger.debug(f"Failed to download {name}: {exc}")
-            return False, f"Error: {name} - {exc}", None
-
-        ext = "png" if size == "png" else "jpg"
-        filename = self._build_face_filename(uuid, face_index, ext)
-        file_path = self.cache.cache_dir / size / filename
-
-        try:
-            atomic_write_bytes(file_path, resp.content)
-        except Exception as exc:
-            logger.debug(f"Failed to write image {name}: {exc}")
-            return False, f"Error saving image for {name}: {exc}", None
-
-        self.cache.add_image(
-            uuid=uuid,
-            name=name,
-            set_code=card.get("set", ""),
-            collector_number=card.get("collector_number", ""),
-            image_size=size,
-            file_path=file_path,
-            scryfall_uri=card.get("scryfall_uri"),
-            artist=card.get("artist"),
-            face_index=face_index,
-        )
-        return True, f"Downloaded: {name}", file_path
-
-    @staticmethod
-    def _build_face_filename(uuid: str, face_index: int, ext: str) -> str:
-        if face_index <= 0:
-            return f"{uuid}.{ext}"
-        return f"{uuid}-f{face_index}.{ext}"
 
     def download_all_images(
         self,

--- a/services/image_service/downloader_protocol.py
+++ b/services/image_service/downloader_protocol.py
@@ -1,0 +1,32 @@
+"""Shared ``self`` contract that the :class:`BulkImageDownloader` mixins assume.
+
+The downloader is composed from three responsibility-specific mixins
+(:class:`BulkMetadataMixin`, :class:`LocalResolverMixin`,
+:class:`ImageWriterMixin`) plus the thin orchestration on
+:class:`BulkImageDownloader` itself. They share only the ``session``/``cache``
+handles and the lazily-built local image index; this Protocol documents that
+surface so each mixin can reach it via ``self`` under the ``_Base = Proto``
+idiom used elsewhere in the package.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Protocol
+
+import requests
+
+from services.image_service.disk_cache import CardImageCache
+from services.image_service.schemas import BulkCardImage
+
+
+class BulkImageDownloaderProto(Protocol):
+    """Cross-mixin ``self`` surface for ``BulkImageDownloader``."""
+
+    cache: CardImageCache
+    max_workers: int
+    session: requests.Session
+
+    _local_image_index: dict[str, list[BulkCardImage]] | None
+    _local_image_index_mtime: float | None
+    _local_image_index_lock: threading.Lock

--- a/services/image_service/image_writer.py
+++ b/services/image_service/image_writer.py
@@ -1,0 +1,172 @@
+"""Per-face image writing for :class:`BulkImageDownloader`.
+
+Talks only to ``self.cache`` and ``self.session``: layout dispatch, per-face
+fetch + :func:`atomic_write_bytes` + ``cache.add_image``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from utils.atomic_io import atomic_write_bytes
+from utils.constants import SCRYFALL_REQUEST_TIMEOUT_SECONDS
+
+if TYPE_CHECKING:
+    from services.image_service.downloader_protocol import BulkImageDownloaderProto
+
+    _Base = BulkImageDownloaderProto
+else:
+    _Base = object
+
+
+class ImageWriterMixin(_Base):
+    """Layout dispatch and per-face image fetch + atomic write + cache record."""
+
+    def _download_single_image(
+        self, card: dict[str, Any], size: str = "normal"
+    ) -> tuple[bool, str]:
+        uuid = card.get("id")
+        name = card.get("name", "Unknown")
+
+        if not uuid:
+            return False, f"No UUID for {name}"
+
+        card_faces = card.get("card_faces") or []
+        if card_faces:
+            return self._download_multi_face_card(card, card_faces, size)
+
+        success, message, _ = self._download_face_asset(
+            uuid=uuid,
+            face_index=0,
+            name=name,
+            image_uris=card.get("image_uris") or {},
+            size=size,
+            card=card,
+        )
+        return success, message
+
+    def _download_multi_face_card(
+        self, card: dict[str, Any], faces: list[dict[str, Any]], size: str
+    ) -> tuple[bool, str]:
+        uuid = card.get("id")
+        if not uuid:
+            return False, "Missing UUID for multi-face card"
+
+        # Single-image layouts (split, flip, adventure, prepare) carry one
+        # physical image at the top level; per-face image_uris are empty.
+        # Two-image layouts (transform, modal_dfc, reversible_card) put the
+        # image_uris on each face. Dispatch by presence rather than by layout
+        # name so future Scryfall layouts with the same shape work without code
+        # changes.
+        if not any((face.get("image_uris") or {}) for face in faces):
+            return self._download_single_image_multi_face(card, size)
+
+        downloaded = 0
+        front_path: Path | None = None
+        for idx, face in enumerate(faces):
+            face_name = face.get("name") or card.get("name", "Unknown")
+            image_uris = face.get("image_uris") or {}
+            success, _, file_path = self._download_face_asset(
+                uuid=uuid,
+                face_index=idx,
+                name=face_name,
+                image_uris=image_uris,
+                size=size,
+                card=card,
+            )
+            if success:
+                downloaded += 1
+                if idx == 0:
+                    front_path = file_path
+
+        # Store combined display name pointing to the front face
+        combined_name = card.get("name")
+        if combined_name and front_path:
+            self.cache.add_image(
+                uuid=uuid,
+                name=combined_name,
+                set_code=card.get("set", ""),
+                collector_number=card.get("collector_number", ""),
+                image_size=size,
+                file_path=front_path,
+                scryfall_uri=card.get("scryfall_uri"),
+                artist=card.get("artist"),
+                face_index=-1,
+            )
+
+        if downloaded == 0:
+            return False, f"No downloadable faces for {card.get('name', 'Unknown')}"
+        return True, f"Downloaded {downloaded} faces for {card.get('name', 'Unknown')}"
+
+    def _download_single_image_multi_face(
+        self, card: dict[str, Any], size: str
+    ) -> tuple[bool, str]:
+        uuid = card.get("id") or ""
+        combined_name = card.get("name", "Unknown")
+        image_uris = card.get("image_uris") or {}
+
+        success, message, _ = self._download_face_asset(
+            uuid=uuid,
+            face_index=0,
+            name=combined_name,
+            image_uris=image_uris,
+            size=size,
+            card=card,
+        )
+        return success, message
+
+    def _download_face_asset(
+        self,
+        uuid: str,
+        face_index: int,
+        name: str,
+        image_uris: dict[str, Any],
+        size: str,
+        card: dict[str, Any],
+    ) -> tuple[bool, str, Path | None]:
+        if self.cache.is_cached(uuid, size, face_index=face_index):
+            path = self.cache.get_image_by_uuid(uuid, size, face_index=face_index)
+            return True, f"Already cached: {name}", path
+
+        image_url = image_uris.get(size) or image_uris.get("normal")
+        if not image_url:
+            return False, f"No {size} image for {name}", None
+
+        try:
+            resp = self.session.get(image_url, timeout=SCRYFALL_REQUEST_TIMEOUT_SECONDS)
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.debug(f"Failed to download {name}: {exc}")
+            return False, f"Error: {name} - {exc}", None
+
+        ext = "png" if size == "png" else "jpg"
+        filename = self._build_face_filename(uuid, face_index, ext)
+        file_path = self.cache.cache_dir / size / filename
+
+        try:
+            atomic_write_bytes(file_path, resp.content)
+        except Exception as exc:
+            logger.debug(f"Failed to write image {name}: {exc}")
+            return False, f"Error saving image for {name}: {exc}", None
+
+        self.cache.add_image(
+            uuid=uuid,
+            name=name,
+            set_code=card.get("set", ""),
+            collector_number=card.get("collector_number", ""),
+            image_size=size,
+            file_path=file_path,
+            scryfall_uri=card.get("scryfall_uri"),
+            artist=card.get("artist"),
+            face_index=face_index,
+        )
+        return True, f"Downloaded: {name}", file_path
+
+    @staticmethod
+    def _build_face_filename(uuid: str, face_index: int, ext: str) -> str:
+        if face_index <= 0:
+            return f"{uuid}.{ext}"
+        return f"{uuid}-f{face_index}.{ext}"

--- a/services/image_service/local_resolver.py
+++ b/services/image_service/local_resolver.py
@@ -1,0 +1,129 @@
+"""Local-index resolution for :class:`BulkImageDownloader`.
+
+Owns the lazily-built name -> :class:`BulkCardImage` index
+(``_local_image_index``/``_mtime``/``_lock``, initialized on the composed class)
+and the Scryfall ``/cards/named`` and ``/cards/search`` API fallbacks.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from services.image_service.schemas import (
+    SCRYFALL_CARD_NAMED_URL,
+    SCRYFALL_CARD_SEARCH_URL,
+    BulkCardImage,
+)
+from utils.atomic_io import locked_path
+from utils.constants import SCRYFALL_REQUEST_TIMEOUT_SECONDS
+
+if TYPE_CHECKING:
+    from services.image_service.downloader_protocol import BulkImageDownloaderProto
+
+    _Base = BulkImageDownloaderProto
+else:
+    _Base = object
+
+
+class LocalResolverMixin(_Base):
+    """Local bulk-data image resolution plus Scryfall name/search fallbacks."""
+
+    def fetch_card_by_name(self, name: str, set_code: str | None = None) -> dict[str, Any]:
+        params = {"exact": name}
+        if set_code:
+            params["set"] = set_code.lower()
+        resp = self.session.get(
+            SCRYFALL_CARD_NAMED_URL, params=params, timeout=SCRYFALL_REQUEST_TIMEOUT_SECONDS
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def fetch_printings_by_name(self, name: str) -> list[dict[str, Any]]:
+        params = {"q": f'!"{name}"', "unique": "prints", "order": "released"}
+        results: list[dict[str, Any]] = []
+        url: str | None = SCRYFALL_CARD_SEARCH_URL
+        while url:
+            resp = self.session.get(url, params=params, timeout=SCRYFALL_REQUEST_TIMEOUT_SECONDS)
+            resp.raise_for_status()
+            payload = resp.json()
+            results.extend(payload.get("data", []))
+            url = payload.get("next_page")
+            params = None
+        return results
+
+    def _resolve_card_locally(self, name: str, set_code: str | None = None) -> BulkCardImage | None:
+        """Resolve a card's image metadata from the locally-cached bulk data.
+
+        Returns ``None`` on any miss (no bulk data, name absent, or no
+        matching printing for the requested set) so callers fall back to the
+        Scryfall ``/cards/named`` API.
+        """
+        index = self._get_local_image_index()
+        if not index:
+            return None
+        entries = index.get((name or "").strip().lower())
+        if not entries:
+            return None
+        if set_code:
+            wanted = set_code.strip().lower()
+            for entry in entries:
+                if (entry.set or "").strip().lower() == wanted:
+                    return entry
+            # Requested a specific printing we don't have locally; defer to the
+            # API so the correct set printing is fetched.
+            return None
+        return entries[0]
+
+    def _get_local_image_index(self) -> dict[str, list[BulkCardImage]] | None:
+        """Lazily build (and cache) the name -> image-record index.
+
+        The index is rebuilt when the on-disk bulk data file changes. Building
+        parses the full bulk file once; subsequent lookups are in-memory.
+        """
+        from services.image_service import schemas as _schemas
+        from services.image_service.printing_index import _collect_face_aliases
+        from services.image_service.schemas import _bulk_card_images_decoder
+
+        bulk_path = _schemas.BULK_DATA_CACHE
+        if not bulk_path.exists():
+            return None
+
+        try:
+            mtime = bulk_path.stat().st_mtime
+        except OSError:
+            return None
+
+        with self._local_image_index_lock:
+            if self._local_image_index is not None and self._local_image_index_mtime == mtime:
+                return self._local_image_index
+
+            try:
+                with locked_path(bulk_path):
+                    raw = bulk_path.read_bytes()
+                cards = _bulk_card_images_decoder.decode(raw)
+            except Exception as exc:
+                logger.warning(f"Failed to build local image index from bulk data: {exc}")
+                self._local_image_index = {}
+                self._local_image_index_mtime = mtime
+                return self._local_image_index
+
+            index: dict[str, list[BulkCardImage]] = {}
+            for card in cards:
+                name = (card.name or "").strip()
+                if not name or not card.id:
+                    continue
+                key = name.lower()
+                index.setdefault(key, []).append(card)
+                # Alias individual face names (and split halves) so that deck
+                # entries that reference a single face still resolve locally,
+                # mirroring Scryfall's exact-name face matching.
+                for alias in _collect_face_aliases(card, name):
+                    alias_key = alias.lower()
+                    if alias_key != key:
+                        index.setdefault(alias_key, []).append(card)
+            self._local_image_index = index
+            self._local_image_index_mtime = mtime
+            logger.debug(f"Built local image index ({len(index)} names) from bulk data")
+            return self._local_image_index


### PR DESCRIPTION
Closes #804

Behavior-preserving decomposition of the 551-LOC `BulkImageDownloader` god-class in `services/image_service/downloader.py` into three responsibility-specific mixins composed onto a slimmed concrete class. This follows the package's existing mixin+protocol service pattern (`ImageService` composes `BulkDataMixin`/`PrintingIndexMixin`/… with `ImageServiceProto`).

This is a move-only refactor: method bodies, names, signatures, and wiring are unchanged. No runtime behavior, public API, or event-wiring semantics changed.

## Files added
- `services/image_service/bulk_metadata.py` (147 LOC) — `BulkMetadataMixin`: `_fetch_bulk_metadata`, `_get_cached_bulk_data_record`, `is_bulk_data_outdated`, `download_bulk_metadata` (Scryfall metadata fetch, `bulk_data_meta` freshness check, streamed atomic download).
- `services/image_service/local_resolver.py` (129 LOC) — `LocalResolverMixin`: `fetch_card_by_name`, `fetch_printings_by_name`, `_resolve_card_locally`, `_get_local_image_index` (lazy name->`BulkCardImage` index build/mtime-invalidation/face-aliasing + `/cards/named` and `/cards/search` fallbacks).
- `services/image_service/image_writer.py` (172 LOC) — `ImageWriterMixin`: `_download_single_image`, `_download_multi_face_card`, `_download_single_image_multi_face`, `_download_face_asset`, `_build_face_filename` (layout dispatch, per-face fetch + `atomic_write_bytes` + `cache.add_image`).
- `services/image_service/downloader_protocol.py` (32 LOC) — `BulkImageDownloaderProto`: the shared `self` surface (`cache`/`session`/`max_workers` + the local-index trio) for the `_Base = Proto` idiom. Kept in its own module to avoid the import cycle with the existing `protocol.py` (which imports `BulkImageDownloader`).

## Files changed
- `services/image_service/downloader.py` — **551 -> 201 LOC**. Slimmed `BulkImageDownloader` now composes `BulkMetadataMixin, LocalResolverMixin, ImageWriterMixin`. `__init__` keeps **all** instance state (session, the `_local_image_index`/`_mtime`/`_lock` trio, cache, max_workers) on the concrete class — mixins reach it via `self`. Retains the `download_card_image_by_name` entrypoint, `download_all_images` ThreadPoolExecutor orchestration (`self.session` still reused across the pool), and the unchanged module-level singleton facade (`get_cache`/`get_card_image`/`download_bulk_images`/`get_cache_stats`).
- `services/image_service/__init__.py` — docstring module list updated; the `BulkImageDownloader` re-export is unchanged.

## Safety notes
- The local-index trio is initialized only in the composed class `__init__` and read/written only by `LocalResolverMixin` via `self` — mixins do not define their own `__init__`.
- Lazy imports of `services.image_service.schemas` (for `BULK_DATA_CACHE` monkeypatching) and `printing_index._collect_face_aliases` moved **with** their methods, so the existing test monkeypatches still resolve.
- Class identity, method names (public and private), and the `services.image_service` package re-export of `BulkImageDownloader` are preserved. Tests in `tests/test_card_images_cache.py` construct `BulkImageDownloader` directly and call internals (`_resolve_card_locally`, `_download_face_asset`, `_download_single_image`, `is_bulk_data_outdated`, `cls._build_face_filename`) — all remain on the composed class.

## Verification (off-Windows; wx not importable here)
- `python -m py_compile` on all created/changed files: OK.
- `ruff check` on the 6 changed/new files: all checks passed.
- `black --check`: all files unchanged (already formatted).
- AST coverage check: all 15 original methods present exactly once across the split, none missing.
- `git grep` confirms every importer of `services.image_service.downloader` references only `BulkImageDownloader`/`get_cache`/the helpers — no dangling references to moved symbols.

Tests, the Windows installer build, and wx unit tests run on CI.

Nothing was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)