### PR TITLE
Point remote snapshot client at renamed MTGO_Tools_Data repo

### DIFF
--- a/repositories/remote_snapshot_client/__init__.py
+++ b/repositories/remote_snapshot_client/__init__.py
@@ -1,6 +1,6 @@
 """Remote Snapshot Client package — consumes published metagame artifacts.
 
-This package downloads and stages snapshots from the MTGO_Scrapes_Repository so
+This package downloads and stages snapshots from the MTGO_Tools_Data repo so
 the app can resolve archetype lists, deck metadata, and metagame stats without
 hitting MTGGoldfish directly in the common path.
 

--- a/utils/constants/__init__.py
+++ b/utils/constants/__init__.py
@@ -256,7 +256,7 @@ from utils.constants.ui_windows import (
 REMOTE_SNAPSHOTS_ENABLED = os.getenv("REMOTE_SNAPSHOTS_ENABLED", "false").lower() == "true"
 REMOTE_SNAPSHOT_BASE_URL = os.getenv(
     "REMOTE_SNAPSHOT_BASE_URL",
-    "https://raw.githubusercontent.com/Pedrogush/MTGO_Scrapes_Repository/data-publish",
+    "https://raw.githubusercontent.com/Pedrogush/MTGO_Tools_Data/data-publish",
 )
 REMOTE_SNAPSHOT_BUNDLE_PATH = "data/latest/client-bundle.tar.gz"
 


### PR DESCRIPTION
## Summary
The data repo was renamed `MTGO_Scrapes_Repository` → `MTGO_Tools_Data`. This updates the default `REMOTE_SNAPSHOT_BASE_URL` and the remote snapshot client docstring. GitHub's rename redirect keeps the old raw URL working meanwhile, so this is not urgent — but the redirect would break if a new repo ever claimed the old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)