### PR TITLE
fix(archetype-resolver): treat blank input and nameless entries as no-match

### DIFF
--- a/services/archetype_resolver.py
+++ b/services/archetype_resolver.py
@@ -34,6 +34,10 @@ def find_archetype_by_name(
     repo = metagame_repo or get_metagame_repository()
     normalized_input = normalize_archetype_name(archetype_name)
 
+    if not normalized_input:
+        logger.debug("Empty archetype name; no match")
+        return None
+
     try:
         archetypes = repo.get_archetypes_for_format(format_name)
     except Exception:
@@ -49,6 +53,8 @@ def find_archetype_by_name(
     for archetype in archetypes:
         name = archetype.get("name", "")
         normalized_name = normalize_archetype_name(name)
+        if not normalized_name:
+            continue
         if normalized_input in normalized_name or normalized_name in normalized_input:
             logger.debug(f"Partial match: '{archetype_name}' -> '{name}'")
             return archetype

--- a/tests/test_archetype_resolver.py
+++ b/tests/test_archetype_resolver.py
@@ -160,6 +160,41 @@ class TestFindArchetypeByName:
         result = find_archetype_by_name("UR Murktide", "Modern", repo)
         assert result is None
 
+    @pytest.mark.parametrize("query", ["", "   ", "\t\n"])
+    def test_empty_or_blank_input_returns_none(self, seeded_repo, query):
+        # A blank query normalizes to "", which is a substring of every stored
+        # name; without the empty-input guard the partial-match branch would
+        # silently return the first archetype. Assert it is treated as no-match.
+        result = find_archetype_by_name(query, "Modern", seeded_repo)
+        assert result is None
+
+    def test_archetype_missing_name_key_does_not_match(self, repo, cache_files):
+        # An entry without a "name" key normalizes to "", which is a substring
+        # of any input; it must not spuriously win the partial-match fallback.
+        archetype_cache_file, _ = cache_files
+        _write_archetype_cache(
+            archetype_cache_file,
+            "Modern",
+            [
+                {"href": "/archetype/nameless"},
+                {"name": "UR Murktide", "href": "/archetype/ur-murktide"},
+            ],
+        )
+        result = find_archetype_by_name("Murktide", "Modern", repo)
+        assert result == {"name": "UR Murktide", "href": "/archetype/ur-murktide"}
+
+    def test_only_nameless_archetype_returns_none(self, repo, cache_files):
+        # The lone entry has no name; nothing real to match, so the resolver
+        # must return None rather than the nameless dict.
+        archetype_cache_file, _ = cache_files
+        _write_archetype_cache(
+            archetype_cache_file,
+            "Modern",
+            [{"href": "/archetype/nameless"}],
+        )
+        result = find_archetype_by_name("Murktide", "Modern", repo)
+        assert result is None
+
     def test_uses_default_repo_when_none(self, tmp_path, monkeypatch):
         """When no repo is passed, the default singleton repository is used."""
         archetype_cache_file = tmp_path / "default_archetype_cache.json"


### PR DESCRIPTION
## Summary

Empty/blank archetype queries normalize to `""`, which is a substring of every stored name, so `find_archetype_by_name`'s partial-match fallback silently returned the *first* archetype instead of `None`. The same problem affected archetype dicts missing a `name` key: their name normalizes to `""`, making them spuriously win the partial-match branch for any input. This change adds an early no-match guard for empty normalized input and skips entries whose name normalizes to empty during partial matching. Tests now pin the blank-input behavior and the missing-`name`-key cases (both spurious-match avoidance and the only-nameless-entry case), closing the unexercised paths flagged in the test review.

## Verification

Ran from WSL (wx not importable here; the test injects a wx stub, so these run without Windows):
- `python -m ruff check services/archetype_resolver.py tests/test_archetype_resolver.py` — all checks passed
- `python -m black --check services/archetype_resolver.py tests/test_archetype_resolver.py` — both files unchanged
- `python -m pytest tests/test_archetype_resolver.py -q` — 19 passed

Not checked in WSL: any real `wx`/GUI behavior and the full Windows UI test suite. The stale-cache / remote-snapshot resolution layers noted in the issue are out of scope here (flagged for a dedicated `metagame_repository` test); no change made to those.

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)