### PR TITLE
test(help): validate index.hhk topics + resource_path frozen branch

### DIFF
--- a/tests/test_help_assets.py
+++ b/tests/test_help_assets.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import utils.constants.paths as paths_module
 from utils.constants.paths import resource_path
 
 
@@ -79,3 +80,34 @@ def test_help_contents_topics_all_exist():
     for topic in locals_:
         path = hhp.parent / topic
         assert path.is_file(), f"contents topic missing: {path}"
+
+
+def test_help_index_topics_all_exist():
+    hhp = resource_path("help", "mtgo_tools.hhp")
+    hhk = hhp.parent / "index.hhk"
+    assert hhk.is_file(), f"index file missing: {hhk}"
+
+    text = hhk.read_text(encoding="utf-8")
+    locals_ = re.findall(r'<param\s+name="Local"\s+value="([^"]+)"', text, flags=re.IGNORECASE)
+    assert locals_, "index.hhk references no topics"
+
+    for topic in locals_:
+        path = hhp.parent / topic
+        assert path.is_file(), f"index topic missing: {path}"
+
+
+def test_resource_path_uses_meipass_when_frozen(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths_module.sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    resolved = resource_path("help", "mtgo_tools.hhp")
+
+    assert resolved == tmp_path / "help" / "mtgo_tools.hhp"
+
+
+def test_resource_path_uses_repo_root_when_not_frozen(monkeypatch):
+    monkeypatch.delattr(paths_module.sys, "_MEIPASS", raising=False)
+
+    resolved = resource_path("help", "mtgo_tools.hhp")
+
+    expected_root = Path(paths_module.__file__).resolve().parent.parent.parent
+    assert resolved == expected_root / "help" / "mtgo_tools.hhp"


### PR DESCRIPTION
Closes the two gaps the test-review flagged for `tests/test_help_assets.py`. The contents-of-table check is mirrored over `help/index.hhk` so a broken topic linked from the help keyword index can no longer pass silently, and `resource_path` now has direct coverage for both of its branches: one test monkeypatches `sys._MEIPASS` to assert the frozen (PyInstaller) resolution, the other deletes it to assert the source-tree repo-root resolution. No production code changed — this is test-only.

## Verification
- `python -m ruff check tests/test_help_assets.py` — passed.
- `python -m black --check tests/test_help_assets.py` — passed (unchanged).
- Confirmed against the real bundled assets that all 35 `<param name="Local">` topics in `help/index.hhk` resolve to existing files, so the new assertion holds.
- Validated the `resource_path` branch logic with a standalone simulation (non-empty `_MEIPASS` -> frozen root; attribute deleted -> repo root three levels up from `paths.py`).
- Could NOT run `pytest tests/test_help_assets.py` in WSL: the module path `utils.constants` imports `wx` via `utils/constants/keyboard.py`, and `wx` is not installable here. This is pre-existing — the original test file already fails to import in WSL for the same reason — so these tests run under Windows CI. The import style I added (`import utils.constants.paths as paths_module`) executes the same `utils.constants.__init__`, so it does not change WSL importability.

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)