### PR TITLE
fix: guard image download against None downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 CLAUDE.md
 AGENTS.md
 env/
+.venv/
 magic_online_metagame_crawler.egg-info/
 config/
 cache/

--- a/widgets/dialogs/image_download_dialog/dialog.py
+++ b/widgets/dialogs/image_download_dialog/dialog.py
@@ -40,7 +40,7 @@ class ImageDownloadDialog(
         self,
         parent: wx.Window,
         image_cache: Any,
-        image_downloader: BulkImageDownloader,
+        image_downloader: BulkImageDownloader | None,
         bulk_data_cache_path: Path,
         on_status_update: Callable[[str], None] | None = None,
     ):

--- a/widgets/dialogs/image_download_dialog/handlers.py
+++ b/widgets/dialogs/image_download_dialog/handlers.py
@@ -5,20 +5,19 @@ from __future__ import annotations
 import threading
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import wx
 from loguru import logger
 
-if TYPE_CHECKING:
-    from services.image_service import BulkImageDownloader
+from services.image_service import BulkImageDownloader
 
 
 class ImageDownloadDialogHandlersMixin:
     """Threaded download worker that reports progress to the status bar."""
 
     image_cache: Any
-    image_downloader: BulkImageDownloader
+    image_downloader: BulkImageDownloader | None
     bulk_data_cache_path: Path
     on_status_update: Callable[..., None] | None
 
@@ -38,10 +37,16 @@ class ImageDownloadDialogHandlersMixin:
 
         def worker():
             try:
+                # The image service exposes ``image_downloader`` lazily (it is
+                # ``None`` until first used), so fall back to a fresh instance
+                # here — mirrors the ``or BulkImageDownloader(...)`` pattern used
+                # elsewhere in the image service.
+                downloader = self.image_downloader or BulkImageDownloader(self.image_cache)
+
                 # Ensure bulk data is downloaded
                 if not self.bulk_data_cache_path.exists():
                     wx.CallAfter(self._report_status, "app.status.image_download_metadata")
-                    success, msg = self.image_downloader.download_bulk_metadata(force=False)
+                    success, msg = downloader.download_bulk_metadata(force=False)
                     if not success:
                         wx.CallAfter(
                             self._on_download_failed, f"Failed to download metadata: {msg}"
@@ -49,7 +54,7 @@ class ImageDownloadDialogHandlersMixin:
                         return
 
                 # Download images
-                result = self.image_downloader.download_all_images(
+                result = downloader.download_all_images(
                     size=quality, max_cards=max_cards, progress_callback=progress_callback
                 )
 


### PR DESCRIPTION
## Problem

Clicking **Download Card Images → Download** in the UI crashed with:

```
AttributeError: 'NoneType' object has no attribute 'download_all_images'
```

## Root cause

The image service exposes `image_downloader` lazily — `ImageService.__init__` sets it to `None` (`services/image_service/service.py:29`) and never reassigns it. Every caller uses the fallback pattern `self.image_downloader or BulkImageDownloader(self.image_cache)` (e.g. `services/image_service/metadata.py:34`).

The download dialog was the one exception: `right_panel.py:95` caches the service's `image_downloader` at build time (still `None`) and the menu handler (`app_frame.py:51`) passes it straight into the dialog, so the worker called `None.download_all_images(...)`.

## Fix

Apply the same fallback inside the dialog worker, resolving a fresh `BulkImageDownloader(self.image_cache)` when none was supplied. Widened the type hints to `BulkImageDownloader | None` in `handlers.py` and `dialog.py` to match reality. The dialog already receives `image_cache`, so no call-site changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)