### PR TITLE
test(image-effects): cover composite_rounded_on_background math (#824)

### DIFF
--- a/tests/test_card_image_display_logic.py
+++ b/tests/test_card_image_display_logic.py
@@ -20,6 +20,7 @@ import pytest
 from utils.image_effects import (
     apply_rounded_corner_alpha_bytes,
     blend_rgb_bytes,
+    composite_rounded_on_background_bytes,
     rounded_corner_mask_bytes,
 )
 
@@ -124,11 +125,12 @@ def test_blend_output_length_matches_input():
 
 @pytest.mark.parametrize("alpha", [0.0, 0.35, 1.0])
 def test_blend_non_square_matches_reference(alpha):
-    """Blend must be correct when width != height.
+    """Blend must be correct for a non-square (width != height) buffer.
 
-    ``blend_rgb_bytes`` reconstructs PIL images from ``(w, h)``; swapping the
-    two would only ever be caught by a rectangular image, since square inputs
-    are dimension-symmetric.  This guards against a width/height transposition.
+    The blend is a flat per-byte operation, so a w/h swap is *not* observable
+    here (PIL ``frombytes`` over a contiguous RGB buffer is dimension-invariant).
+    This case simply exercises a rectangular size to confirm the output length
+    and per-pixel math hold when the buffer is not a perfect square.
     """
     nw, nh = 6, 10  # deliberately non-square so w and h are not interchangeable
     rng = random.Random(7)
@@ -278,3 +280,87 @@ def test_corners_preserves_partial_alpha_in_interior():
     assert (
         result[center_idx] == partial_value
     ), f"Interior partial alpha {partial_value} was changed to {result[center_idx]}"
+
+
+# ── composite-on-background tests (exercise composite_rounded_on_background) ───
+
+BG = (33, 66, 99)  # distinctive opaque background colour
+
+
+def test_composite_interior_is_card_rgb():
+    """Fully-opaque interior pixels must equal the card RGB, untouched by bg.
+
+    Inside the rounded rect alpha is 255, so ``rgb*1 + bg*0`` must reproduce the
+    card pixel exactly. A dropped alpha term or a bg/fg swap would surface here.
+    """
+    card_rgb = (200, 40, 150)
+    rgb_in = bytes(list(card_rgb) * (RW * RH))
+    alpha_in = bytes([255] * RW * RH)
+
+    out = composite_rounded_on_background_bytes(rgb_in, alpha_in, RW, RH, radius=4, bg_rgb=BG)
+
+    assert len(out) == RW * RH * 3
+    cx, cy = RW // 2, RH // 2
+    base = (cy * RW + cx) * 3
+    assert tuple(out[base : base + 3]) == card_rgb
+
+
+def test_composite_corner_is_background():
+    """A true corner pixel (mask alpha 0) must become the background colour.
+
+    With alpha 0 the blend is ``rgb*0 + bg*1``; if the ``(1-alpha)`` term were
+    dropped the corner would show the card pixel instead of ``bg``.
+    """
+    card_rgb = (200, 40, 150)
+    rgb_in = bytes(list(card_rgb) * (RW * RH))
+    alpha_in = bytes([255] * RW * RH)
+
+    out = composite_rounded_on_background_bytes(rgb_in, alpha_in, RW, RH, radius=4, bg_rgb=BG)
+
+    assert tuple(out[0:3]) == BG  # top-left corner is outside the rounded rect
+
+
+def test_composite_mid_alpha_is_weighted_blend():
+    """A partially-transparent interior pixel must be the weighted card/bg blend."""
+    card_rgb = (200, 40, 150)
+    rgb_in = bytes(list(card_rgb) * (RW * RH))
+    # Half-transparent everywhere; interior keeps alpha=128 after the mask min.
+    alpha_in = bytes([128] * RW * RH)
+
+    out = composite_rounded_on_background_bytes(rgb_in, alpha_in, RW, RH, radius=4, bg_rgb=BG)
+
+    cx, cy = RW // 2, RH // 2
+    base = (cy * RW + cx) * 3
+    a = 128 / 255.0
+    for k in range(3):
+        expected = int(card_rgb[k] * a + BG[k] * (1.0 - a))
+        assert (
+            abs(out[base + k] - expected) <= 1
+        ), f"channel {k}: expected ~{expected}, got {out[base + k]}"
+
+
+def test_composite_output_has_no_alpha_length():
+    """Output is RGB only (no alpha channel): 3 bytes per pixel."""
+    rgb_in = bytes([10] * RW * RH * 3)
+    alpha_in = bytes([255] * RW * RH)
+    out = composite_rounded_on_background_bytes(rgb_in, alpha_in, RW, RH, radius=2, bg_rgb=BG)
+    assert len(out) == RW * RH * 3
+
+
+def test_composite_respects_existing_transparent_pixel():
+    """An interior pixel already alpha=0 must show the background, not the card.
+
+    The mask is combined with the existing alpha via ``min``, so a transparent
+    interior pixel stays transparent and blends to ``bg``.
+    """
+    card_rgb = (200, 40, 150)
+    rgb_in = bytes(list(card_rgb) * (RW * RH))
+    cx, cy = RW // 2, RH // 2
+    alpha_list = [255] * (RW * RH)
+    alpha_list[cy * RW + cx] = 0
+    alpha_in = bytes(alpha_list)
+
+    out = composite_rounded_on_background_bytes(rgb_in, alpha_in, RW, RH, radius=4, bg_rgb=BG)
+
+    base = (cy * RW + cx) * 3
+    assert tuple(out[base : base + 3]) == BG

--- a/utils/image_effects.py
+++ b/utils/image_effects.py
@@ -46,6 +46,35 @@ def blend_rgb_bytes(data1: bytes, data2: bytes, w: int, h: int, alpha: float) ->
     return PilImage.blend(pil1, pil2, alpha).tobytes()
 
 
+def composite_rounded_on_background_bytes(
+    rgb_data: bytes,
+    existing_alpha: bytes,
+    w: int,
+    h: int,
+    radius: int,
+    bg_rgb: tuple[int, int, int],
+) -> bytes:
+    """Flatten a rounded card's RGB onto an opaque ``bg_rgb`` background.
+
+    Pure-byte core of :func:`composite_rounded_on_background`. ``rgb_data`` is a
+    ``w*h`` RGB buffer (3 bytes/pixel); ``existing_alpha`` is the matching
+    ``w*h`` per-pixel alpha buffer. The rounded-corner mask is combined with the
+    existing alpha (per-pixel ``min``) and used to blend the card over ``bg_rgb``
+    via ``out = rgb*alpha + bg*(1-alpha)``. Returns a ``w*h`` RGB byte buffer
+    with no alpha channel.
+    """
+    alpha = (
+        np.frombuffer(
+            apply_rounded_corner_alpha_bytes(existing_alpha, w, h, radius), dtype=np.uint8
+        ).astype(np.float32)
+        / 255.0
+    )
+    rgb = np.frombuffer(rgb_data, dtype=np.uint8).astype(np.float32).reshape(-1, 3)
+    bg = np.array(bg_rgb, dtype=np.float32)
+    out = (rgb * alpha[:, None] + bg * (1.0 - alpha[:, None])).astype(np.uint8)
+    return out.tobytes()
+
+
 def apply_rounded_corner_alpha(image: wx.Image, radius: int) -> wx.Image:
     """Return a copy of ``image`` with a rounded-corner alpha mask applied.
 
@@ -85,15 +114,9 @@ def composite_rounded_on_background(
     if not img.HasAlpha():
         img.InitAlpha()
     w, h = img.GetWidth(), img.GetHeight()
-    alpha = (
-        np.frombuffer(
-            apply_rounded_corner_alpha_bytes(bytes(img.GetAlpha()), w, h, radius), dtype=np.uint8
-        ).astype(np.float32)
-        / 255.0
+    out = composite_rounded_on_background_bytes(
+        bytes(img.GetData()), bytes(img.GetAlpha()), w, h, radius, bg_rgb
     )
-    rgb = np.frombuffer(bytes(img.GetData()), dtype=np.uint8).astype(np.float32).reshape(-1, 3)
-    bg = np.array(bg_rgb, dtype=np.float32)
-    out = (rgb * alpha[:, None] + bg * (1.0 - alpha[:, None])).astype(np.uint8)
     result = wx.Image(w, h)
-    result.SetData(out.tobytes())
+    result.SetData(out)
     return result


### PR DESCRIPTION
## Summary

Issue #824 (test-review of `tests/test_card_image_display_logic.py`) flagged that the production compositing function `composite_rounded_on_background` — used by the #782 fast-BitBlt grid path — had its own per-pixel alpha-over-background math with no test anywhere, so a dropped `(1-alpha)` term or a bg/fg swap would go uncaught. This PR extracts the wx-free pure-byte core into `composite_rounded_on_background_bytes(rgb_data, existing_alpha, w, h, radius, bg_rgb)` and routes the wx wrapper through it (no behaviour change), then adds tests asserting interior == card rgb, true corner == background, mid-alpha == weighted blend, RGB-only output length, and that an existing-transparent interior pixel blends to bg. It also corrects the misleading non-square blend test docstring (the flat per-byte blend cannot detect a width/height transposition, contrary to its previous rationale).

The remaining 🟡 item — exercising the wx `apply_rounded_corner_alpha` `InitAlpha` branch — is left as a known wx-only edge gap, since it requires importing wx (Windows/CI only).

## Verification

Ran from WSL (wx is not importable here):
- `python -m ruff check utils/image_effects.py tests/test_card_image_display_logic.py` — passed.
- `python -m black` — reformatted the test file, now clean.
- `python -m pytest tests/test_card_image_display_logic.py -q` — 27 passed (22 prior + 5 new composite tests).

Could not verify in WSL: the wx wrapper `composite_rounded_on_background` / `apply_rounded_corner_alpha` themselves (wx.Image), and any on-screen rendering of the composited cards. The extraction is a mechanical move of the existing math into the helper the wrapper now calls, so the wrapper's numeric output is unchanged.

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)
