### PR TITLE
fix(rules-browser): lazy-load frame so html_render is importable without wx (#871)

### DIFF
--- a/widgets/frames/rules_browser/__init__.py
+++ b/widgets/frames/rules_browser/__init__.py
@@ -2,6 +2,20 @@
 
 from __future__ import annotations
 
-from widgets.frames.rules_browser.frame import RulesBrowserFrame
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from widgets.frames.rules_browser.frame import RulesBrowserFrame
 
 __all__ = ["RulesBrowserFrame"]
+
+
+def __getattr__(name: str) -> Any:
+    # Lazily import the wx-dependent frame so that pure-Python submodules
+    # (e.g. ``html_render``) can be imported — and unit-tested — without
+    # pulling in ``wx`` via this package ``__init__``.
+    if name == "RulesBrowserFrame":
+        from widgets.frames.rules_browser.frame import RulesBrowserFrame
+
+        return RulesBrowserFrame
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

The `widgets/frames/rules_browser` package `__init__` eagerly imported `RulesBrowserFrame`, which imports `wx`. As a result, importing the pure-Python `html_render` submodule pulled in `wx` via the package `__init__`, so `tests/test_rules_browser_html_render.py` raised `ModuleNotFoundError: No module named 'wx'` at collection in WSL and only ran on Windows CI — contradicting its "without a wx App" claim (issue #871 / `docs/TEST_REVIEW.md`). This replaces the eager import with a module-level `__getattr__` that lazily resolves `RulesBrowserFrame` on first access. The public API (`from widgets.frames.rules_browser import RulesBrowserFrame`) is unchanged, and the sole consumer (`widgets/frames/app_frame/handlers/app_frame.py`) already imports it lazily inside a function.

## Verification

Ran in WSL (wx not importable here):
- `python -m pytest tests/test_rules_browser_html_render.py -q` → 16 passed (previously errored at collection with `ModuleNotFoundError: No module named 'wx'`).
- `python -m ruff check` and `python -m black --check` on the changed file → both clean.
- Manual import check: `import widgets.frames.rules_browser` succeeds without wx; `pkg.RulesBrowserFrame` still triggers the lazy frame import (raises the expected `ModuleNotFoundError` only because wx is absent in WSL — on Windows it loads the frame); an unknown attribute raises `AttributeError`.

Could NOT verify in WSL: actual wx/UI behavior of `RulesBrowserFrame` (the frame loading and the rules browser window rendering) — that requires Windows with `wx` installed. This change only defers the import; it does not alter frame construction.

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)