### PR TITLE
test(printing-index): cover payload normalization, self-alias, and corrupt cache (#825)

### DIFF
--- a/tests/test_card_images_aliases.py
+++ b/tests/test_card_images_aliases.py
@@ -91,6 +91,9 @@ def test_build_printing_index_sorts_and_counts():
             "set_name": "Alpha",
             "collector_number": "1",
             "released_at": "2001-01-01",
+            # full_art is truthy-but-not-bool and flavor_text is omitted, so the
+            # bool() coercion and the "" default both get exercised below.
+            "full_art": 1,
         },
         {
             "name": "Test Card",
@@ -109,6 +112,16 @@ def test_build_printing_index_sorts_and_counts():
     assert stats["total_printings"] == 2
     entries = by_name["test card"]
     assert [entry["id"] for entry in entries] == ["uuid-2", "uuid-1"]
+
+    # Per-printing payload normalization: set is upper-cased, missing string
+    # fields default to "", and full_art is coerced to a real bool.
+    newest = entries[0]
+    assert newest["set"] == "DEF"
+    oldest = entries[1]
+    assert oldest["set"] == "ABC"
+    assert oldest["flavor_text"] == ""
+    assert oldest["full_art"] is True
+    assert newest["full_art"] is False
 
 
 def test_face_alias_does_not_pollute_a_real_standalone_card():
@@ -145,6 +158,46 @@ def test_face_alias_does_not_pollute_a_real_standalone_card():
     # The non-colliding face name still resolves to the combined card.
     assert [e["id"] for e in by_name["emeritus of conflict"]] == ["emeritus-combined"]
     assert by_name["emeritus of conflict // lightning bolt"][0]["id"] == "emeritus-combined"
+
+
+def test_face_alias_equal_to_display_name_does_not_self_duplicate():
+    """A card_face whose name equals the card's own display name is skipped.
+
+    Isolates the ``alias.lower() != display_key`` filter in
+    ``_collect_face_aliases`` together with the ``alias_key == key`` guard in
+    ``build_printing_index``: the self-referential face must not create a
+    duplicate entry under the same key.
+    """
+    cards = [
+        {
+            "name": "Solo Card",
+            "id": "solo-1",
+            "set": "abc",
+            "released_at": "2001-01-01",
+            "card_faces": [
+                {"name": "Solo Card"},
+            ],
+        }
+    ]
+
+    by_name, _stats = card_images.build_printing_index(cards)
+
+    # Exactly one entry under the single key — no self-alias duplicate.
+    assert list(by_name.keys()) == ["solo card"]
+    assert [e["id"] for e in by_name["solo card"]] == ["solo-1"]
+
+
+def test_load_printing_index_payload_returns_none_for_corrupt_cache(tmp_path, monkeypatch):
+    """A non-decodable cache file is treated as absent (returns None)."""
+    cache_dir = tmp_path / "card_images"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    printings_path = cache_dir / "printings.json"
+    printings_path.write_text("not valid json {{{", encoding="utf-8")
+
+    monkeypatch.setattr(card_images_schemas, "IMAGE_CACHE_DIR", cache_dir, raising=False)
+    monkeypatch.setattr(card_images_schemas, "PRINTING_INDEX_CACHE", printings_path, raising=False)
+
+    assert card_images.load_printing_index_payload() is None
 
 
 def _write_bulk_payload(cache_dir, monkeypatch, printings_path):


### PR DESCRIPTION
## Summary

Strengthens `tests/test_card_images_aliases.py` to close the coverage gaps flagged by the `test-review` workflow for `services/image_service/printing_index.py`. Adds assertions and tests so the per-printing entry payload normalization, the self-referential face-alias skip branch, and the corrupt-cache load path are all exercised. No production code changed — tests only.

Specifically:
- `test_build_printing_index_sorts_and_counts` now also asserts the entry-payload normalization: `set` is upper-cased (`abc` → `ABC`, `def` → `DEF`), an omitted `flavor_text` defaults to `""`, and a truthy-but-non-bool `full_art` (`1`) is coerced to `True` while a missing one is `False`.
- New `test_face_alias_equal_to_display_name_does_not_self_duplicate` isolates the `alias.lower() != display_key` filter in `_collect_face_aliases` and the `alias_key == key` guard in `build_printing_index`: a `card_faces` entry whose name equals the card's own display name must not create a duplicate entry.
- New `test_load_printing_index_payload_returns_none_for_corrupt_cache` writes non-JSON to the cache and asserts `load_printing_index_payload()` returns `None`, exercising the `msgspec.DecodeError` branch in `_load_printing_index_payload`.

## Verification

- `python -m ruff check tests/test_card_images_aliases.py` — passed.
- `python -m black --check tests/test_card_images_aliases.py` — clean.
- `python -m py_compile tests/test_card_images_aliases.py` — OK.
- The test module cannot be collected by pytest in WSL because its import chain (`services.image_service` → `utils.constants` → `utils.constants.keyboard`) imports `wx`, which is not installable off-Windows. This is pre-existing, not introduced here. To validate the new test logic I imported the pure functions (`build_printing_index`, `load_printing_index_payload`) against the real source with `wx` stubbed via `MagicMock`, and all three new checks passed (the corrupt-cache case correctly hit the `msgspec.DecodeError` branch and returned `None`).
- Not verified in WSL: full pytest run on Windows CI (where `wx` is importable) — the source under test is pure and the assertions match the real return values observed in the stubbed run.

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)