### PR TITLE
test(math_utils): value-check at_least multi-bucket summation (#857)

### DIFF
--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -130,6 +130,22 @@ class TestHypergeometricAtLeast:
         prob = hypergeometric_at_least(40, 17, 7, 1)
         assert prob > 0.98
 
+    def test_at_least_two_playset_sums_multiple_buckets(self) -> None:
+        """P(at least 2 copies of a 4-of in 7-card hand) value-checks the multi-term sum.
+
+        Unlike the ``min_successes=1`` cases (which reduce to ``1 - P(0)``), this
+        requires summing the k=2, 3 and 4 buckets, so it exercises the loop body
+        for more than one iteration.
+
+        Reference: https://aetherhub.com/Apps/HyperGeometric
+        Expected: ~6.32%
+        """
+        prob = hypergeometric_at_least(60, 4, 7, 2)
+        assert 0.063 <= prob <= 0.0634
+        # Cross-check against the explicit sum of per-k probabilities.
+        expected = sum(hypergeometric_probability(60, 4, 7, k) for k in range(2, 5))
+        assert prob == pytest.approx(expected)
+
 
 class TestInputValidation:
     """Tests for input validation error handling."""


### PR DESCRIPTION
## Summary

Closes the 🟠 coverage gap flagged in the `test-review` report for `tests/test_math_utils.py`: every existing `hypergeometric_at_least` test used `min_successes=1`, which reduces to `1 - P(0)` and only ever runs the summation loop for a single iteration. This adds a `min_successes=2` case (`60, 4, 7, 2 ≈ 0.0632`) that asserts a reference value (cross-checked against aetherhub's hypergeometric calculator) and verifies it equals the explicit sum of the per-k probabilities for `k=2..4`, so the multi-bucket loop body is now value-checked.

The 🟡 item (dead defensive branches in `hypergeometric_probability`) was intentionally left untouched: the report itself states "No new test is feasible," and removing the `if denominator == 0` guard would be a source behavior change outside the scope of a focused test-coverage fix.

## Verification

Ran in WSL:
- `python -m pytest tests/test_math_utils.py -q` → 32 passed (was 31).
- `python -m ruff check tests/test_math_utils.py` → clean.
- `python -m black --check tests/test_math_utils.py` → clean.
- Confirmed the reference value independently: `hypergeometric_at_least(60, 4, 7, 2) == 0.06321941616167831`, equal to `sum(hypergeometric_probability(60, 4, 7, k) for k in range(2, 5))`.

This change is a pure-math, non-wx test addition, so there is no wx/UI behavior to verify and nothing here requires Windows.

Closes #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)