### PR TITLE
fix(printing-index): correct DFC back face when faceNames are missing (#822)

### DIFF
--- a/repositories/card_repository/builder.py
+++ b/repositories/card_repository/builder.py
@@ -62,19 +62,21 @@ def _select_front_back(
     if "//" not in canonical_name or len(printings) < 2:
         return printings[0], None
     front_part = canonical_name.split("//", 1)[0].strip().lower()
-    front_printing: dict[str, Any] | None = None
-    back_printing: dict[str, Any] | None = None
-    for printing in printings:
+    front_index: int | None = None
+    for index, printing in enumerate(printings):
         face_name = (printing.get("faceName") or "").strip().lower()
-        if face_name == front_part and front_printing is None:
-            front_printing = printing
-        elif back_printing is None:
-            back_printing = printing
-    if front_printing is None:
-        front_printing = printings[0]
-        if back_printing is None:
-            back_printing = printings[1]
-    return front_printing, back_printing
+        if face_name == front_part:
+            front_index = index
+            break
+    if front_index is None:
+        # No faceName matched the canonical front: fall back to printings order,
+        # treating the first printing as the front and the second as the back.
+        return printings[0], printings[1]
+    back_printing = next(
+        (p for i, p in enumerate(printings) if i != front_index),
+        None,
+    )
+    return printings[front_index], back_printing
 
 
 def _apply_back_face(

--- a/tests/test_card_data_aliases.py
+++ b/tests/test_card_data_aliases.py
@@ -16,6 +16,8 @@ def _sample_atomic_payload():
                 "manaValue": 2,
                 "type": "Legendary Creature — Human Wizard",
                 "text": "T: Draw a card, then discard a card.",
+                "power": "0",
+                "toughness": "2",
                 "colors": ["U"],
                 "colorIdentity": ["U"],
                 "legalities": {"modern": "Legal"},
@@ -27,6 +29,7 @@ def _sample_atomic_payload():
                 "manaValue": 0,
                 "type": "Legendary Planeswalker — Jace",
                 "text": "+1: Up to one target creature gets -2/-0 until your next turn.",
+                "loyalty": "5",
                 "colors": ["U"],
                 "colorIdentity": ["U"],
                 "legalities": {"modern": "Legal"},
@@ -63,10 +66,20 @@ def test_build_index_populates_back_face_fields():
     assert entry["type_line"] == "Legendary Creature — Human Wizard"
     assert "Draw a card" in (entry["oracle_text"] or "")
     assert entry["mana_cost"] == "{1}{U}"
+    assert entry["mana_value"] == 2
+    # Front P/T and colors come from the front printing (not swapped/dropped).
+    assert entry["power"] == "0"
+    assert entry["toughness"] == "2"
+    assert entry["colors"] == ["U"]
+    assert entry["color_identity"] == ["U"]
 
     assert entry["back_name"] == "Jace, Telepath Unbound"
     assert entry["back_type_line"] == "Legendary Planeswalker — Jace"
     assert "+1:" in (entry["back_oracle_text"] or "")
+    # Back-face specific fields read from the back printing.
+    assert entry["back_mana_cost"] == ""
+    assert entry["back_loyalty"] == "5"
+    assert entry["back_power"] is None
 
 
 def test_build_index_back_face_when_back_listed_first():
@@ -157,6 +170,37 @@ def test_build_index_merges_and_filters_legalities():
 
     # Banned/Restricted dropped; Legal formats from both printings unioned.
     assert entry["legalities"] == {"legacy": "Legal", "commander": "Legal"}
+
+
+def test_build_index_legalities_union_keeps_legal_across_printings():
+    """A format Legal on one printing stays Legal even if Banned on another.
+
+    ``_merge_legalities`` unions the ``Legal`` formats rather than letting a later
+    printing's non-Legal state override an earlier Legal one.
+    """
+    payload = {
+        "Format Flip": [
+            {
+                "name": "Format Flip",
+                "manaCost": "{1}",
+                "manaValue": 1,
+                "type": "Artifact",
+                "legalities": {"modern": "Legal", "legacy": "Banned"},
+            },
+            {
+                "name": "Format Flip",
+                "manaCost": "{1}",
+                "manaValue": 1,
+                "type": "Artifact",
+                "legalities": {"modern": "Banned", "legacy": "Legal"},
+            },
+        ]
+    }
+    index = build_index(payload)
+    entry = index["cards"][0]
+
+    # Each format Legal on at least one printing survives the union.
+    assert entry["legalities"] == {"modern": "Legal", "legacy": "Legal"}
 
 
 def test_build_index_sorts_cards_and_maps_distinct_indices():
@@ -274,13 +318,6 @@ def test_build_index_leaves_non_numeric_mana_value_unchanged():
     assert entry["mana_value"] == "unknown"
 
 
-def test_build_index_dfc_mana_value():
-    """The existing DFC entry exposes the front-face int mana value."""
-    index = build_index(_sample_atomic_payload())
-    entry = index["cards"][0]
-    assert entry["mana_value"] == 2
-
-
 def test_build_index_skips_non_list_and_empty_variations():
     """Group values that are not non-empty lists are ignored."""
     payload = {
@@ -317,11 +354,11 @@ def test_build_index_skips_printing_without_name():
 
 
 def test_build_index_dfc_without_facenames_derives_back_name_from_canonical():
-    """When a DFC printing has no faceName, the back name comes from the canonical.
+    """When a DFC printing has no faceName, the back face comes from the second printing.
 
-    With no ``faceName`` to match, ``_select_front_back`` falls back to using the
-    first printing as the front face, and ``_apply_back_face`` derives the back
-    name from the half of ``name`` after ``//``.
+    With no ``faceName`` to match, ``_select_front_back`` falls back to printings
+    order: the first printing is the front and the *second* printing is the back.
+    The back name is derived from the half of ``name`` after ``//``.
     """
     canonical = "Front Half // Back Half"
     payload = {
@@ -346,6 +383,11 @@ def test_build_index_dfc_without_facenames_derives_back_name_from_canonical():
     entry = index["cards"][0]
 
     assert entry["type_line"] == "Creature — Front"
+    assert entry["oracle_text"] == "Front text."
+    # The back face is the *second* printing, not a re-read of the front.
+    assert entry["back_type_line"] == "Land"
+    assert entry["back_oracle_text"] == "Back text."
+    assert entry["back_mana_cost"] == ""
     # Back name is derived from the canonical's second half when faceName is absent.
     assert entry["back_name"] == "Back Half"
     # Both halves of the canonical are exposed as aliases.


### PR DESCRIPTION
## Summary

For a double-faced card whose printings carry no `faceName`, `_select_front_back` in `repositories/card_repository/builder.py` assigned the *first* printing to the back slot (the `elif back_printing is None` branch fired while iterating the front printing), so both faces resolved to `printings[0]`: `back_type_line` and `back_oracle_text` echoed the front face. This PR rewrites the fallback to treat the first printing as the front and the *second* as the back when no `faceName` matches the canonical front half, fixing the back-face data. It also strengthens `tests/test_card_data_aliases.py` per the test-review findings: the no-faceName DFC test now asserts the back type/text/mana-cost (which previously masked the bug), the back-face test asserts front/back power, toughness, loyalty, colors and `back_mana_cost`, and a new test exercises the Legal-then-Banned legalities union across printings (the redundant DFC mana-value test was folded in).

## Verification

- Ran the pure `build_index` transform in isolation (loading `builder.py` directly to bypass the wx-importing package `__init__`) against the no-faceName DFC, back-listed-first, and Legal-then-Banned payloads; all assertions pass and the back face now resolves to the second printing.
- `python -m ruff check` and `python -m black --check` on both changed files: pass.
- Could NOT run `pytest tests/test_card_data_aliases.py` in WSL: importing the test module pulls `repositories.card_repository.__init__` -> `utils.constants` -> `wx`, and `wx` is not importable off-Windows. The test assertions themselves were validated against the same `build_index` logic in isolation; the full test file will run on Windows CI.
- No wx/UI behavior was exercised.

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)