### PR TITLE
test(opponent-detection): pin split + substring-match contracts (#862)

### DIFF
--- a/tests/test_opponent_detection.py
+++ b/tests/test_opponent_detection.py
@@ -34,6 +34,34 @@ def test_find_opponent_names_detects_windows(
     assert find_opponent_names() == expected
 
 
+@pytest.mark.parametrize(
+    "titles, expected",
+    [
+        # Multiple 'vs.' segments: only the final segment is captured (split[-1]).
+        (["Alice vs. Bob vs. Carol"], ["Carol"]),
+        # Realistic full MTGO title with a trailing suffix on the opponent name;
+        # the whole remainder after the last 'vs.' (stripped) is the opponent.
+        (
+            ["Magic: The Gathering Online — Match: Hero vs. Rival [Paused]"],
+            ["Rival [Paused]"],
+        ),
+        # 'vs.' embedded inside a word (no boundary) still triggers a match;
+        # this pins the chosen substring contract rather than a word-boundary one.
+        (["elvs. Goblin"], ["Goblin"]),
+        (["Champion advs. Underdog"], ["Underdog"]),
+    ],
+)
+def test_find_opponent_names_split_and_matching_contract(
+    monkeypatch: pytest.MonkeyPatch, titles: Iterable[str], expected: list[str]
+) -> None:
+    """Pin the split contract (last 'vs.' segment, suffix kept) and the substring-match contract."""
+    monkeypatch.setattr(
+        "utils.find_opponent_names.pygetwindow.getAllTitles",
+        lambda: list(titles),
+    )
+    assert find_opponent_names() == expected
+
+
 def test_find_opponent_names_ignores_non_match_titles(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure titles without the vs. marker are skipped."""
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Addresses the three 🟡 coverage findings from the `test-review` workflow for `tests/test_opponent_detection.py` (module under test: `utils/find_opponent_names.py`). The function's behavior was correct but its implicit contracts were untested. This PR adds a parametrized test that pins those contracts so the chosen semantics are documented and regression-protected: (1) when a title has multiple `vs.` segments only the final segment is captured (`split("vs.")[-1]`), (2) a realistic full MTGO title preserves any trailing suffix on the opponent name (the stripped remainder after the last `vs.`), and (3) an embedded `vs.` with no word boundary still matches — pinning the substring contract rather than a word-boundary one. No production code changed.

## Verification

Ran in WSL:
- `python -m pytest tests/test_opponent_detection.py -q` → 12 passed.
- `python -m ruff check tests/test_opponent_detection.py` → clean.
- `python -m black --check tests/test_opponent_detection.py` → unchanged.

This change is test-only and does not import `wx`, so there is no wx/UI behavior to verify; nothing required the Windows-only UI test suite.

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)