### PR TITLE
test(marquee): exercise per-view geometry + controller guards

### DIFF
--- a/tests/ui/test_marquee_selection.py
+++ b/tests/ui/test_marquee_selection.py
@@ -105,6 +105,97 @@ def test_controller_drives_begin_update_finish():
         frame.Destroy()
 
 
+@pytest.mark.usefixtures("wx_app")
+def test_controller_double_begin_is_a_no_op():
+    """A second begin while a marquee is active must not re-fire on_begin or
+    clobber the existing rectangle (the active-guard at marquee.py:114)."""
+    frame = wx.Frame(None)
+    try:
+        window = wx.Window(frame)
+        window.CaptureMouse = lambda: None  # type: ignore[assignment]
+        window.HasCapture = lambda: False  # type: ignore[assignment]
+        window.ReleaseMouse = lambda: None  # type: ignore[assignment]
+
+        begins: list[bool] = []
+        controller = MarqueeController(
+            window,
+            to_logical=lambda p: p,
+            on_begin=lambda additive: begins.append(additive),
+            on_select=lambda rect: None,
+            on_finish=lambda: None,
+        )
+        controller._update_overlay = lambda: None  # type: ignore[assignment]
+
+        controller.begin(wx.Point(5, 5), additive=True)
+        controller.begin(wx.Point(99, 99), additive=False)
+
+        assert begins == [True]  # second begin was ignored
+    finally:
+        frame.Destroy()
+
+
+@pytest.mark.usefixtures("wx_app")
+def test_controller_update_and_finish_before_begin_do_nothing():
+    """update()/finish() while idle are no-ops (the active-guards at
+    marquee.py:138 and :146): neither selects nor fires on_finish."""
+    frame = wx.Frame(None)
+    try:
+        window = wx.Window(frame)
+        window.CaptureMouse = lambda: None  # type: ignore[assignment]
+        window.HasCapture = lambda: False  # type: ignore[assignment]
+        window.ReleaseMouse = lambda: None  # type: ignore[assignment]
+
+        events: list[str] = []
+        controller = MarqueeController(
+            window,
+            to_logical=lambda p: p,
+            on_begin=lambda additive: events.append("begin"),
+            on_select=lambda rect: events.append("select"),
+            on_finish=lambda: events.append("finish"),
+        )
+        controller._update_overlay = lambda: None  # type: ignore[assignment]
+
+        controller.update(wx.Point(10, 10))
+        controller.finish()
+
+        assert events == []
+        assert not controller.active
+    finally:
+        frame.Destroy()
+
+
+@pytest.mark.usefixtures("wx_app")
+def test_controller_cancel_fires_finish_only_when_active():
+    """cancel() tears down and fires on_finish when active, but its was_active
+    guard (marquee.py:153-156) keeps a cancel-while-idle silent."""
+    frame = wx.Frame(None)
+    try:
+        window = wx.Window(frame)
+        window.CaptureMouse = lambda: None  # type: ignore[assignment]
+        window.HasCapture = lambda: False  # type: ignore[assignment]
+        window.ReleaseMouse = lambda: None  # type: ignore[assignment]
+
+        finishes: list[int] = []
+        controller = MarqueeController(
+            window,
+            to_logical=lambda p: p,
+            on_begin=lambda additive: None,
+            on_select=lambda rect: None,
+            on_finish=lambda: finishes.append(1),
+        )
+        controller._update_overlay = lambda: None  # type: ignore[assignment]
+
+        controller.cancel()  # idle: guarded, no on_finish
+        assert finishes == []
+
+        controller.begin(wx.Point(5, 5), additive=False)
+        controller.cancel()  # active: tears down and notifies
+        assert not controller.active
+        assert finishes == [1]
+    finally:
+        frame.Destroy()
+
+
 # ----- grid view -----
 @pytest.mark.usefixtures("wx_app")
 def test_grid_marquee_selects_covered_cards():
@@ -127,6 +218,48 @@ def test_grid_marquee_selects_covered_cards():
 
         assert view._selected_names == {"Grizzly Bears", "Llanowar Elves", "Forest"}
         assert view.get_selected_name() is None  # multi-select reports no single
