### PR TITLE
test(collection): fix mock-policy & redundancy in test_collection_loading.py (#833)

### DIFF
--- a/tests/test_collection_loading.py
+++ b/tests/test_collection_loading.py
@@ -7,6 +7,7 @@ exhaustively in ``test_card_repository.py`` and are not re-tested here.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from repositories.card_repository import CardRepository
@@ -29,6 +30,8 @@ def test_collection_service_loads_inventory_from_export(tmp_path):
     # that ownership lookups are case-insensitive (issue #469).
     assert service.get_owned_count("Lightning Bolt") == 5  # 4 + 1 duplicate entry
     assert service.get_owned_count("Island") == 12
+    # Spell Pierce is stored with a numeric-string quantity in the fixture; the
+    # real parser coerces "2" -> 2 (string-quantity coercion).
     assert service.get_owned_count("Spell Pierce") == 2
     # Lookups are case-insensitive regardless of caller casing.
     assert service.get_owned_count("lightning bolt") == 5
@@ -39,39 +42,32 @@ def test_collection_service_short_circuits_when_already_loaded(tmp_path):
     service = CollectionService(card_repository=repo)
 
     temp_file = tmp_path / "collection.json"
-    temp_file.write_text(FIXTURE_PATH.read_text(encoding="utf-8"), encoding="utf-8")
 
-    calls = {"count": 0}
-    original = repo.load_collection_from_file
+    def write(quantity: int) -> None:
+        temp_file.write_text(
+            json.dumps([{"name": "Island", "quantity": quantity}]), encoding="utf-8"
+        )
 
-    def counting_load(path):
-        calls["count"] += 1
-        return original(path)
-
-    repo.load_collection_from_file = counting_load  # type: ignore[method-assign]
-
+    write(7)
     assert service.load_collection(temp_file)
-    assert calls["count"] == 1
+    assert service.get_owned_count("Island") == 7
 
-    # A second load without force must not re-read the file.
+    # Mutate the file on disk, then load again without force: the cached
+    # inventory is reused, so the new quantity is *not* observed.
+    write(20)
     assert service.load_collection(temp_file)
-    assert calls["count"] == 1
+    assert service.get_owned_count("Island") == 7
 
-    # force=True triggers a fresh read.
+    # force=True re-reads the file and the new quantity becomes visible.
     assert service.load_collection(temp_file, force=True)
-    assert calls["count"] == 2
+    assert service.get_owned_count("Island") == 20
 
 
-def test_collection_service_returns_false_on_read_error(tmp_path):
+def test_collection_service_returns_false_on_bad_filepath():
     repo = CardRepository()
     service = CollectionService(card_repository=repo)
 
-    temp_file = tmp_path / "collection.json"
-    temp_file.write_text(FIXTURE_PATH.read_text(encoding="utf-8"), encoding="utf-8")
-
-    def boom(path):
-        raise RuntimeError("disk on fire")
-
-    repo.load_collection_from_file = boom  # type: ignore[method-assign]
-
-    assert service.load_collection(temp_file) is False
+    # Passing a non-Path object makes the real ``filepath.exists()`` probe raise
+    # inside ``load_collection``; the except branch must swallow it and report
+    # failure rather than propagate. No internal method is replaced.
+    assert service.load_collection("not-a-path-object") is False  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Addresses the test-review findings for `tests/test_collection_loading.py` (#833). The read-error test no longer replaces the real `CardRepository.load_collection_from_file` parser with a `boom` stub; instead it passes a non-`Path` filepath so the real `filepath.exists()` probe raises inside `load_collection`, genuinely reaching the `except → return False` branch with no internal method patched. (Pointing at a directory — the report's literal suggestion — would not work here, because the real parser catches `OSError` and returns `[]`.) The short-circuit test drops its call-count probe on an internal method in favor of observable owned-count assertions (cached reload keeps the old quantity; `force=True` picks up the mutated file). An inline comment now documents that the Spell Pierce assertion covers numeric-string quantity coercion.

## Verification

- `python -m ruff check tests/test_collection_loading.py` — passed.
- `python -m black --check tests/test_collection_loading.py` — passed (unchanged).
- `python -m pytest tests/test_collection_loading.py` cannot run in WSL: the module transitively imports `wx` via `utils.constants.keyboard`, and `wx` is not installable here (pre-existing constraint, unrelated to this change). To exercise the logic I ran all three test functions against the real `CollectionService` + `CardRepository` with only the `wx` module stubbed (`unittest.mock.MagicMock`) to satisfy the import chain — `wx` itself is not used by these tests. All three passed, and the ERROR log confirmed the bad-filepath case hits the service's `except → return False` branch.
- Not verified in WSL: any wx/UI behavior. These are pure service/repository integration tests and touch no UI code, but the standard `pytest` collection path still requires Windows because of the transitive `wx` import.

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)