### PR TITLE
test: wire 5 missing reset_* singletons into isolation harness (#849)

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -81,15 +81,25 @@ reset_collection_service = _optional_reset(
 reset_comp_rules_service = _optional_reset(
     "services.comp_rules_service", "reset_comp_rules_service"
 )
+reset_card_service = _optional_reset("services.card_service", "reset_card_service")
+reset_metagame_service = _optional_reset("services.metagame_service", "reset_metagame_service")
+reset_radar_service = _optional_reset("services.radar_service", "reset_radar_service")
+reset_remote_snapshot_client = _optional_reset(
+    "repositories.remote_snapshot_client", "reset_remote_snapshot_client"
+)
+reset_deck_cache = _optional_reset("repositories.deck_text_cache", "reset_deck_cache")
 
 
 def reset_all_services() -> None:
     """Reset all global service instances."""
     reset_bundle_snapshot_client()
+    reset_card_service()
     reset_collection_service()
     reset_comp_rules_service()
     reset_deck_service()
     reset_format_card_pool_service()
+    reset_metagame_service()
+    reset_radar_service()
     reset_search_service()
     reset_image_service()
 
@@ -98,9 +108,11 @@ def reset_all_repositories() -> None:
     """Reset all global repository instances."""
     reset_card_repository()
     reset_deck_repository()
+    reset_deck_cache()
     reset_format_card_pool_repository()
     reset_metagame_repository()
     reset_radar_repository()
+    reset_remote_snapshot_client()
 
 
 def reset_all_globals() -> None:

--- a/tests/test_reset_helpers.py
+++ b/tests/test_reset_helpers.py
@@ -6,12 +6,34 @@ silently broken (no-op) test-isolation hook, while a genuinely missing optional
 dependency (e.g. ``wx``) stays silent.
 """
 
+import inspect
+import re
 import sys
 import types
 import warnings
+from pathlib import Path
 
 import pytest
 import test_helpers
+
+_REPO_ROOT = Path(test_helpers.__file__).resolve().parent.parent
+# Module-level ``def reset_*(`` declarations (column 0, i.e. not class methods).
+_RESET_DEF_RE = re.compile(r"^def (reset_[a-zA-Z0-9_]+)\(", re.MULTILINE)
+
+
+def _discover_reset_singletons():
+    """Find every module-level ``reset_*`` function under repositories/ and services/.
+
+    Returns a list of ``(name, source_path)`` tuples. These are the global
+    singleton reset hooks the test-isolation harness is expected to invoke.
+    """
+    found = []
+    for package in ("repositories", "services"):
+        for path in sorted((_REPO_ROOT / package).rglob("*.py")):
+            text = path.read_text(encoding="utf-8")
+            for name in _RESET_DEF_RE.findall(text):
+                found.append((name, path))
+    return found
 
 
 @pytest.fixture
@@ -126,3 +148,29 @@ def test_import_error_without_name_warns(monkeypatch):
 
     assert fn() is None
     assert any(module_path in str(c.message) for c in caught)
+
+
+def test_every_reset_singleton_is_wired_into_reset_all_globals():
+    """Guard: each discovered ``reset_*`` singleton must be reset by the harness.
+
+    A new module-level ``reset_*`` function added under repositories/ or
+    services/ that is not wired into ``reset_all_globals()`` leaks its cached
+    instance across the whole test session, defeating isolation. This test
+    fails loudly so the harness is kept in sync.
+    """
+    aggregate_source = "\n".join(
+        inspect.getsource(fn)
+        for fn in (
+            test_helpers.reset_all_services,
+            test_helpers.reset_all_repositories,
+        )
+    )
+
+    discovered = _discover_reset_singletons()
+    assert discovered, "expected to discover at least one reset_* singleton"
+
+    missing = sorted({name for name, _ in discovered if f"{name}()" not in aggregate_source})
+    assert not missing, (
+        "reset_all_globals() does not invoke these reset_* singletons, leaking "
+        f"state between tests: {missing}"
+    )


### PR DESCRIPTION
## Summary

`tests/test_helpers.py`'s `reset_all_globals()` invoked only 12 of the 17 module-level `reset_*` singletons that exist under `repositories/` and `services/`. The 5 unwired ones — `reset_card_service`, `reset_metagame_service`, `reset_radar_service` (services), `reset_remote_snapshot_client` and `reset_deck_cache` (repositories) — kept their cached instances across the entire test session, defeating the harness's stated "complete isolation between tests" guarantee and risking order-dependent flakiness. This PR resolves those 5 via the existing `_optional_reset` mechanism and wires them into `reset_all_services()` / `reset_all_repositories()`, and adds a guard test that discovers every module-level `def reset_*` under `repositories/` and `services/` and asserts each is invoked by `reset_all_globals()`, so a future singleton that is not wired up fails loudly.

## Verification

Run from WSL (wx is not importable here):
- `python -m pytest tests/test_reset_helpers.py tests/test_helpers.py -q` -> 6 passed (includes the new guard test).
- `python -m ruff check tests/test_helpers.py tests/test_reset_helpers.py` -> all checks passed.
- `python -m black --check` on both files -> would be left unchanged.
- Direct invocation of `reset_all_globals()` runs without error; the 5 new singletons resolve to silent no-ops in WSL because their modules transitively import `wx` (the harness's intended benign fallback). On Windows CI, where wx is installed, they resolve to the real reset functions.

Could not verify in WSL: the actual cross-test state-cleanup behavior on Windows (wx installed), where these singletons resolve to their real implementations — that path is exercised by the full Windows CI test suite, not reproducible here.

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)