+    finally:
+        frame.Destroy()
+
+
+@pytest.mark.usefixtures("wx_app")
+def test_grid_marquee_geometry_selects_only_swept_card():
+    """A rectangle that covers exactly one card's cell selects only that card,
+    reports it as the single selection, and a rect that misses every cell
+    selects nothing — exercising the real _card_rect geometry rather than the
+    all-covering _BIG_RECT."""
+    chosen: list[Any] = []
+    frame = wx.Frame(None)
+    try:
+        view = DeckGridView(
+            frame,
+            "main",
+            _get_metadata,
+            lambda _n, _s: None,
+            lambda _n, _q: ("owned", (0, 0, 0)),
+            ManaIconFactory(icon_size=12),
+            on_select=lambda card: chosen.append(card),
+            on_hover=None,
+        )
+        view.set_cards(_cards())
+
+        # Sweep exactly the second card's cell; only that card is hit.
+        target = view._card_rect(1)
+        expected = view._cards[1]["name"]
+
+        view._marquee_begin(False)
+        view._marquee_select(target)
+
+        assert view._selected_names == {expected}
+        # A lone marquee hit is forwarded as the single selection.
+        assert chosen and chosen[-1] is not None
+        assert chosen[-1]["name"] == expected
+        assert view.get_selected_name() == expected
+
+        # A rectangle in the gutter far below every cell selects nothing.
+        view._marquee_begin(False)
+        view._marquee_select(wx.Rect(5_000, 5_000, 1, 1))
+        assert view._selected_names == set()
     finally:
         frame.Destroy()
 
@@ -178,5 +311,49 @@ def test_table_marquee_selects_covered_rows():
 
         assert view._selected_names == {"Grizzly Bears", "Llanowar Elves", "Forest"}
         assert view.get_selected_name() is None
+    finally:
+        frame.Destroy()
+
+
+@pytest.mark.usefixtures("wx_app")
+def test_table_marquee_geometry_selects_only_swept_row():
+    """A rectangle spanning exactly one row's vertical extent selects only that
+    row and reports it as the single selection; a rect above every row selects
+    nothing — exercising the real CellToRect vertical-overlap test instead of
+    the all-covering _BIG_RECT."""
+    chosen: list[Any] = []
+    frame = wx.Frame(None)
+    try:
+        view = DeckTableView(
+            frame,
+            "main",
+            _get_metadata,
+            on_select=lambda card: chosen.append(card),
+            on_hover=None,
+            icon_factory=ManaIconFactory(icon_size=12),
+        )
+        view.set_cards(_cards())
+
+        # Span exactly the second row's vertical extent (the column is
+        # irrelevant for full-row selection).
+        row_rect = view.grid.CellToRect(1, 0)
+        expected = view._rows[1]["name"]
+        band = wx.Rect(
+            row_rect.GetLeft(), row_rect.GetTop() + 1, row_rect.GetWidth(), row_rect.GetHeight() - 2
+        )
+
+        view._marquee_begin(False)
+        view._marquee_select(band)
+
+        assert view._selected_names == {expected}
+        assert chosen and chosen[-1] is not None
+        assert chosen[-1]["name"] == expected
+        assert view.get_selected_name() == expected
+
+        # A zero-height rect above the first row overlaps no row's span.
+        top = view.grid.CellToRect(0, 0).GetTop()
+        view._marquee_begin(False)
+        view._marquee_select(wx.Rect(0, top - 10, 1, 1))
+        assert view._selected_names == set()
     finally:
         frame.Destroy()


### PR DESCRIPTION
## Summary

Strengthens `tests/ui/test_marquee_selection.py`. Previously every coverage assertion swept the all-covering `_BIG_RECT`, so the per-view intersection geometry — grid `_card_rect` and the table `CellToRect` vertical-overlap test, the one thing that actually differs between the views — was never exercised; an off-by-one or inverted bound would still pass. The single-card `on_select` notify path, `MarqueeController.cancel()`'s `was_active` guard, and the begin/update/finish idempotence guards were also untested. This PR adds geometry-aware grid/table tests that compute a target rect from the real `_card_rect`/`CellToRect`, sweep exactly one card/row, and assert only that item is selected, reported as the single selection, and that a missing rect selects nothing — plus controller tests covering `cancel()`'s active/idle branches and the double-begin / update-before-begin / finish-before-begin no-ops. No production code changed.

## Verification

- `python -m ruff check tests/ui/test_marquee_selection.py` — passed.
- `python -m black --check tests/ui/test_marquee_selection.py` — passed (unchanged).
- `python -m py_compile tests/ui/test_marquee_selection.py` — passed.
- Confirmed against the source that the asserted APIs exist and behave as expected: `DeckGridView._card_rect`, `DeckTableView.grid.CellToRect`, `_marquee_select`/`_marquee_begin`, `_notify_selection` → constructor `on_select`, and `get_selected_name` (returns the lone name only when exactly one is selected).

Could NOT be checked in WSL: the tests themselves do not run here. `tests/ui/conftest.py` skips the whole module on non-Windows, and `wx` is not importable in this environment (the app runs on Windows). Per the repo workflow these UI tests require Windows + an available display; they were not executed. New geometry assertions are derived from the real layout helpers rather than hardcoded pixels, so they remain valid under layout/constant changes, but their pass/fail must be confirmed by the Windows CI / a Windows run.

Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)