### PR TITLE
test(search): cover mana-cost generic/case/hybrid edge cases (#873)

### DIFF
--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -63,6 +63,34 @@ def test_matches_mana_cost_empty_query():
     assert matches_mana_cost(card_cost, query, "contains") is True
 
 
+def test_matches_mana_cost_contains_generic_token_is_literal():
+    """Generic-mana tokens are matched as literal symbols, not quantities.
+
+    A ``{2}`` generic token only satisfies a card that actually carries a
+    ``{2}`` token; a different generic amount (``{3}``) does not count toward
+    it in 'contains' mode.
+    """
+    assert matches_mana_cost("{3}{G}", "{2}", "contains") is False
+    assert matches_mana_cost("{2}{G}", "{2}", "contains") is True
+
+
+def test_matches_mana_cost_contains_empty_card():
+    """A card with no mana cost cannot contain a required colored symbol."""
+    assert matches_mana_cost("", "{G}", "contains") is False
+
+
+def test_matches_mana_cost_exact_case_insensitive():
+    """Exact matching is case-insensitive on symbol spelling."""
+    assert matches_mana_cost("{2}{g}{g}", "{2}{G}{G}", "exact") is True
+
+
+def test_matches_mana_cost_hybrid_is_atomic():
+    """A hybrid symbol is a single atomic token, not its two component pips."""
+    # {G}{U} (two separate pips) is not the same cost as {G/U} (one hybrid pip).
+    assert matches_mana_cost("{G}{U}", "{G/U}", "exact") is False
+    assert matches_mana_cost("{G/U}", "{G/U}", "exact") is True
+
+
 def test_matches_mana_cost_hybrid_mana():
     """Test matching with hybrid mana symbols."""
     card_cost = "{G/U}{G/U}"


### PR DESCRIPTION
Strengthens `tests/test_search_filters.py` per the test-review findings for #873. Adds four targeted assertions for `matches_mana_cost`: generic-mana tokens in 'contains' mode are treated as literal symbols rather than numeric quantities (`{3}{G}` does not contain `{2}`, while `{2}{G}` does); 'contains' against an empty/colorless card cost is False; exact matching is case-insensitive on symbol spelling (`{g}` == `{G}`); and hybrid symbols are atomic, so `{G}{U}` (two pips) is not equal to `{G/U}` (one hybrid pip) in exact mode. No production code changes — these are pure-predicate test additions exercising existing behavior of `services/search_service/mana_filters.py` and `tokenize_mana_symbols`.

## Verification
- `python -m ruff check tests/test_search_filters.py` — passed.
- `python -m black --check tests/test_search_filters.py` — passed (unchanged).
- Could not run `pytest tests/test_search_filters.py` in WSL: collecting the file imports `services.search_service` whose package `__init__` transitively `import wx`, which is not available off-Windows. To confirm the new assertions, I loaded `mana_query.py` and `mana_filters.py` directly (bypassing the wx-importing package init) and executed every new assertion — all passed. The tests should collect and pass normally on Windows CI where `wx` is importable; that full-suite run was not performed here.

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)