### PR TITLE
test(perf): assert timed log template format

### DIFF
--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -72,6 +72,7 @@ def test_timed_logs_qualname_and_elapsed():
     mock_logger.debug.assert_called_once()
     call_args = mock_logger.debug.call_args
     template, qualname_arg, elapsed_arg = call_args.args
+    assert template == "{} took {:.4f}s"
     assert "my_func" in qualname_arg
     assert isinstance(elapsed_arg, float)
     assert elapsed_arg >= 0.0


### PR DESCRIPTION
Adds a single assertion to `test_timed_logs_qualname_and_elapsed` pinning the `timed()` log template to `"{} took {:.4f}s"`, mirroring the existing `perf_phase` template assertion. This closes the one minor coverage nit flagged in the test review: the `timed` log template format was previously never asserted, so a regression in the format string would go undetected. No production code changes.

## Verification
- `python -m ruff check tests/test_perf.py` — passed
- `python -m black --check tests/test_perf.py` — passed (unchanged)
- `python -m pytest tests/test_perf.py -q` — 11 passed

This is a non-wx test file, so it runs fully in WSL; no Windows/wx-only behavior is involved and nothing required Windows to verify.

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)