### PR TITLE
test(results-filter): cover Wins </≤/= ops + drop dead int() guards (#870)

### DIFF
--- a/tests/test_results_filter.py
+++ b/tests/test_results_filter.py
@@ -291,6 +291,28 @@ def test_placement_filter_ge_wins_4():
     assert results == ["4-1", "5-0"]
 
 
+def test_placement_filter_eq_wins_5():
+    # Wins uses standard (non-inverted) numeric semantics: "= 5" → only 5-0.
+    result = filter_decks(DECKS, placement_op="=", placement_field="Wins", placement_value="5")
+    assert len(result) == 1
+    assert result[0]["result"] == "5-0"
+
+
+def test_placement_filter_lt_wins_5():
+    # "< 5" reads literally as "fewer than 5 wins" → 4-1 only. This is distinct
+    # from Placement, where "<" is inverted; here it stays a plain operator.gt.
+    result = filter_decks(DECKS, placement_op="<", placement_field="Wins", placement_value="5")
+    assert len(result) == 1
+    assert result[0]["result"] == "4-1"
+
+
+def test_placement_filter_le_wins_4():
+    # "≤ 4" → only 4-1 (4 wins); 5-0 is excluded. Non-inverted semantics.
+    result = filter_decks(DECKS, placement_op="≤", placement_field="Wins", placement_value="4")
+    assert len(result) == 1
+    assert result[0]["result"] == "4-1"
+
+
 def test_placement_filter_excludes_decks_without_parseable_value():
     # Wins filter excludes "1st", "2nd", "Top 8", "7th", "Winner"
     result = filter_decks(DECKS, placement_op="≥", placement_field="Wins", placement_value="0")

--- a/widgets/panels/deck_research_panel/results_filter.py
+++ b/widgets/panels/deck_research_panel/results_filter.py
@@ -66,10 +66,8 @@ def parse_placement(result_str: str) -> int | None:
     match = _PLACEMENT_RE.search(result_str)
     if match is None:
         return None
-    try:
-        return int(match.group(1))
-    except ValueError:
-        return None
+    # The capture group is ``\d+``, so ``int()`` cannot raise here.
+    return int(match.group(1))
 
 
 def parse_wins(result_str: str) -> int | None:
@@ -82,10 +80,8 @@ def parse_wins(result_str: str) -> int | None:
     match = _WINS_RE.search(result_str)
     if match is None:
         return None
-    try:
-        return int(match.group(1))
-    except ValueError:
-        return None
+    # The capture group is ``\d+``, so ``int()`` cannot raise here.
+    return int(match.group(1))
 
 
 def _placement_value_for_field(result_str: str, field: str) -> int | None:


### PR DESCRIPTION
## Summary

Addresses the two test-review findings for `tests/test_results_filter.py`. Adds Wins-field filter cases for the `<`, `≤`, and `=` operators so the suite locks in the non-inverted numeric semantics that distinguish the `Wins` field from `Placement` (where comparator direction is intentionally flipped). Also removes the unreachable `try/except ValueError` around `int(match.group(1))` in `parse_placement` and `parse_wins` in `results_filter.py` — both capture groups are `\d+`, so the conversion can never raise.

## Verification

Run from WSL:
- `python -m pytest tests/test_results_filter.py -q` → 72 passed (includes the 3 new Wins cases).
- `python -m ruff check` on both changed files → all checks passed.
- `python -m black --check` on both changed files → unchanged.

This module is pure (no wx/network), so it is fully exercisable in WSL. No wx/UI behavior is involved, so nothing was deferred to Windows for this change.

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)