### PR TITLE
test(session-manager): cover deck sash position and zero-coordinate save

### DIFF
--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -322,6 +322,71 @@ def test_deck_view_and_pile_sort_modes(tmp_path):
     assert manager.settings["deck_pile_sort_modes"]["side"] == "mv"
 
 
+def test_deck_sash_position_getter_and_setter(tmp_path):
+    manager = _make_manager(tmp_path)
+
+    # No saved position: the getter returns the supplied default (0 means
+    # "no saved position" by contract).
+    assert manager.get_deck_sash_position() == 0
+    assert manager.get_deck_sash_position(default=150) == 150
+
+    # A positive position round-trips.
+    manager.update_deck_sash_position(220)
+    assert manager.settings["deck_sash_position"] == 220
+    assert manager.get_deck_sash_position() == 220
+    assert manager.get_deck_sash_position(default=150) == 220
+
+    # Non-positive and non-int updates are silently dropped, leaving the last
+    # valid value intact.
+    manager.update_deck_sash_position(0)
+    manager.update_deck_sash_position(-5)
+    manager.update_deck_sash_position("300")  # type: ignore[arg-type]
+    assert manager.settings["deck_sash_position"] == 220
+
+
+def test_get_deck_sash_position_coerces_and_clamps(tmp_path):
+    # A stringified int is coerced; a positive value passes through.
+    manager = _make_manager(tmp_path, {"deck_sash_position": "180"})
+    assert manager.get_deck_sash_position() == 180
+
+    # Zero/negative stored values fall back to the default ("no saved position").
+    manager = _make_manager(tmp_path, {"deck_sash_position": 0})
+    assert manager.get_deck_sash_position(default=150) == 150
+    manager = _make_manager(tmp_path, {"deck_sash_position": -10})
+    assert manager.get_deck_sash_position(default=150) == 150
+
+    # A non-numeric stored value falls back to the default rather than raising.
+    manager = _make_manager(tmp_path, {"deck_sash_position": "not-a-number"})
+    assert manager.get_deck_sash_position(default=150) == 150
+
+
+def test_save_drops_omitted_window_size_but_keeps_zero_screen_pos(tmp_path):
+    manager = _make_manager(tmp_path)
+    base_kwargs = {
+        "current_format": "Modern",
+        "left_mode": "builder",
+        "deck_data_source": "mtgo",
+        "zone_cards": {"main": [], "side": [], "out": []},
+    }
+
+    # Omitted (None) window_size leaves no key behind.
+    manager.save(**base_kwargs)
+    data = json.loads(manager.settings_file.read_text(encoding="utf-8"))
+    assert "window_size" not in data
+    assert "screen_pos" not in data
+
+    # screen_pos=(0, 0) is a non-empty tuple, so it persists and restores
+    # rather than being dropped as a falsy coordinate.
+    manager.save(**base_kwargs, window_size=(1024, 768), screen_pos=(0, 0))
+    data = json.loads(manager.settings_file.read_text(encoding="utf-8"))
+    assert data["window_size"] == [1024, 768]
+    assert data["screen_pos"] == [0, 0]
+
+    restored = manager.restore_session_state({"main": [], "side": [], "out": []})
+    assert restored["window_size"] == (1024, 768)
+    assert restored["screen_pos"] == (0, 0)
+
+
 def test_event_type_player_and_date_filters(tmp_path):
     manager = _make_manager(tmp_path)
     assert manager.get_deck_event_type_filter() == "All"


### PR DESCRIPTION
Adds non-wx unit tests for the two coverage gaps flagged in the test review of `tests/test_session_manager.py` (issue #875). It exercises the previously-untested `get_deck_sash_position` / `update_deck_sash_position` pair — the `int()` coercion, the `>0 else default` clamp, and the silent-drop guard on zero/negative/non-int updates, including the load-bearing "0 means no saved position" contract — and pins `save()`'s falsy-coordinate behavior: an omitted `window_size` leaves no key behind, while `screen_pos=(0, 0)` is a non-empty (truthy) tuple that persists and restores intact. No production code changed.

## Verification
- `python -m ruff check tests/test_session_manager.py` — passed.
- `python -m black --check tests/test_session_manager.py` — passed (unchanged).
- The test file's module loader transitively imports `wx` (via `utils.constants`), so the suite cannot run directly in WSL. To validate the new assertions I ran the file under a minimal in-process `wx` stub (NOT committed): all 22 tests pass (19 existing + 3 new). On Windows CI, where `wx` is importable, the file runs without any stub.
- Not verifiable in WSL: actual wx/UI behavior. These are pure controller-logic tests against real collaborators, so there is no GUI behavior to exercise here.

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)