### PR TITLE
fix(store): coerce non-object JSON to empty dict in load_store

### DIFF
--- a/services/store_service.py
+++ b/services/store_service.py
@@ -19,7 +19,11 @@ class StoreService:
             return {}
         try:
             with locked_path(path):
-                return fast_load(path)
+                data = fast_load(path)
+            if not isinstance(data, dict):
+                logger.warning(f"Store at {path} is not a JSON object; ignoring store")
+                return {}
+            return data
         except Exception as exc:
             if isinstance(exc, OSError):
                 logger.warning(f"Failed to read {path}: {exc}")

--- a/tests/test_store_service.py
+++ b/tests/test_store_service.py
@@ -73,6 +73,36 @@ def test_load_store_handles_oserror(monkeypatch, tmp_path: Path, store_service: 
     assert any("Failed to read" in message for message in messages)
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        ["Out 2 Bolt", "In 2 Aether Gust"],
+        "just a string",
+        42,
+    ],
+)
+def test_load_store_coerces_non_dict_json_to_empty_dict(
+    payload, tmp_path: Path, store_service: StoreService
+):
+    """Valid-but-non-object JSON is rejected so callers always get a dict[str, Any]."""
+    from loguru import logger
+
+    path = tmp_path / "store.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        result = store_service.load_store(path)
+    finally:
+        logger.remove(sink_id)
+
+    # Contract is dict[str, Any]: a top-level list/str/int must not leak through.
+    assert result == {}
+    assert isinstance(result, dict)
+    assert any("not a JSON object" in message for message in messages)
+
+
 def test_load_store_logs_invalid_json_branch(tmp_path: Path, store_service: StoreService):
     """Invalid JSON triggers the JSON-decode logging branch, not the OSError one."""
     from loguru import logger
@@ -100,8 +130,13 @@ def test_save_store_writes_json_payload(tmp_path: Path, store_service: StoreServ
     store_service.save_store(target, data)
 
     assert target.exists()
-    contents = json.loads(target.read_text(encoding="utf-8"))
+    raw = target.read_text(encoding="utf-8")
+    contents = json.loads(raw)
     assert contents == data
+    # save_store requests indent=2; assert the on-disk shape so a dropped
+    # indent (compact single-line output) is caught.
+    assert "\n" in raw
+    assert '  "guides"' in raw
 
 
 def test_save_store_preserves_unicode(tmp_path: Path, store_service: StoreService):


### PR DESCRIPTION
## Summary

`StoreService.load_store` is typed `dict[str, Any]` and all three callers in `AppController` (`deck_notes_store`, `outboard_store`, `guide_store`) consume the result dict-style (subscript assignment and `.get`). A *valid* top-level JSON list/string/int previously decoded cleanly through `fast_load` and leaked past the existing corrupt-store guard, which would later break those callers with `AttributeError`/`TypeError`. This change checks that the decoded payload is a `dict`; anything else is treated as an invalid store — it logs a warning and returns `{}`, matching the existing OSError/invalid-JSON fallbacks. Addresses both findings in #876 (the unexercised non-dict contract path and the unverified `save_store` indent formatting).

## Verification

Ran in WSL:
- `python -m pytest tests/test_store_service.py -q` → 11 passed.
- `python -m ruff check services/store_service.py tests/test_store_service.py` → all checks passed.
- `python -m black --check services/store_service.py tests/test_store_service.py` → unchanged.

Added a parametrized test exercising the new non-dict contract path (list/str/int → `{}` + warning), and tightened the `save_store` happy-path test to assert the on-disk `indent=2` shape so a dropped indent is caught.

Could not verify in WSL: nothing wx/UI-related is involved here (this is a pure service-layer JSON helper with no `wx` import), so there is no GUI behavior to check off-Windows. The full Windows UI test suite was not run from WSL.

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)