### PR TITLE
fix(dates): repair impossible future deck dates from upstream transpositions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ build/
 # local install
 *.egg-info/
 issues/
+# uv-generated lockfile — the project pins deps via pyproject/venv, not uv
+uv.lock

--- a/repositories/metagame_repository/date_utils.py
+++ b/repositories/metagame_repository/date_utils.py
@@ -2,17 +2,28 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
+
+from utils.deck_dates import repair_future_date
 
 
-def _parse_deck_date(date_str: str) -> tuple[int, int, int]:
+def _parse_deck_date(date_str: str, today: date | None = None) -> tuple[int, int, int]:
     """Parse deck dates into a sortable ``(year, month, day)`` tuple.
 
     Accepts the canonical YYYY-MM-DD (MTGGoldfish) and MM/DD/YYYY (MTGO)
     forms. Also accepts YYYY-DD-MM as a fallback so misformatted upstream
     rows sort by their true calendar date rather than collapsing to
     ``(0, 0, 0)`` and appearing as the oldest entries (issue #475).
+
+    Impossible future dates (upstream day/month transpositions where both
+    fields are <= 12, so the string parses cleanly) are repaired via
+    :func:`repair_future_date` before parsing, so such rows sort by their
+    true calendar date instead of floating to the top of the list.
     """
+    if not date_str:
+        return (0, 0, 0)
+
+    date_str = repair_future_date(date_str, today)
     if not date_str:
         return (0, 0, 0)
 

--- a/repositories/scrapers/mtggoldfish.py
+++ b/repositories/scrapers/mtggoldfish.py
@@ -28,6 +28,7 @@ from utils.constants import (
     MTGGOLDFISH_STATS_READ_TIMEOUT_SECONDS,
     ONE_DAY_SECONDS,
 )
+from utils.deck_dates import repair_future_date
 from utils.json_io import fast_load
 from utils.perf import timed
 
