### PR TITLE
refactor(sideboard-guide): extract wx-free CSV codec from sideboard_guide_io.py (#806)

### DIFF
--- a/tests/test_sideboard_guide_csv.py
+++ b/tests/test_sideboard_guide_csv.py
@@ -1,0 +1,146 @@
+"""Tests for the wx-free sideboard-guide CSV codec."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from widgets.frames.app_frame.handlers.sideboard_guide_csv import (
+    export_guide_to_csv,
+    import_guide_from_csv,
+)
+
+
+def _read_rows(path: Path) -> list[list[str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.reader(fh))
+
+
+def test_export_builds_matrix_and_decklist(tmp_path: Path) -> None:
+    entries = [
+        {
+            "archetype": "Burn",
+            "play_out": {"Negate": 1},
+            "play_in": {"Pyroblast": 2},
+            "draw_out": {},
+            "draw_in": {},
+        }
+    ]
+    zone_cards = {
+        "main": [{"name": "Negate", "qty": 3}],
+        "side": [{"name": "Pyroblast", "qty": 2}],
+    }
+
+    out = tmp_path / "guide.csv"
+    export_guide_to_csv(entries, [], zone_cards, str(out))
+
+    rows = _read_rows(out)
+    header = rows[0]
+    assert header[0] == "Card"
+    assert "Burn (Play)" in header
+
+    play_col = header.index("Burn (Play)")
+    cells = {row[0]: row[play_col] for row in rows[1:] if row and row[0] in {"Negate", "Pyroblast"}}
+    assert cells["Negate"] == "Out 1"
+    assert cells["Pyroblast"] == "In 2"
+
+    assert ["DECKLIST"] in rows
+    assert ["Mainboard"] in rows
+    assert ["3 Negate"] in rows
+    assert ["Sideboard"] in rows
+    assert ["2 Pyroblast"] in rows
+
+
+def test_export_respects_exclusions(tmp_path: Path) -> None:
+    entries = [
+        {
+            "archetype": "Burn",
+            "play_out": {"Negate": 1},
+            "play_in": {},
+            "draw_out": {},
+            "draw_in": {},
+        },
+    ]
+    out = tmp_path / "guide.csv"
+    with pytest.raises(ValueError):
+        export_guide_to_csv(entries, ["Burn"], {"main": [], "side": []}, str(out))
+
+
+def test_export_raises_when_nothing_to_export(tmp_path: Path) -> None:
+    out = tmp_path / "guide.csv"
+    with pytest.raises(ValueError):
+        export_guide_to_csv([], [], {"main": [], "side": []}, str(out))
+
+
+def test_import_roundtrips_export(tmp_path: Path) -> None:
+    entries = [
+        {
+            "archetype": "Burn",
+            "play_out": {"Negate": 1},
+            "play_in": {"Pyroblast": 2},
+            "draw_out": {},
+            "draw_in": {},
+        }
+    ]
+    zone_cards = {
+        "main": [{"name": "Negate", "qty": 3}],
+        "side": [{"name": "Pyroblast", "qty": 2}],
+    }
+    path = tmp_path / "guide.csv"
+    export_guide_to_csv(entries, [], zone_cards, str(path))
+
+    imported, warnings = import_guide_from_csv(
+        file_path=str(path), mainboard_names={"Negate"}, sideboard_names={"Pyroblast"}
+    )
+    assert warnings == []
+    assert len(imported) == 1
+    entry = imported[0]
+    assert entry["archetype"] == "Burn"
+    assert entry["play_out"] == {"Negate": 1}
+    assert entry["play_in"] == {"Pyroblast": 2}
+    assert entry["notes"] == ""
+
+
+def test_import_warns_on_missing_cards(tmp_path: Path) -> None:
+    path = tmp_path / "guide.csv"
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["Card", "Burn (Play)"])
+        writer.writerow(["Negate", "Out 1"])
+        writer.writerow(["Pyroblast", "In 2"])
+
+    imported, warnings = import_guide_from_csv(
+        str(path), mainboard_names=set(), sideboard_names=set()
+    )
+    assert imported == [] or all(not e["play_out"] and not e["play_in"] for e in imported)
+    assert warnings
+    assert "Negate (not in mainboard)" in warnings[0]
+    assert "Pyroblast (not in sideboard)" in warnings[0]
+
+
+def test_import_rejects_bad_header(tmp_path: Path) -> None:
+    path = tmp_path / "bad.csv"
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["NotCard", "Burn (Play)"])
+    with pytest.raises(ValueError):
+        import_guide_from_csv(str(path), set(), set())
+
+
+def test_import_stops_at_decklist_section(tmp_path: Path) -> None:
+    path = tmp_path / "guide.csv"
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["Card", "Burn (Play)"])
+        writer.writerow(["Negate", "Out 1"])
+        writer.writerow(["DECKLIST"])
+        writer.writerow(["Mainboard"])
+        writer.writerow(["3 Negate"])
+
+    imported, _ = import_guide_from_csv(
+        str(path), mainboard_names={"Negate"}, sideboard_names=set()
+    )
+    assert len(imported) == 1
+    assert imported[0]["play_out"] == {"Negate": 1}

--- a/widgets/frames/app_frame/handlers/sideboard_guide_csv.py
+++ b/widgets/frames/app_frame/handlers/sideboard_guide_csv.py
@@ -1,0 +1,196 @@
+"""wx-free CSV codec for the sideboard guide.
+
+Pure serialization/parsing for the sideboard-guide matrix format, extracted
+from the wx import/export handlers so the matrix-building and regex-parsing
+logic is directly unit-testable. No wx dependency.
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+from typing import Any
+
+
+def export_guide_to_csv(
+    entries: list[dict[str, Any]],
+    exclusions: list[str],
+    zone_cards: dict[str, list[dict[str, Any]]],
+    file_path: str,
+) -> None:
+    """Export a sideboard guide to CSV with smart filtering.
+
+    Rows are cards, columns are matchups (archetype + scenario), cells show
+    actions (In/Out) and the decklist is appended after a separator.
+
+    Args:
+        entries: Sideboard guide entries.
+        exclusions: Archetype names to exclude from export.
+        zone_cards: Mapping of zone name ("main"/"side") to card dicts.
+        file_path: Destination CSV path.
+
+    Raises:
+        ValueError: If no cards remain to export after filtering.
+    """
+    card_actions: dict[str, dict[str, set[str]]] = {}
+
+    for entry in entries:
+        if entry.get("archetype") in exclusions:
+            continue
+
+        archetype = entry.get("archetype", "Unknown")
+        for scenario, out_key, in_key in [
+            ("Play", "play_out", "play_in"),
+            ("Draw", "draw_out", "draw_in"),
+        ]:
+            out_cards = entry.get(out_key, {})
+            in_cards = entry.get(in_key, {})
+
+            if isinstance(out_cards, dict):
+                for card_name, qty in out_cards.items():
+                    if qty > 0:
+                        card_actions.setdefault(card_name, {}).setdefault(
+                            f"{archetype} ({scenario})", set()
+                        ).add(f"Out {qty}")
+
+            if isinstance(in_cards, dict):
+                for card_name, qty in in_cards.items():
+                    if qty > 0:
+                        card_actions.setdefault(card_name, {}).setdefault(
+                            f"{archetype} ({scenario})", set()
+                        ).add(f"In {qty}")
+
+    filtered_cards = {card: actions for card, actions in card_actions.items() if actions}
+    if not filtered_cards:
+        raise ValueError("No cards to export after filtering")
+
+    all_matchups = sorted(
+        {matchup for actions in filtered_cards.values() for matchup in actions.keys()}
+    )
+
+    with open(file_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["Card"] + all_matchups)
+
+        for card_name in sorted(filtered_cards.keys()):
+            row = [card_name]
+            for matchup in all_matchups:
+                actions = filtered_cards[card_name].get(matchup, set())
+                row.append(" & ".join(sorted(actions)) if actions else "")
+            writer.writerow(row)
+
+        writer.writerow([])
+        writer.writerow([])
+        writer.writerow(["DECKLIST"])
+        writer.writerow([])
+
+        writer.writerow(["Mainboard"])
+        mainboard_cards = zone_cards.get("main", [])
+        for card in sorted(mainboard_cards, key=lambda c: c.get("name", "")):
+            writer.writerow([f"{card.get('qty', 0)} {card.get('name', '')}"])
+
+        writer.writerow([])
+        writer.writerow(["Sideboard"])
+        sideboard_cards = zone_cards.get("side", [])
+        for card in sorted(sideboard_cards, key=lambda c: c.get("name", "")):
+            writer.writerow([f"{card.get('qty', 0)} {card.get('name', '')}"])
+
+
+def import_guide_from_csv(
+    file_path: str,
+    mainboard_names: set[str],
+    sideboard_names: set[str],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Import a sideboard guide from CSV format with sanitization.
+
+    Args:
+        file_path: Source CSV path.
+        mainboard_names: Valid mainboard card names (for "Out" validation).
+        sideboard_names: Valid sideboard card names (for "In" validation).
+
+    Returns:
+        A tuple of (imported entries, list of warning messages).
+
+    Raises:
+        ValueError: If the CSV header is not in the expected format.
+    """
+    entries_by_archetype: dict[str, dict[str, dict[str, int]]] = {}
+    warnings: list[str] = []
+    missing_cards: set[str] = set()
+
+    with open(file_path, encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        header = next(reader, None)
+        if not header or header[0] != "Card":
+            raise ValueError("Invalid CSV format: expected 'Card' as first column header")
+
+        matchup_columns = header[1:]
+        archetype_scenario_map: list[tuple[str | None, str | None]] = []
+        for col in matchup_columns:
+            match = re.match(r"^(.+?)\s*\((Play|Draw)\)$", col)
+            if match:
+                archetype_name = match.group(1).strip()
+                scenario = match.group(2).lower()
+                archetype_scenario_map.append((archetype_name, scenario))
+            else:
+                archetype_scenario_map.append((None, None))
+
+        for row in reader:
+            if not row:
+                continue
+            if row[0] in ["DECKLIST", "Mainboard", "Sideboard"]:
+                break
+
+            card_name = row[0].strip()
+            if not card_name:
+                continue
+
+            for idx, cell_value in enumerate(row[1:], start=0):
+                if idx >= len(archetype_scenario_map):
+                    continue
+                archetype_name, scenario = archetype_scenario_map[idx]
+                if not archetype_name or not scenario:
+                    continue
+                if not cell_value or not cell_value.strip():
+                    continue
+
+                entries_by_archetype.setdefault(
+                    archetype_name,
+                    {"play_out": {}, "play_in": {}, "draw_out": {}, "draw_in": {}},
+                )
+
+                actions = cell_value.split("&")
+                for action in actions:
+                    action = action.strip()
+                    match = re.match(r"^(Out|In)\s+(\d+)$", action)
+                    if not match:
+                        continue
+                    direction = match.group(1).lower()
+                    qty = int(match.group(2))
+                    key = f"{scenario}_{direction}"
+
+                    if direction == "out" and card_name not in mainboard_names:
+                        missing_cards.add(f"{card_name} (not in mainboard)")
+                        continue
+                    if direction == "in" and card_name not in sideboard_names:
+                        missing_cards.add(f"{card_name} (not in sideboard)")
+                        continue
+
+                    entries_by_archetype[archetype_name][key][card_name] = qty
+
+    imported_entries = [
+        {
+            "archetype": archetype_name,
+            "play_out": data["play_out"],
+            "play_in": data["play_in"],
+            "draw_out": data["draw_out"],
+            "draw_in": data["draw_in"],
+            "notes": "",
+        }
+        for archetype_name, data in entries_by_archetype.items()
+    ]
+
+    if missing_cards:
+        warnings.append(f"Cards not in deck: {', '.join(sorted(missing_cards))}")
+
+    return imported_entries, warnings

--- a/widgets/frames/app_frame/handlers/sideboard_guide_io.py
+++ b/widgets/frames/app_frame/handlers/sideboard_guide_io.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import wx
 from loguru import logger
@@ -12,6 +12,10 @@ from utils.constants.ui_layout import PADDING_BASE, PADDING_XL
 from utils.constants.ui_windows import (
     GUIDE_IMPORT_OPTIONS_DIALOG_HEIGHT,
     GUIDE_IMPORT_OPTIONS_DIALOG_WIDTH,
+)
+from widgets.frames.app_frame.handlers.sideboard_guide_csv import (
+    export_guide_to_csv,
+    import_guide_from_csv,
 )
 
 if TYPE_CHECKING:
@@ -49,7 +53,12 @@ class SideboardGuideImportExportHandlers(_Base):
 
         def worker() -> None:
             try:
-                self._export_guide_to_csv(file_path)
+                export_guide_to_csv(
+                    self.sideboard_guide_entries,
+                    self.sideboard_exclusions,
+                    self.zone_cards,
+                    file_path,
+                )
                 wx.CallAfter(self._set_status, "guide.status.exported")
             except Exception as exc:
                 wx.CallAfter(self._set_status, "guide.status.export_error")
@@ -112,7 +121,11 @@ class SideboardGuideImportExportHandlers(_Base):
 
         def worker() -> None:
             try:
-                imported_entries, warnings = self._import_guide_from_csv(file_path)
+                mainboard_names = {card["name"] for card in self.zone_cards.get("main", [])}
+                sideboard_names = {card["name"] for card in self.zone_cards.get("side", [])}
+                imported_entries, warnings = import_guide_from_csv(
+                    file_path, mainboard_names, sideboard_names
+                )
             except Exception as exc:
                 wx.CallAfter(self._set_status, "guide.status.import_error")
                 logger.exception(f"Error importing sideboard guide from CSV: {exc}")
@@ -151,193 +164,3 @@ class SideboardGuideImportExportHandlers(_Base):
             wx.CallAfter(apply)
 
         threading.Thread(target=worker, daemon=True).start()
-
-    def _export_guide_to_csv(self: AppFrame, file_path: str) -> None:
-        """
-        Export sideboard guide to CSV with smart filtering.
-
-        Rows are cards, columns are matchups (archetype + scenario),
-        cells show actions (In/Out) and decklist is appended after a separator.
-        """
-        import csv
-
-        card_actions: dict[str, dict[str, set[str]]] = {}
-
-        for entry in self.sideboard_guide_entries:
-            if entry.get("archetype") in self.sideboard_exclusions:
-                continue
-
-            archetype = entry.get("archetype", "Unknown")
-            for scenario, out_key, in_key in [
-                ("Play", "play_out", "play_in"),
-                ("Draw", "draw_out", "draw_in"),
-            ]:
-                out_cards = entry.get(out_key, {})
-                in_cards = entry.get(in_key, {})
-
-                if isinstance(out_cards, dict):
-                    for card_name, qty in out_cards.items():
-                        if qty > 0:
-                            card_actions.setdefault(card_name, {}).setdefault(
-                                f"{archetype} ({scenario})", set()
-                            ).add(f"Out {qty}")
-
-                if isinstance(in_cards, dict):
-                    for card_name, qty in in_cards.items():
-                        if qty > 0:
-                            card_actions.setdefault(card_name, {}).setdefault(
-                                f"{archetype} ({scenario})", set()
-                            ).add(f"In {qty}")
-
-        filtered_cards = {card: actions for card, actions in card_actions.items() if actions}
-        if not filtered_cards:
-            raise ValueError("No cards to export after filtering")
-
-        all_matchups = sorted(
-            {matchup for actions in filtered_cards.values() for matchup in actions.keys()}
-        )
-
-        with open(file_path, "w", newline="", encoding="utf-8") as fh:
-            writer = csv.writer(fh)
-            writer.writerow(["Card"] + all_matchups)
-
-            for card_name in sorted(filtered_cards.keys()):
-                row = [card_name]
-                for matchup in all_matchups:
-                    actions = filtered_cards[card_name].get(matchup, set())
-                    row.append(" & ".join(sorted(actions)) if actions else "")
-                writer.writerow(row)
-
-            writer.writerow([])
-            writer.writerow([])
-            writer.writerow(["DECKLIST"])
-            writer.writerow([])
-
-            writer.writerow(["Mainboard"])
-            mainboard_cards = self.zone_cards.get("main", [])
-            for card in sorted(mainboard_cards, key=lambda c: c.get("name", "")):
-                writer.writerow([f"{card.get('qty', 0)} {card.get('name', '')}"])
-
-            writer.writerow([])
-            writer.writerow(["Sideboard"])
-            sideboard_cards = self.zone_cards.get("side", [])
-            for card in sorted(sideboard_cards, key=lambda c: c.get("name", "")):
-                writer.writerow([f"{card.get('qty', 0)} {card.get('name', '')}"])
-
-    def _import_guide_from_csv(
-        self: AppFrame, file_path: str
-    ) -> tuple[list[dict[str, Any]], list[str]]:
-        """
-        Import sideboard guide from CSV format with sanitization.
-
-        Returns imported entries and list of warning messages.
-        """
-        import csv
-        import re
-
-        mainboard_names = {card["name"] for card in self.zone_cards.get("main", [])}
-        sideboard_names = {card["name"] for card in self.zone_cards.get("side", [])}
-
-        entries_by_archetype: dict[str, dict[str, dict[str, int]]] = {}
-        warnings: list[str] = []
-        missing_cards: set[str] = set()
-
-        with open(file_path, encoding="utf-8") as fh:
-            reader = csv.reader(fh)
-            header = next(reader, None)
-            if not header or header[0] != "Card":
-                raise ValueError("Invalid CSV format: expected 'Card' as first column header")
-
-            matchup_columns = header[1:]
-            archetype_scenario_map: list[tuple[str | None, str | None]] = []
-            for col in matchup_columns:
-                match = re.match(r"^(.+?)\s*\((Play|Draw)\)$", col)
-                if match:
-                    archetype_name = match.group(1).strip()
-                    scenario = match.group(2).lower()
-                    archetype_scenario_map.append((archetype_name, scenario))
-                else:
-                    archetype_scenario_map.append((None, None))
-
-            for row in reader:
-                if not row:
-                    continue
-                if row[0] in ["DECKLIST", "Mainboard", "Sideboard"]:
-                    break
-
-                card_name = row[0].strip()
-                if not card_name:
-                    continue
-
-                for idx, cell_value in enumerate(row[1:], start=0):
-                    if idx >= len(archetype_scenario_map):
-                        continue
-                    archetype_name, scenario = archetype_scenario_map[idx]
-                    if not archetype_name or not scenario:
-                        continue
-                    if not cell_value or not cell_value.strip():
-                        continue
-
-                    entries_by_archetype.setdefault(
-                        archetype_name,
-                        {"play_out": {}, "play_in": {}, "draw_out": {}, "draw_in": {}},
-                    )
-
-                    actions = cell_value.split("&")
-                    for action in actions:
-                        action = action.strip()
-                        match = re.match(r"^(Out|In)\s+(\d+)$", action)
-                        if not match:
-                            continue
-                        direction = match.group(1).lower()
-                        qty = int(match.group(2))
-                        key = f"{scenario}_{direction}"
-
-                        if direction == "out" and card_name not in mainboard_names:
-                            missing_cards.add(f"{card_name} (not in mainboard)")
-                            continue
-                        if direction == "in" and card_name not in sideboard_names:
-                            missing_cards.add(f"{card_name} (not in sideboard)")
-                            continue
-
-                        entries_by_archetype[archetype_name][key][card_name] = qty
-
-        imported_entries = [
-            {
-                "archetype": archetype_name,
-                "play_out": data["play_out"],
-                "play_in": data["play_in"],
-                "draw_out": data["draw_out"],
-                "draw_in": data["draw_in"],
-                "notes": "",
-            }
-            for archetype_name, data in entries_by_archetype.items()
-        ]
-
-        if missing_cards:
-            warnings.append(f"Cards not in deck: {', '.join(sorted(missing_cards))}")
-
-        return imported_entries, warnings
-
-    def _parse_card_text(self: AppFrame, text: str) -> dict[str, int]:
-        if not text or not isinstance(text, str):
-            return {}
-
-        result: dict[str, int] = {}
-        lines = text.replace(",", "\n").split("\n")
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
-            parts = line.split(None, 1)
-            if len(parts) == 2:
-                qty_str, name = parts
-                qty_str = qty_str.rstrip("x")
-                try:
-                    qty = int(qty_str)
-                    result[name.strip()] = qty
-                    continue
-                except ValueError:
-                    pass
-            result[line] = 1
-        return result

--- a/widgets/frames/app_frame/handlers/sideboard_guide_persistence.py
+++ b/widgets/frames/app_frame/handlers/sideboard_guide_persistence.py
@@ -22,6 +22,29 @@ else:
 class SideboardGuidePersistenceHandlers(_Base):
     """Persistence/state I/O for guides, outboards, and the pin indicator."""
 
+    def _parse_card_text(self: AppFrame, text: str) -> dict[str, int]:
+        if not text or not isinstance(text, str):
+            return {}
+
+        result: dict[str, int] = {}
+        lines = text.replace(",", "\n").split("\n")
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(None, 1)
+            if len(parts) == 2:
+                qty_str, name = parts
+                qty_str = qty_str.rstrip("x")
+                try:
+                    qty = int(qty_str)
+                    result[name.strip()] = qty
+                    continue
+                except ValueError:
+                    pass
+            result[line] = 1
+        return result
+
     def _persist_outboard_for_current(self: AppFrame) -> None:
         key = self.controller.deck_repo.get_current_deck_key()
         self.controller.outboard_store[key] = self.zone_cards.get("out", [])


### PR DESCRIPTION
Closes #806

## What

Splits `widgets/frames/app_frame/handlers/sideboard_guide_io.py` (343 LOC) along the wx / non-wx seam, following the issue's decomposition plan and the layer's reads/writes/schema codec convention.

### Files
- **Added** `widgets/frames/app_frame/handlers/sideboard_guide_csv.py` (196 LOC) — pure, wx-free codec:
  - `export_guide_to_csv(entries, exclusions, zone_cards, file_path)`
  - `import_guide_from_csv(file_path, mainboard_names, sideboard_names) -> (entries, warnings)`
  
  Instance state (`sideboard_guide_entries`, `sideboard_exclusions`, `zone_cards`, the derived mainboard/sideboard name sets) is now passed in as plain arguments instead of being reached through the mixin `self`.
- **Changed** `sideboard_guide_io.py` (343 → 166 LOC) — slim `SideboardGuideImportExportHandlers` mixin retaining only `_on_export_guide` / `_on_import_guide`: file dialogs, the hand-built import-options dialog, status updates, threaded workers, and the `apply()` merge/dedup + `_persist_guide_for_current` + `_refresh_guide_view` logic. Delegates serialization to the codec.
- **Changed** `sideboard_guide_persistence.py` (127 → 149 LOC) — `_parse_card_text` relocated here, its sole consumer (three existing call sites unchanged, resolved via `self`).
- **Added** `tests/test_sideboard_guide_csv.py` — unit tests for the new codec (matrix build + decklist, exclusions, empty-export `ValueError`, export→import roundtrip, missing-card warnings, bad-header rejection, decklist-section termination).

LOC: io.py 343 → 166; new codec 196; persistence 127 → 149.

## Behavior preservation
Code was moved, not rewritten. Public mixin API (`_on_export_guide`, `_on_import_guide`) and wx event wiring are unchanged. Threading contract preserved: only the pure codec call runs off-thread; all wx and instance-state mutation stays on the main thread via `wx.CallAfter`. The mainboard/sideboard name sets are still computed inside the import worker (same timing/thread as before). No changes to `handlers/__init__.py` were needed — the mixin class name and module path are unchanged.

## Verification (off-Windows; wx not importable here, CI runs the wx tests on Windows)
- `python -m py_compile` on all four changed/added files — pass.
- `ruff check` on all four — pass.
- `black --check` on all four — clean.
- Codec verified genuinely wx-free by loading the module directly (bypassing the package `__init__` that imports wx): `'wx' in sys.modules` is `False`, and an export→import roundtrip reproduces the input entries. (Full pytest collection of the new test file is blocked off-Windows only because the parent package `__init__` imports wx — the same pre-existing condition affects several other test modules here; they run on Windows CI.)
- `git grep` confirms no dangling references to the moved `_export_guide_to_csv` / `_import_guide_from_csv` methods.

## Skipped
Nothing from the plan was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)