### PR TITLE
test(runtime-flags): clarify tutorial-gate composition test (#872)

### DIFF
--- a/tests/test_runtime_flags.py
+++ b/tests/test_runtime_flags.py
@@ -75,8 +75,14 @@ def test_skip_tutorial_when_shown_and_automation():
     assert should_show_tutorial(tutorial_shown=True, automation_enabled=True) is False
 
 
-def test_tutorial_gate_reads_live_automation_flag(runtime_flags):
-    """The gate honours the real process-wide automation flag set at startup."""
+def test_tutorial_gate_composes_with_live_automation_flag(runtime_flags):
+    """The pure gate composes correctly with the real process-wide flag value.
+
+    ``should_show_tutorial`` takes ``automation_enabled`` as an argument; this
+    checks that wiring it to the live ``runtime_flags`` reading (as the startup
+    handler does) produces the expected decision. The exhaustive truth table is
+    covered by the cases above; here we assert a single representative wiring.
+    """
     runtime_flags.set_automation_enabled(True)
     assert (
         should_show_tutorial(
@@ -84,12 +90,4 @@ def test_tutorial_gate_reads_live_automation_flag(runtime_flags):
             automation_enabled=runtime_flags.is_automation_enabled(),
         )
         is False
-    )
-    runtime_flags.set_automation_enabled(False)
-    assert (
-        should_show_tutorial(
-            tutorial_shown=False,
-            automation_enabled=runtime_flags.is_automation_enabled(),
-        )
-        is True
     )


### PR DESCRIPTION
Addresses the two 🟡 test-review nits for `tests/test_runtime_flags.py` from issue #872. The single affected test (`test_tutorial_gate_reads_live_automation_flag`) is renamed to `test_tutorial_gate_composes_with_live_automation_flag` with a reworded docstring, because the pure `should_show_tutorial` predicate takes `automation_enabled` as an argument and never "reads" the flag itself — it merely composes with the live `runtime_flags` reading. The redundant second assertion is dropped since the exhaustive 2×2 truth table is already covered by the four cases above; one representative wiring assertion remains to convey the test's composition purpose.

## Verification
Ran from WSL (wx not importable here, but these are wx-free pure modules):
- `python -m ruff check tests/test_runtime_flags.py` — passed
- `python -m black --check tests/test_runtime_flags.py` — unchanged
- `python -m pytest tests/test_runtime_flags.py -q` — 8 passed

No wx/UI behavior is involved in this change, so nothing required Windows-only verification. The touched module (`session_logic.py`) and `utils/runtime_flags.py` are wx-free and fully exercised by the passing suite.

Closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)