@@ -181,7 +182,10 @@ def get_archetype_decks(archetype: str):
         tds: list[bs4.Tag] = tr.find_all("td")
         decks.append(
             {
-                "date": tds[GOLDFISH_DECK_TABLE_COL_DATE].text.strip(),
+                # MTGGoldfish serves paper-event dates verbatim as entered by
+                # the store, occasionally day/month-transposed — repair
+                # impossible future dates before they enter the cache.
+                "date": repair_future_date(tds[GOLDFISH_DECK_TABLE_COL_DATE].text.strip()),
                 "number": tds[GOLDFISH_DECK_TABLE_COL_NUMBER]
                 .select_one("a")
                 .attrs.get("href")

--- a/services/bundle_snapshot_client/archetype_cache.py
+++ b/services/bundle_snapshot_client/archetype_cache.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from utils.atomic_io import atomic_write_json, locked_path
+from utils.deck_dates import repair_future_date
 from utils.perf import timed
 
 if TYPE_CHECKING:
@@ -70,6 +71,11 @@ class ArchetypeCacheMixin(_Base):
                 decks = entry.get("decks")
                 if not href or not isinstance(decks, list):
                     continue
+                # The bundle carries upstream dates verbatim; repair impossible
+                # future dates (day/month transpositions) before caching.
+                for deck in decks:
+                    if isinstance(deck, dict) and deck.get("date"):
+                        deck["date"] = repair_future_date(str(deck["date"]))
                 existing[href] = {"timestamp": now, "items": decks}
 
             try:
@@ -134,7 +140,7 @@ class ArchetypeCacheMixin(_Base):
                         deck_texts.append((deck_id, deck_text, "mtgo"))
                     date_raw = deck.get("date", "")
                     metadata: dict[str, Any] = {
-                        "date": date_raw[:10] if date_raw else "",
+                        "date": repair_future_date(date_raw[:10]) if date_raw else "",
                         "number": deck_id,
                         "player": deck.get("player", ""),
                         "event": deck.get("event", ""),

--- a/tests/test_deck_dates.py
+++ b/tests/test_deck_dates.py
@@ -1,0 +1,111 @@
+"""Tests for impossible-future deck-date repair (utils.deck_dates).
+
+Regression context: MTGGoldfish served a paper Store Qualifier played on
+2026-04-11 with the day/month-transposed date ``2026-11-04``. Both fields
+are <= 12, so the string parses cleanly as YYYY-MM-DD and the existing
+YYYY-DD-MM fallback in ``_parse_deck_date`` never fires — the deck showed
+up "from the future" at the top of the Modern deck list.
+"""
+
+from datetime import date, timedelta
+
+from repositories.metagame_repository.date_utils import _parse_deck_date
+from utils.deck_dates import repair_future_date
+
+TODAY = date(2026, 7, 24)
+
+
+# ---------------------------------------------------------------------------
+# repair_future_date
+# ---------------------------------------------------------------------------
+def test_ambiguous_day_month_swap_is_repaired():
+    # The real-world regression: April 11 published as 2026-11-04.
+    assert repair_future_date("2026-11-04", today=TODAY) == "2026-04-11"
+
+
+def test_past_dates_are_untouched():
+    assert repair_future_date("2026-04-11", today=TODAY) == "2026-04-11"
+    assert repair_future_date("2019-12-31", today=TODAY) == "2019-12-31"
+
+
+def test_today_and_tomorrow_are_untouched():
+    assert repair_future_date("2026-07-24", today=TODAY) == "2026-07-24"
+    # A source clock running ahead can legitimately stamp tomorrow.
+    assert repair_future_date("2026-07-25", today=TODAY) == "2026-07-25"
+
+
+def test_unrepairable_future_date_is_blanked():
+    # Swap would need month 25 — invalid, so the date is unknown.
+    assert repair_future_date("2026-12-25", today=TODAY) == ""
+    # Swap is valid but still in the future.
+    assert repair_future_date("2027-01-02", today=TODAY) == ""
+
+
+def test_non_iso_strings_pass_through():
+    assert repair_future_date("", today=TODAY) == ""
+    assert repair_future_date("04/15/2026", today=TODAY) == "04/15/2026"
+    assert repair_future_date("2026-25-03", today=TODAY) == "2026-25-03"
+    assert repair_future_date("not a date", today=TODAY) == "not a date"
+
+
+# ---------------------------------------------------------------------------
+# _parse_deck_date sort keys
+# ---------------------------------------------------------------------------
+def test_sort_key_uses_true_date_for_transposed_future_date():
+    assert _parse_deck_date("2026-11-04", today=TODAY) == (2026, 4, 11)
+
+
+def test_sort_key_sends_unrepairable_future_date_to_the_bottom():
+    assert _parse_deck_date("2027-01-02", today=TODAY) == (0, 0, 0)
+
+
+def test_sort_key_normal_forms_still_parse():
+    assert _parse_deck_date("2026-07-20", today=TODAY) == (2026, 7, 20)
+    assert _parse_deck_date("07/20/2026", today=TODAY) == (2026, 7, 20)
+    # Issue #475 fallback: unambiguous YYYY-DD-MM still parses.
+    assert _parse_deck_date("2026-25-03", today=TODAY) == (2026, 3, 25)
+
+
+def test_future_deck_no_longer_sorts_to_the_top():
+    decks = [
+        {"date": "2026-11-04"},  # actually 2026-04-11
+        {"date": "2026-07-20"},
+        {"date": "2026-05-01"},
+    ]
+    decks.sort(key=lambda d: _parse_deck_date(d.get("date", ""), today=TODAY), reverse=True)
+    assert [d["date"] for d in decks] == ["2026-07-20", "2026-05-01", "2026-11-04"]
+
+
+# ---------------------------------------------------------------------------
+# Regression: the UI display path never shows a date from the future
+# ---------------------------------------------------------------------------
+def test_ui_never_displays_a_future_date():
+    from widgets.panels.deck_research_panel.results_filter import _normalize_date
+
+    horizon = TODAY + timedelta(days=1)
+    samples = [
+        "2026-11-04",  # the regression itself
+        "2026-12-25",  # unrepairable transposition
+        "2027-01-02",
+        "9999-12-31",
+        "2026-07-24",
+        "2026-07-25",
+        "2019-12-31",
+        "Modern Challenge 2026-11-04",  # date embedded in an event string
+        "",
+    ]
+    for value in samples:
+        shown = _normalize_date(value, today=TODAY)
+        try:
+            shown_date = date.fromisoformat(shown)
+        except ValueError:
+            continue  # non-date display values are out of scope here
+        assert shown_date <= horizon, f"UI would display future date {shown!r} for {value!r}"
+
+
+def test_ui_never_displays_a_future_date_with_real_clock():
+    # The UI calls _normalize_date without a `today` argument; make sure the
+    # default-clock path also repairs. 9999-12-31 is future on any clock.
+    from widgets.panels.deck_research_panel.results_filter import _normalize_date
+
+    assert _normalize_date("9999-12-31") == ""

--- a/utils/deck_dates.py
+++ b/utils/deck_dates.py
@@ -1,0 +1,47 @@
+"""Repair for impossible "future" deck dates coming from upstream sources.
+
+Decklists record results of events that already happened, so a deck date
+beyond tomorrow is always an upstream data-entry error. The dominant failure
+is a day/month transposition on paper events entered in DD/MM locales (e.g.
+an April 11 store qualifier published as ``2026-11-04``). When both fields
+are <= 12 the swap is invisible to format-based parsing and can only be
+detected by the future-date impossibility itself, which is what this module
+keys on.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+# Deck dates are calendar days with no timezone; a source running ahead of the
+# local clock can legitimately stamp "tomorrow", so only dates beyond that are
+# treated as impossible.
+_FUTURE_TOLERANCE = timedelta(days=1)
+
+
+def repair_future_date(iso_date: str, today: date | None = None) -> str:
+    """Return *iso_date* with an impossible future date repaired or blanked.
+
+    - Not a well-formed ``YYYY-MM-DD`` string, or a date on or before
+      tomorrow: returned unchanged.
+    - Beyond tomorrow, and swapping day/month yields a valid non-future
+      date: the swapped ISO date is returned.
+    - Beyond tomorrow and unrepairable: ``""`` is returned — an unknown
+      date is less wrong than a future one.
+    """
+    if not iso_date:
+        return iso_date
+    try:
+        parsed = date.fromisoformat(iso_date)
+    except ValueError:
+        return iso_date
+    horizon = (today or date.today()) + _FUTURE_TOLERANCE
+    if parsed <= horizon:
+        return iso_date
+    try:
+        swapped = date(parsed.year, parsed.day, parsed.month)
+    except ValueError:
+        return ""
+    if swapped <= horizon:
+        return swapped.isoformat()
+    return ""

--- a/widgets/panels/deck_research_panel/results_filter.py
+++ b/widgets/panels/deck_research_panel/results_filter.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import operator as _op
 import re
 from collections.abc import Callable
+from datetime import date
 from typing import Any
+
+from utils.deck_dates import repair_future_date
 
 PLACEMENT_OP_NONE = "-"
 PLACEMENT_OPERATORS: tuple[str, ...] = (PLACEMENT_OP_NONE, ">", "≥", "≤", "<", "=")
@@ -47,12 +50,17 @@ def _classify_event_type(event_str: str) -> str | None:
     return None
 
 
-def _normalize_date(value: str) -> str:
-    """Extract the first YYYY-MM-DD substring from *value*, or return *value* as-is."""
+def _normalize_date(value: str, today: date | None = None) -> str:
+    """Extract the first YYYY-MM-DD substring from *value*, or return *value* as-is.
+
+    Extracted dates pass through :func:`repair_future_date`, so the UI never
+    displays an impossible future date: upstream day/month transpositions are
+    swapped back, and unrepairable future dates render blank.
+    """
     if not value:
         return ""
     match = re.search(r"\d{4}-\d{2}-\d{2}", value)
-    return match.group(0) if match else value
+    return repair_future_date(match.group(0), today) if match else value
 
 
 def parse_placement(result_str: str) -> int | None:


### PR DESCRIPTION
## Problem

Selecting Modern showed a segment of decklists dated **2026-11-04** — in the future — at the top of the list.

Diagnosis (verified against the live site): MTGGoldfish itself serves `2026-11-04` for the paper event "Store Qualifier CAMS 13 | The Raccoon House" (6 Modern decks). The true date is almost certainly **2026-04-11** (a Saturday, typical for a store qualifier; Nov 4 is a Wednesday) — a day/month transposition entered in a DD/MM locale. Neither the bundle nor the client mis-parses anything: the data is wrong at the source.

The existing issue-#475 `YYYY-DD-MM` fallback in `_parse_deck_date` only catches *unambiguous* swaps (day > 12). `11-04` parses cleanly as Nov 4, sails through as a valid future date, and sorts to the top.

## Fix

Deck dates record results of past events, so **any date beyond tomorrow is impossible** (tomorrow allowed for timezone slack). That impossibility is the only signal that catches ambiguous transpositions.

New `utils/deck_dates.repair_future_date()`: for a date beyond tomorrow, swap day/month when that yields a plausible past date; otherwise blank it (unknown beats wrong). Applied at every layer:

- **Sorting** — `_parse_deck_date` repairs before parsing, so transposed rows sort at their true position; unrepairable ones sink to the bottom (matching #475 semantics)
- **Display** — `_normalize_date` (the choke point for all UI deck rows) repairs after extraction, so the UI can never render a future date. This also fixes already-cached bad rows immediately, no cache wipe needed
- **Ingestion** — the MTGGoldfish scraper and both bundle hydration paths sanitize before caching, so stored data heals on the next refresh

Residual class: a transposition landing in the *past* (e.g. March 4 entered as April 3) is undetectable from the string alone — only upstream correction or cross-referencing tournament pages could catch those. The same repair is worth adopting on the bundle/server side so corrected data ships to all clients.

## Tests

`tests/test_deck_dates.py`: the exact regression case, sort order, #475 fallback intact, and the guarantee that the UI display path never emits a date beyond tomorrow (pinned clock and real clock). Full suite: **1780 passed**, ruff clean. Verified all 6 bad rows in a real cache now display and sort as `2026-04-11`.

## Housekeeping

Gitignores `uv.lock` — the project pins deps via pyproject + a plain venv; the lockfile was an incidental local artifact never tracked by the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)