### PR TITLE
test(reset-helpers): cover dotted-path warn/silent boundary

### DIFF
--- a/tests/test_reset_helpers.py
+++ b/tests/test_reset_helpers.py
@@ -100,6 +100,47 @@ def test_transitive_missing_optional_dependency_is_silent(monkeypatch):
     assert not caught, [str(c.message) for c in caught]
 
 
+def test_dotted_missing_submodule_warns(fake_module):
+    """A dotted target whose parent exists but submodule is absent must warn.
+
+    Real registrations use dotted paths (e.g. ``repositories.card_repository``).
+    When the parent package is importable but the named submodule is gone
+    (renamed/removed/relocated), Python raises ``ImportError`` with ``exc.name``
+    equal to the *full dotted* ``module_path``. That is indistinguishable from a
+    broken target module, so the safe behaviour is to surface a warning rather
+    than silently no-op.
+    """
+    pkg = fake_module("fake_reset_pkg")
+    pkg.__path__ = []  # mark as a package so submodule import is attempted
+
+    module_path = "fake_reset_pkg.missing_submod"
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn = test_helpers._optional_reset(module_path, "reset_z")
+
+    assert fn() is None
+    assert any(module_path in str(c.message) for c in caught)
+
+
+def test_dotted_missing_top_level_package_is_silent():
+    """A dotted target whose *top-level* package is absent stays silent.
+
+    Here ``exc.name`` is the missing top-level package name, which differs from
+    the full dotted ``module_path``. This mirrors the benign case where an
+    optional dependency's whole package tree is not installed, so the
+    resolution should fall back to a no-op without warning.
+    """
+    module_path = "definitely_absent_top_pkg.some_submod"
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn = test_helpers._optional_reset(module_path, "reset_w")
+
+    assert fn() is None
+    assert not caught, [str(c.message) for c in caught]
+
+
 def test_import_error_without_name_warns(monkeypatch):
     """An ImportError with no ``.name`` (``exc.name is None``) must warn.
 


### PR DESCRIPTION
## Summary

Strengthens `tests/test_reset_helpers.py` to cover the dotted-module-path branch of `tests/test_helpers._optional_reset`, the nuance flagged in the test-review report. The prior missing-module/missing-attribute tests used bare top-level names, so the warn-vs-silent boundary — which hinges on `exc.name` versus the full dotted `module_path` — went unexercised even though every real registration is dotted (`repositories.*`, `services.*`). Two cases are added: (1) parent package present but submodule absent, where `exc.name` equals the full dotted path and the helper must warn so a renamed/removed/relocated reset function stays loud; and (2) top-level package absent, where `exc.name` is the top-level name (differs from `module_path`) and the helper silently falls back to a no-op (the benign uninstalled-optional-dependency case). No production code changed.

## Verification

Ran in WSL:
- `python -m pytest tests/test_reset_helpers.py -q` — 7 passed (5 existing + 2 new). The two new cases confirm both the warn and silent branches for genuine dotted imports (no monkeypatching of `__import__`; they rely on real `ImportError`/`ModuleNotFoundError` `.name` population via a `sys.modules`-registered package stub and a guaranteed-absent top-level package).
- `python -m ruff check tests/test_reset_helpers.py` — clean.
- `python -m black --check tests/test_reset_helpers.py` — clean.

Not checked in WSL: nothing wx/UI-related is involved here (this is a pure-Python test of test-isolation helpers), so there is no Windows-only behavior to defer. The full Windows test suite was not run.

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)