### PR TITLE
feat: auto-fetch mana assets from pinned fork on first run

### DIFF
--- a/main.py
+++ b/main.py
@@ -121,6 +121,32 @@ class MetagameWxApp(wx.App):
         return True
 
 
+def _ensure_mana_assets() -> None:
+    """Fetch the mana symbol assets on first run if they are missing.
+
+    Runs once, before the UI is built, so mana icons render without a manual
+    ``scripts/fetch_mana_assets.py`` step. On every subsequent launch the assets
+    are already present and this is a cheap local check. Any failure (no network,
+    git unavailable, running frozen) is non-fatal: the mana icon factory falls
+    back to placeholder glyphs, so we log and continue.
+    """
+    try:
+        from scripts.fetch_mana_assets import ensure_mana_assets, mana_assets_present
+
+        if mana_assets_present():
+            return
+        logger.info("Mana assets missing; fetching on first run…")
+        if ensure_mana_assets(quiet=True):
+            logger.info("Mana assets fetched successfully.")
+        else:
+            logger.warning(
+                "Could not fetch mana assets; mana symbols will use fallback glyphs. "
+                "Run scripts/fetch_mana_assets.py to retry."
+            )
+    except Exception as exc:  # pragma: no cover - defensive; never block startup
+        logger.warning(f"Skipping mana asset fetch: {exc}")
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="MTGO Metagame Deck Builder")
     parser.add_argument(
@@ -154,6 +180,8 @@ def main() -> None:
     if log_file:
         logger.info(f"Writing logs to {log_file}")
     logger.info(f"Using base data directory: {BASE_DATA_DIR}")
+
+    _ensure_mana_assets()
 
     if _automation_enabled:
         logger.info(f"Automation mode enabled on port {_automation_port}")

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -11,7 +11,7 @@ Prerequisites: Inno Setup 6, Python 3.11+ with PyInstaller, and optionally .NET 
 To customize edit installer.iss to change version, app name, included files, or shortcuts. For distribution sign the installer and generate checksums. The build and test scripts are CI/CD friendly.
 
 Notes:
-- Mana symbol assets are auto-fetched (and bundled) during the build if `assets/mana` is missing.
+- Mana symbol assets are auto-fetched (and bundled) during the build if `assets/mana` is missing. They come from the `Pedrogush/mana` fork of `andrewgioia/mana`, which pins the source so upstream changes never affect us until the fork is synced. The app also self-fetches these assets on first run (see `scripts/fetch_mana_assets.py`).
 
 ## Bridge release flow
 

--- a/packaging/build_installer.ps1
+++ b/packaging/build_installer.ps1
@@ -154,7 +154,7 @@ try {
 
     $ManaDir = Join-Path $ProjectRoot "assets\mana"
     if (-not (Test-Path $ManaDir)) {
-        Write-Info "Mana assets missing; fetching andrewgioia/mana…"
+        Write-Info "Mana assets missing; fetching from the Pedrogush/mana fork…"
         $FetchScript = Join-Path $ProjectRoot "scripts\fetch_mana_assets.py"
         if (Test-Path $FetchScript) {
             if (Test-Path $VendorPython) {

--- a/packaging/build_installer.sh
+++ b/packaging/build_installer.sh
@@ -144,7 +144,7 @@ fi
 # Ensure mana assets are present (needed for packaged icons)
 MANA_DIR="$PROJECT_ROOT/assets/mana"
 if [ ! -d "$MANA_DIR" ]; then
-    echo_info "Mana assets missing; fetching andrewgioia/mana…"
+    echo_info "Mana assets missing; fetching from the Pedrogush/mana fork…"
     if ! python3 scripts/fetch_mana_assets.py; then
         echo_warn "Failed to fetch mana assets; mana symbols will not render in the installer build."
     fi

--- a/scripts/fetch_mana_assets.py
+++ b/scripts/fetch_mana_assets.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""Fetch the mana symbol assets from andrewgioia/mana when missing."""
+"""Fetch the mana symbol assets when missing.
+
+Assets are cloned from ``Pedrogush/mana`` — our fork of ``andrewgioia/mana``.
+Pointing at the fork pins this dependency: upstream changes only reach us when
+we deliberately sync the fork, so a maintainer edit can never alter what the
+app or a build fetches out from under us.
+
+This module is importable: :func:`ensure_mana_assets` detects the local state
+and only clones when the assets are actually missing, so the application can
+self-heal on startup instead of relying on a manual run.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +18,43 @@ import shutil
 import subprocess  # nosec B404 - needed to invoke git clone of a trusted repo
 import sys
 from pathlib import Path
+
+# Our fork of andrewgioia/mana. Using the fork (rather than upstream) pins the
+# asset source so maintainer changes never affect us until we sync the fork.
+DEFAULT_MANA_REPO = "https://github.com/Pedrogush/mana.git"
+# Retained for reference/provenance; the fork above is what we actually clone.
+UPSTREAM_MANA_REPO = "https://github.com/andrewgioia/mana.git"
+
+# Files/directories that must exist for the mana assets to be considered
+# usable. A bare ``assets/mana`` directory (e.g. a half-finished clone) is not
+# enough — these are the paths the mana icon factory actually reads.
+_REQUIRED_ASSET_PATHS: tuple[Path, ...] = (
+    Path("fonts") / "mana.ttf",
+    Path("css") / "mana.min.css",
+    Path("svg"),
+)
+
+
+def _project_root() -> Path:
+    # In a PyInstaller bundle the assets live under ``sys._MEIPASS`` (mirrors
+    # ManaIconFactory._assets_root); from source they sit next to the repo root.
+    frozen_root = getattr(sys, "_MEIPASS", None)
+    if frozen_root:
+        return Path(frozen_root)
+    return Path(__file__).resolve().parents[1]
+
+
+def mana_assets_dir() -> Path:
+    """Return the directory where the mana assets live (``<repo>/assets/mana``)."""
+    return _project_root() / "assets" / "mana"
+
+
+def mana_assets_present(target_dir: Path | None = None) -> bool:
+    """Return ``True`` when the required mana asset files are present locally."""
+    target = target_dir or mana_assets_dir()
+    if not target.is_dir():
+        return False
+    return all((target / rel).exists() for rel in _REQUIRED_ASSET_PATHS)
 
 
 def _run_git_clone(url: str, target: Path, depth: int = 1) -> None:
@@ -23,6 +70,58 @@ def _run_git_clone(url: str, target: Path, depth: int = 1) -> None:
     subprocess.check_call(cmd)  # nosec B603
 
 
+def ensure_mana_assets(
+    repo: str = DEFAULT_MANA_REPO,
+    *,
+    force: bool = False,
+    quiet: bool = False,
+) -> bool:
+    """Ensure the mana assets exist locally, cloning ``repo`` if they are missing.
+
+    Returns ``True`` when the assets are present afterwards. Cloning failures
+    are surfaced to the caller (return value / raised errors are handled by
+    :func:`main`); the application treats a missing asset set as non-fatal and
+    falls back to placeholder glyphs.
+    """
+
+    def _log(message: str) -> None:
+        if not quiet:
+            print(message)
+
+    target_dir = mana_assets_dir()
+
+    if mana_assets_present(target_dir) and not force:
+        _log(f"Mana assets already present at {target_dir}")
+        return True
+
+    # Remove any stale/partial directory so ``git clone`` has a clean target.
+    if target_dir.exists():
+        reason = "force requested" if force else "existing assets incomplete"
+        _log(f"Removing directory {target_dir} ({reason})")
+        shutil.rmtree(target_dir)
+
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        _log(f"Cloning {repo} into {target_dir}…")
+        _run_git_clone(repo, target_dir)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(f"Failed to clone mana assets: {exc}", file=sys.stderr)
+        if target_dir.exists():
+            shutil.rmtree(target_dir, ignore_errors=True)
+        return False
+
+    if not mana_assets_present(target_dir):
+        print(
+            f"Clone of {repo} did not produce the expected mana asset files.",
+            file=sys.stderr,
+        )
+        return False
+
+    _log("Mana assets downloaded successfully.")
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -32,36 +131,13 @@ def main() -> int:
     )
     parser.add_argument(
         "--repo",
-        default="https://github.com/andrewgioia/mana.git",
+        default=DEFAULT_MANA_REPO,
         help="Git repository to clone (default: %(default)s)",
     )
     args = parser.parse_args()
 
-    project_root = Path(__file__).resolve().parents[1]
-    assets_dir = project_root / "assets"
-    target_dir = assets_dir / "mana"
-
-    if target_dir.exists():
-        if not args.force:
-            print(f"Mana assets already present at {target_dir}")
-            return 0
-        print(f"Removing existing directory {target_dir} (force requested)")
-        shutil.rmtree(target_dir)
-
-    assets_dir.mkdir(parents=True, exist_ok=True)
-
-    try:
-        print(f"Cloning {args.repo} into {target_dir}…")
-        _run_git_clone(args.repo, target_dir)
-    except subprocess.CalledProcessError as exc:
-        print(f"Failed to clone mana assets: {exc}", file=sys.stderr)
-        if target_dir.exists():
-            shutil.rmtree(target_dir)
-        return exc.returncode or 1
-
-    print("Mana assets downloaded successfully.")
-    print("You may keep the repository as-is or prune unused files if desired.")
-    return 0
+    ok = ensure_mana_assets(args.repo, force=args.force)
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":

--- a/tests/test_fetch_mana_assets.py
+++ b/tests/test_fetch_mana_assets.py
@@ -1,0 +1,107 @@
+"""Tests for mana asset detection and the self-healing fetch helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import scripts.fetch_mana_assets as fetch
+
+
+def _write_required_assets(target: Path) -> None:
+    """Create the minimal file tree that counts as present mana assets."""
+    (target / "fonts").mkdir(parents=True)
+    (target / "fonts" / "mana.ttf").write_bytes(b"ttf")
+    (target / "css").mkdir(parents=True)
+    (target / "css" / "mana.min.css").write_text("/* css */", encoding="utf-8")
+    (target / "svg").mkdir(parents=True)
+
+
+def test_mana_assets_present_true_when_required_files_exist(tmp_path):
+    _write_required_assets(tmp_path)
+    assert fetch.mana_assets_present(tmp_path) is True
+
+
+def test_mana_assets_present_false_when_missing(tmp_path):
+    assert fetch.mana_assets_present(tmp_path / "nope") is False
+
+
+def test_mana_assets_present_false_for_partial_dir(tmp_path):
+    # A bare/half-cloned directory must not count as usable assets.
+    (tmp_path / "fonts").mkdir()
+    assert fetch.mana_assets_present(tmp_path) is False
+
+
+def test_ensure_skips_clone_when_present(tmp_path, monkeypatch):
+    target = tmp_path / "assets" / "mana"
+    target.mkdir(parents=True)
+    _write_required_assets(target)
+    monkeypatch.setattr(fetch, "mana_assets_dir", lambda: target)
+
+    def _fail_clone(*_args, **_kwargs):
+        raise AssertionError("clone must not run when assets are present")
+
+    monkeypatch.setattr(fetch, "_run_git_clone", _fail_clone)
+
+    assert fetch.ensure_mana_assets(quiet=True) is True
+
+
+def test_ensure_clones_when_missing(tmp_path, monkeypatch):
+    target = tmp_path / "assets" / "mana"
+    monkeypatch.setattr(fetch, "mana_assets_dir", lambda: target)
+
+    calls: list[tuple[str, Path]] = []
+
+    def _fake_clone(url, dest, depth=1):
+        calls.append((url, dest))
+        _write_required_assets(dest)
+
+    monkeypatch.setattr(fetch, "_run_git_clone", _fake_clone)
+
+    assert fetch.ensure_mana_assets(quiet=True) is True
+    assert calls == [(fetch.DEFAULT_MANA_REPO, target)]
+    assert fetch.mana_assets_present(target) is True
+
+
+def test_ensure_replaces_partial_dir_before_clone(tmp_path, monkeypatch):
+    target = tmp_path / "assets" / "mana"
+    target.mkdir(parents=True)
+    (target / "stale.txt").write_text("leftover", encoding="utf-8")
+    monkeypatch.setattr(fetch, "mana_assets_dir", lambda: target)
+
+    def _fake_clone(url, dest, depth=1):
+        # git clone requires a clean target; the stale file must be gone.
+        assert not (dest / "stale.txt").exists()
+        _write_required_assets(dest)
+
+    monkeypatch.setattr(fetch, "_run_git_clone", _fake_clone)
+
+    assert fetch.ensure_mana_assets(quiet=True) is True
+
+
+def test_ensure_returns_false_and_cleans_up_on_clone_failure(tmp_path, monkeypatch):
+    import subprocess
+
+    target = tmp_path / "assets" / "mana"
+    monkeypatch.setattr(fetch, "mana_assets_dir", lambda: target)
+
+    def _boom(url, dest, depth=1):
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "partial").write_text("x", encoding="utf-8")
+        raise subprocess.CalledProcessError(1, ["git", "clone"])
+
+    monkeypatch.setattr(fetch, "_run_git_clone", _boom)
+
+    assert fetch.ensure_mana_assets(quiet=True) is False
+    assert not target.exists()
+
+
+def test_ensure_returns_false_when_clone_incomplete(tmp_path, monkeypatch):
+    target = tmp_path / "assets" / "mana"
+    monkeypatch.setattr(fetch, "mana_assets_dir", lambda: target)
+
+    def _incomplete_clone(url, dest, depth=1):
+        dest.mkdir(parents=True, exist_ok=True)  # clones nothing useful
+
+    monkeypatch.setattr(fetch, "_run_git_clone", _incomplete_clone)
+
+    assert fetch.ensure_mana_assets(quiet=True) is False


### PR DESCRIPTION
## What & why

Previously the mana symbol images had to be fetched manually by running `scripts/fetch_mana_assets.py`. This PR makes the app **detect its own local state and self-heal**, and **pins the asset source to a fork** so upstream changes can't affect us.

## Changes

**Auto-detect + auto-fetch**
- On startup (`main.py`), the app checks whether the mana assets are present and clones them if missing — no manual step. First run only; every later launch is a cheap local check.
- Failure is **non-fatal**: `ManaIconFactory` already falls back to placeholder glyphs, so no network / no git / frozen build just logs a warning and continues.

**Pinned fork**
- Default source is now `Pedrogush/mana` (our fork of `andrewgioia/mana`). Cloning from the fork pins the dependency — a maintainer edit upstream only reaches us when we deliberately sync the fork.
- `UPSTREAM_MANA_REPO` is kept as a constant for provenance.

**Refactor for reuse**
- `scripts/fetch_mana_assets.py` now exposes importable `ensure_mana_assets()` / `mana_assets_present()`. Detection checks the files the icon factory actually reads (`fonts/mana.ttf`, `css/mana.min.css`, `svg/`), so a partial/half-cloned directory is correctly treated as missing and replaced. Root resolution is frozen-aware, matching `ManaIconFactory._assets_root`.

**Packaging**
- `build_installer.sh` / `.ps1` / README messaging reflects the fork as the source. The build's existing auto-fetch keeps working (it uses the script default, now the fork).

## Testing

- New `tests/test_fetch_mana_assets.py` (8 tests): presence detection, partial-dir rejection, skip-when-present, clone-on-missing, stale-dir replacement, and cleanup on clone failure. All pass.
- Verified an actual clone from `Pedrogush/mana` produces the expected font/css/svg tree end-to-end.
- `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)