### PR TITLE
feat(images): predictive batch prefetch, offline images mode, split-card hover fix

### DIFF
--- a/controllers/app_controller/cache_warmer.py
+++ b/controllers/app_controller/cache_warmer.py
@@ -274,9 +274,7 @@ class CacheWarmer:
                 )
                 if self._wait(self._fast_throttle):
                     return
-        logger.info(
-            f"Cache warm-up: image pre-fetch complete ({len(queued_names)} cards queued)"
-        )
+        logger.info(f"Cache warm-up: image pre-fetch complete ({len(queued_names)} cards queued)")
 
     def _warm_deck_images(
         self,

--- a/controllers/app_controller/cache_warmer.py
+++ b/controllers/app_controller/cache_warmer.py
@@ -4,9 +4,22 @@ Two independent daemon threads, started a few seconds after the app finishes its
 initial loads, progressively fill the on-disk caches so that the data a user is
 most likely to open next is already local by the time they click:
 
-* :meth:`CacheWarmer._warm_images` — for every archetype in every format, pick
-  the archetype's most recent decklist and queue a card-image download for each
-  card in it. The currently selected format is warmed first.
+* :meth:`CacheWarmer._warm_images` — queue card-image downloads in the order a
+  user is likely to need them (issue #951), each phase enqueuing at a matching
+  download-queue priority tier so warm-up traffic can never delay the images
+  of the deck open in the UI:
+
+  1. the decks the research panel would show for each format, walking formats
+     alphabetically (``PRIORITY_RESEARCH_FORMATS``);
+  2. every deck of the currently selected format (``PRIORITY_FORMAT_ALL``);
+  3. every deck of every remaining format, alphabetically
+     (``PRIORITY_BACKGROUND``) — the "every competitively played card
+     eventually" sweep.
+
+  Phases 2 and 3 read deck texts through ``get_cached_deck_text`` (cache-only,
+  no network) when it is provided, so the exhaustive sweep only covers decks
+  whose text is already local (the bundle snapshot and the decklist warmer
+  hydrate more over time) instead of committing to thousands of scrapes.
 
 * :meth:`CacheWarmer._warm_decklists` — progressively hydrate the deck-text
   cache. First the headline list of each of the top few archetypes for *every*
@@ -39,6 +52,11 @@ from typing import Any
 
 from loguru import logger
 
+from services.image_service.priorities import (
+    PRIORITY_BACKGROUND,
+    PRIORITY_FORMAT_ALL,
+    PRIORITY_RESEARCH_FORMATS,
+)
 from services.image_service.schemas import CardImageRequest
 from utils.constants.timing import (
     CACHE_WARMUP_DEEP_PASS_MAX_DECKS,
@@ -48,6 +66,7 @@ from utils.constants.timing import (
     CACHE_WARMUP_SLOW_THROTTLE_SECONDS,
     CACHE_WARMUP_START_DELAY_SECONDS,
     CACHE_WARMUP_TOP_DECKS_PER_FORMAT,
+    RESEARCH_PREFETCH_DECK_COUNT,
 )
 
 # Basic lands are trivially available, appear in nearly every deck, and would
@@ -71,11 +90,13 @@ class CacheWarmer:
         get_decks_for_archetype: Callable[[dict[str, Any]], list[dict[str, Any]]],
         download_deck_text: Callable[[dict[str, Any]], str],
         extract_card_names: Callable[[str], list[str]],
-        enqueue_image: Callable[[CardImageRequest], None],
+        enqueue_image: Callable[[CardImageRequest, int], None],
+        get_cached_deck_text: Callable[[dict[str, Any]], str] | None = None,
         start_delay: float = CACHE_WARMUP_START_DELAY_SECONDS,
         fast_throttle: float = CACHE_WARMUP_FAST_THROTTLE_SECONDS,
         slow_throttle: float = CACHE_WARMUP_SLOW_THROTTLE_SECONDS,
         top_decks_per_format: int = CACHE_WARMUP_TOP_DECKS_PER_FORMAT,
+        research_deck_count: int = RESEARCH_PREFETCH_DECK_COUNT,
         progress_interval: int = CACHE_WARMUP_PROGRESS_INTERVAL,
     ) -> None:
         self._get_current_format = get_current_format
@@ -83,12 +104,14 @@ class CacheWarmer:
         self._get_archetypes = get_archetypes
         self._get_decks_for_archetype = get_decks_for_archetype
         self._download_deck_text = download_deck_text
+        self._get_cached_deck_text = get_cached_deck_text
         self._extract_card_names = extract_card_names
         self._enqueue_image = enqueue_image
         self._start_delay = start_delay
         self._fast_throttle = fast_throttle
         self._slow_throttle = slow_throttle
         self._top_decks_per_format = top_decks_per_format
+        self._research_deck_count = research_deck_count
         self._progress_interval = max(1, progress_interval)
 
         # Decklist-warmer running tallies (only touched by its single thread).
@@ -199,33 +222,105 @@ class CacheWarmer:
     def _warm_images(self) -> None:
         if self._wait(self._start_delay):
             return
-        logger.info("Cache warm-up: pre-fetching card images (selected format first)")
-        count = 0
-        for fmt in self._ordered_formats():
+        formats = self._ordered_formats()
+        if not formats:
+            return
+        selected = formats[0]
+        alphabetical = sorted(formats, key=str.lower)
+        # Card names already enqueued this session (an earlier = more urgent
+        # phase wins) and deck numbers already scanned, so no deck's text is
+        # fetched twice and no card is enqueued twice.
+        queued_names: set[str] = set()
+        scanned: set[str] = set()
+
+        # Phase 1: the decks the research panel would show for each format,
+        # walking formats alphabetically. These fetch through the normal
+        # cache-first deck-text path (few decks, worth the network on a miss).
+        logger.info("Cache warm-up: warming research-panel deck images (formats A→Z)")
+        for fmt in alphabetical:
             if self._stopped():
                 return
-            logger.info(f"Cache warm-up: warming images for {fmt}")
-            for archetype in self._safe_archetypes(fmt):
-                if self._stopped():
-                    return
-                decks = self._safe_decks(archetype)
-                if not decks:
-                    continue
-                # Pick the archetype's most recent decklist (decks are sorted
-                # date-descending) and warm an image for each of its cards.
-                deck_text = self._safe_deck_text(decks[0])
-                if not deck_text:
-                    continue
-                for name in self._card_names(deck_text):
-                    if self._stopped():
-                        return
-                    self._queue_image(name)
-                    count += 1
-                # The image warmer is part of the fast initial pass (one deck
-                # per archetype), so it stays at the fast throttle throughout.
+            for deck in self._iter_format_decks(
+                fmt, per_archetype=1, limit=self._research_deck_count
+            ):
+                self._warm_deck_images(
+                    deck, PRIORITY_RESEARCH_FORMATS, queued_names, scanned, cached_only=False
+                )
                 if self._wait(self._fast_throttle):
                     return
-        logger.info(f"Cache warm-up: image pre-fetch complete ({count} cards queued)")
+
+        # Phase 2: every deck of the selected format; Phase 3: every deck of
+        # the remaining formats, alphabetically. Cache-only deck texts — the
+        # sweep covers whatever decklists are already local and grows as the
+        # decklist warmer / bundle hydrate more, instead of committing to
+        # thousands of scrapes.
+        logger.info(f"Cache warm-up: warming all local {selected} deck images")
+        for deck in self._iter_format_decks(selected, per_archetype=None, limit=None):
+            self._warm_deck_images(
+                deck, PRIORITY_FORMAT_ALL, queued_names, scanned, cached_only=True
+            )
+            if self._wait(self._fast_throttle):
+                return
+
+        for fmt in alphabetical:
+            if fmt.lower() == selected.lower():
+                continue
+            if self._stopped():
+                return
+            logger.info(f"Cache warm-up: warming all local {fmt} deck images")
+            for deck in self._iter_format_decks(fmt, per_archetype=None, limit=None):
+                self._warm_deck_images(
+                    deck, PRIORITY_BACKGROUND, queued_names, scanned, cached_only=True
+                )
+                if self._wait(self._fast_throttle):
+                    return
+        logger.info(
+            f"Cache warm-up: image pre-fetch complete ({len(queued_names)} cards queued)"
+        )
+
+    def _warm_deck_images(
+        self,
+        deck: dict[str, Any],
+        priority: int,
+        queued_names: set[str],
+        scanned: set[str],
+        *,
+        cached_only: bool,
+    ) -> None:
+        """Queue an image download at ``priority`` for each new card of ``deck``."""
+        number = str(deck.get("number") or "")
+        if number and number in scanned:
+            return
+        if cached_only:
+            deck_text = self._safe_local_deck_text(deck)
+        else:
+            deck_text = self._safe_deck_text(deck)
+        if number:
+            scanned.add(number)
+        if not deck_text:
+            return
+        for name in self._card_names(deck_text):
+            if self._stopped():
+                return
+            key = name.lower()
+            if key in queued_names:
+                continue
+            queued_names.add(key)
+            self._queue_image(name, priority)
+
+    def _safe_local_deck_text(self, deck: dict[str, Any]) -> str:
+        """Deck text from the local cache only — never the network.
+
+        Falls back to the normal (cache-first, network-on-miss) path when no
+        cache-only getter was injected.
+        """
+        if self._get_cached_deck_text is None:
+            return self._safe_deck_text(deck)
+        try:
+            return self._get_cached_deck_text(deck) or ""
+        except Exception as exc:
+            logger.debug(f"Warm-up: cached deck text lookup failed for {deck.get('number')}: {exc}")
+            return ""
 
     def _card_names(self, deck_text: str) -> list[str]:
         names: list[str] = []
@@ -238,7 +333,7 @@ class CacheWarmer:
             names.append(name)
         return names
 
-    def _queue_image(self, card_name: str) -> None:
+    def _queue_image(self, card_name: str, priority: int) -> None:
         try:
             self._enqueue_image(
                 CardImageRequest(
@@ -247,7 +342,8 @@ class CacheWarmer:
                     set_code=None,
                     collector_number=None,
                     size="normal",
-                )
+                ),
+                priority,
             )
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug(f"Warm-up: failed to queue image for {card_name}: {exc}")

--- a/controllers/app_controller/lifecycle.py
+++ b/controllers/app_controller/lifecycle.py
@@ -10,7 +10,6 @@ from loguru import logger
 from utils.constants import MTGO_BRIDGE_SHUTDOWN_TIMEOUT_SECONDS
 
 if TYPE_CHECKING:
-
     from controllers.app_controller.protocol import AppControllerProto
     from widgets.frames.app_frame import AppFrame
 
@@ -81,6 +80,13 @@ class LifecycleMixin(_Base):
             return get_bundle_snapshot_client().apply(on_archetypes_ready=_surface_archetypes)
 
         def _on_bundle_done(result: tuple[bool, dict[str, list[dict[str, Any]]] | None]) -> None:
+            # The optimistic startup deck load can race ahead of the bundle
+            # apply on a cold cache and find nothing ("No decks for Any").
+            # Now that the deck caches are hydrated, let the frame refresh the
+            # deck list if it is currently empty — regardless of whether the
+            # archetype list itself changed.
+            if result and result[0] and callbacks:
+                callbacks.on_bundle_decks_ready()
             if surfaced_from_bundle:
                 # The bundle's archetypes for the current format were already
                 # handled during phase 1 by _surface_archetypes (surfaced if

--- a/controllers/app_controller/lifecycle.py
+++ b/controllers/app_controller/lifecycle.py
@@ -166,6 +166,15 @@ class LifecycleMixin(_Base):
             cards = analysis.get("mainboard_cards", []) + analysis.get("sideboard_cards", [])
             return [name for name, _count in cards]
 
+        def _get_cached_deck_text(deck: dict) -> str:
+            # Cache-only lookup for the exhaustive image sweep — never scrapes.
+            from repositories.deck_text_cache import get_deck_cache
+
+            number = str(deck.get("number") or "")
+            if not number:
+                return ""
+            return get_deck_cache().get(number) or ""
+
         self._cache_warmer = CacheWarmer(
             get_current_format=lambda: self.current_format,
             formats=list(FORMAT_OPTIONS),
@@ -173,9 +182,10 @@ class LifecycleMixin(_Base):
             get_decks_for_archetype=self.metagame_repo.get_decks_for_archetype,
             download_deck_text=self.metagame_repo.download_deck_content,
             extract_card_names=_extract_card_names,
-            enqueue_image=lambda request: self.image_service.queue_card_image_download(
-                request, prioritize=False
+            enqueue_image=lambda request, priority: self.image_service.queue_card_image_download(
+                request, prioritize=False, priority=priority
             ),
+            get_cached_deck_text=_get_cached_deck_text,
         )
         self._cache_warmer.start()
 

--- a/controllers/app_controller/ui_callbacks.py
+++ b/controllers/app_controller/ui_callbacks.py
@@ -18,6 +18,7 @@ class UICallbacks:
     on_status: Callable[[str], None]
     on_archetypes_success: Callable[..., None]
     on_archetypes_error: Callable[..., None]
+    on_bundle_decks_ready: Callable[[], None]
     on_collection_loaded: Callable[[dict[str, Any]], None]
     on_collection_not_found: Callable[[], None]
     on_collection_refresh_success: Callable[..., None]
@@ -56,6 +57,7 @@ class AppControllerUIHelpers:
                 frame._on_archetypes_loaded, archetypes
             ),
             on_archetypes_error=lambda error: wx.CallAfter(frame._on_archetypes_error, error),
+            on_bundle_decks_ready=lambda: wx.CallAfter(frame.on_bundle_decks_ready),
             on_collection_loaded=_on_collection_loaded,
             on_collection_not_found=lambda: wx.CallAfter(
                 frame.collection_status_label.SetLabel,

--- a/repositories/metagame_repository/deck_operations.py
+++ b/repositories/metagame_repository/deck_operations.py
@@ -35,7 +35,13 @@ class DeckOperationsMixin(_Base):
 
         if not force_refresh:
             cached = self._load_cached_decks(archetype_href)
-            if cached is not None:
+            # An empty cached list is treated as a miss, not a hit: the remote
+            # bundle publishes empty MTGGoldfish deck lists for archetypes
+            # whose recent results are MTGO-only (goldfish scraping upstream is
+            # now partitioned to paper events), and returning that [] here
+            # would permanently block the live-scrape fallback below from ever
+            # finding the archetype's decks.
+            if cached:
                 logger.debug(f"Using cached decks for {archetype_name}")
                 return self._sort_decks_by_date(self._filter_decks_by_source(cached, source_filter))
 
@@ -53,7 +59,9 @@ class DeckOperationsMixin(_Base):
         except Exception as exc:
             logger.error(f"Failed to fetch decks for {archetype_name}: {exc}")
             cached = self._load_cached_decks(archetype_href, max_age=None)
-            if cached:
+            if cached is not None:
+                # Even a stale empty list beats surfacing an error dialog: it
+                # renders as "no decks" while the next click retries the scrape.
                 logger.warning(f"Returning stale cached decks for {archetype_name}")
                 return self._sort_decks_by_date(self._filter_decks_by_source(cached, source_filter))
             raise

--- a/repositories/scrapers/mtggoldfish.py
+++ b/repositories/scrapers/mtggoldfish.py
@@ -147,9 +147,12 @@ def _save_cached_archetype_decks(archetype: str, items: list[dict]):
 
 
 def get_archetype_decks(archetype: str):
-    # Check cache first
+    # Check cache first. An empty cached list counts as a miss: the remote
+    # bundle hydrates empty MTGGoldfish deck lists for archetypes whose recent
+    # results are MTGO-only, and honouring that [] here would keep the scrape
+    # from ever running for them.
     cached = _load_cached_archetype_decks(archetype)
-    if cached is not None:
+    if cached:
         logger.debug(f"Using cached decks for archetype {archetype}")
         return cached
 

--- a/scripts/clear_image_cache.py
+++ b/scripts/clear_image_cache.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Clear the card image cache for a reproducible cold-start state.
+
+Removes the downloaded image files and the SQLite metadata database under
+``cache/card_images`` so prefetch/warmup behavior can be measured from the
+same empty state on every run. The Scryfall bulk data and the printings
+index are *kept* by default — they are inputs to image resolution, not
+images, and re-downloading them would dominate any perf iteration. Pass
+``--all`` to wipe those too.
+
+Usage (from the repo root):
+    ./.venv/Scripts/python.exe scripts/clear_image_cache.py [--all] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from services.image_service.schemas import (  # noqa: E402
+    BULK_DATA_CACHE,
+    IMAGE_CACHE_DIR,
+    IMAGE_DB_PATH,
+    IMAGE_SIZES,
+    PRINTING_INDEX_CACHE,
+)
+
+
+def clear_image_cache(*, include_bulk_data: bool = False, dry_run: bool = False) -> None:
+    if not IMAGE_CACHE_DIR.exists():
+        print(f"No image cache directory at {IMAGE_CACHE_DIR}")
+        return
+
+    targets: list[Path] = [IMAGE_DB_PATH]
+    targets += [IMAGE_CACHE_DIR / size for size in IMAGE_SIZES.values()]
+    if include_bulk_data:
+        targets += [BULK_DATA_CACHE, PRINTING_INDEX_CACHE]
+
+    removed_files = 0
+    for target in targets:
+        if not target.exists():
+            continue
+        if target.is_dir():
+            count = sum(1 for entry in target.rglob("*") if entry.is_file())
+            print(f"{'Would remove' if dry_run else 'Removing'} {target} ({count} files)")
+            if not dry_run:
+                shutil.rmtree(target)
+            removed_files += count
+        else:
+            print(f"{'Would remove' if dry_run else 'Removing'} {target}")
+            if not dry_run:
+                target.unlink()
+            removed_files += 1
+
+    kept = "" if include_bulk_data else " (bulk data + printings index kept; --all wipes them)"
+    print(f"{'Would clear' if dry_run else 'Cleared'} {removed_files} files{kept}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="also remove the Scryfall bulk data and printings index",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="print what would be removed without removing"
+    )
+    args = parser.parse_args()
+    clear_image_cache(include_bulk_data=args.all, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/perf_image_prefetch.py
+++ b/scripts/perf_image_prefetch.py
@@ -91,6 +91,13 @@ def main() -> int:
         "--keep-cache", action="store_true", help="do not clear the image cache first"
     )
     parser.add_argument("--timeout", type=float, default=180.0, help="give up after this long")
+    parser.add_argument(
+        "--startup-gap",
+        type=float,
+        default=0.0,
+        help="seconds between service creation and the deck load, like a real "
+        "session (lets the eager bulk-index warm finish off the critical path)",
+    )
     args = parser.parse_args()
 
     if not args.keep_cache:
@@ -108,6 +115,8 @@ def main() -> int:
 
     service = ImageService()
     cache = get_cache()
+    if args.startup_gap:
+        time.sleep(args.startup_gap)
 
     batch_done = threading.Event()
     batch_result: dict[str, list[str]] = {}

--- a/scripts/perf_image_prefetch.py
+++ b/scripts/perf_image_prefetch.py
@@ -138,8 +138,10 @@ def main() -> int:
     enqueued = batch_result["enqueued"]
     skipped = batch_result["skipped"]
     batch_ms = (time.perf_counter() - t0) * 1000.0
-    print(f"Batch submitted in {batch_ms:.0f} ms: {len(enqueued)} to download, "
-          f"{len(skipped)} already local/queued")
+    print(
+        f"Batch submitted in {batch_ms:.0f} ms: {len(enqueued)} to download, "
+        f"{len(skipped)} already local/queued"
+    )
 
     remaining = set(enqueued)
     completion_ms: list[float] = []
@@ -166,7 +168,10 @@ def main() -> int:
     print(f"RESULT | downloaded {downloaded}/{len(enqueued)} images")
     if completion_ms:
         completion_ms.sort()
-        p = lambda q: completion_ms[min(len(completion_ms) - 1, int(q * len(completion_ms)))]  # noqa: E731
+
+        def p(q: float) -> float:
+            return completion_ms[min(len(completion_ms) - 1, int(q * len(completion_ms)))]
+
         print(f"RESULT | first image  {completion_ms[0]:>8.0f} ms")
         print(f"RESULT | 50% local    {p(0.50):>8.0f} ms")
         print(f"RESULT | 90% local    {p(0.90):>8.0f} ms")

--- a/scripts/perf_image_prefetch.py
+++ b/scripts/perf_image_prefetch.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Headless perf harness for the deck image prefetch path (issue #951).
+
+Reproduces what the UI does when a decklist loads — submits every card of a
+deck to ``ImageService.prefetch_card_images`` at the selected-deck priority —
+and measures how long it takes until every image is on disk. No wx required,
+so iterations can run from a terminal against a cache cleared by
+``scripts/clear_image_cache.py``.
+
+Usage (from the repo root):
+    ./.venv/Scripts/python.exe scripts/perf_image_prefetch.py [--deck FILE]
+        [--keep-cache] [--timeout SECONDS]
+
+By default the image cache is cleared first (bulk data kept) so every run
+starts cold and numbers are comparable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# A real 75-card list (Legacy Dimir Reanimator flavored), 33 unique names —
+# representative of what a deck load submits.
+SAMPLE_DECK = """
+4 Entomb
+4 Reanimate
+4 Brainstorm
+4 Ponder
+4 Force of Will
+4 Daze
+3 Grief
+2 Troll of Khazad-dum
+1 Archon of Cruelty
+1 Griselbrand
+1 Atraxa, Grand Unifier
+2 Animate Dead
+2 Thoughtseize
+1 Personal Tutor
+2 Barrowgoyf
+1 Murktide Regent
+2 Underground Sea
+4 Polluted Delta
+4 Flooded Strand
+2 Misty Rainforest
+3 Island
+1 Swamp
+1 Marsh Flats
+2 Wasteland
+1 Bloodstained Mire
+Sideboard
+2 Surgical Extraction
+2 Flusterstorm
+1 Hydroblast
+2 Barrowgoyf
+1 Sheoldred, the Apocalypse
+2 Force of Negation
+1 Fatal Push
+2 Consign to Memory
+1 Faerie Macabre
+1 Serra's Emissary
+""".strip()
+
+
+def parse_deck(text: str) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.lower().startswith("sideboard"):
+            continue
+        parts = line.split(" ", 1)
+        if len(parts) != 2 or not parts[0].isdigit():
+            continue
+        name = parts[1].strip()
+        if name.lower() not in seen:
+            seen.add(name.lower())
+            names.append(name)
+    return names
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--deck", type=Path, help="decklist file (default: embedded 75-card list)")
+    parser.add_argument(
+        "--keep-cache", action="store_true", help="do not clear the image cache first"
+    )
+    parser.add_argument("--timeout", type=float, default=180.0, help="give up after this long")
+    args = parser.parse_args()
+
+    if not args.keep_cache:
+        from scripts.clear_image_cache import clear_image_cache
+
+        clear_image_cache()
+
+    deck_text = args.deck.read_text(encoding="utf-8") if args.deck else SAMPLE_DECK
+    names = parse_deck(deck_text)
+    print(f"Deck: {len(names)} unique card names")
+
+    from services.image_service import ImageService
+    from services.image_service.downloader import get_cache
+    from services.image_service.priorities import PRIORITY_SELECTED_DECK
+
+    service = ImageService()
+    cache = get_cache()
+
+    batch_done = threading.Event()
+    batch_result: dict[str, list[str]] = {}
+
+    def on_batch(source: str, enqueued: list[str], skipped: list[str]) -> None:
+        batch_result["enqueued"] = enqueued
+        batch_result["skipped"] = skipped
+        batch_done.set()
+
+    # t0 = the moment the deck "loads": what the UI's PERF line measures from.
+    t0 = time.perf_counter()
+    service.prefetch_card_images("deck", names, priority=PRIORITY_SELECTED_DECK, on_batch=on_batch)
+
+    if not batch_done.wait(timeout=30.0):
+        print("FAIL: prefetch batch never ran (30s)")
+        service.shutdown()
+        return 1
+
+    enqueued = batch_result["enqueued"]
+    skipped = batch_result["skipped"]
+    batch_ms = (time.perf_counter() - t0) * 1000.0
+    print(f"Batch submitted in {batch_ms:.0f} ms: {len(enqueued)} to download, "
+          f"{len(skipped)} already local/queued")
+
+    remaining = set(enqueued)
+    completion_ms: list[float] = []
+    while remaining:
+        elapsed = time.perf_counter() - t0
+        if elapsed > args.timeout:
+            print(f"TIMEOUT after {elapsed:.1f}s with {len(remaining)} images missing:")
+            for name in sorted(remaining):
+                print(f"  - {name}")
+            break
+        done = {name for name in remaining if cache.get_image_path(name, "normal") is not None}
+        for _ in done:
+            completion_ms.append(elapsed * 1000.0)
+        remaining -= done
+        if not remaining:
+            break
+        time.sleep(0.1)
+
+    service.shutdown()
+
+    total_ms = (time.perf_counter() - t0) * 1000.0
+    downloaded = len(enqueued) - len(remaining)
+    print()
+    print(f"RESULT | downloaded {downloaded}/{len(enqueued)} images")
+    if completion_ms:
+        completion_ms.sort()
+        p = lambda q: completion_ms[min(len(completion_ms) - 1, int(q * len(completion_ms)))]  # noqa: E731
+        print(f"RESULT | first image  {completion_ms[0]:>8.0f} ms")
+        print(f"RESULT | 50% local    {p(0.50):>8.0f} ms")
+        print(f"RESULT | 90% local    {p(0.90):>8.0f} ms")
+        print(f"RESULT | all local    {completion_ms[-1]:>8.0f} ms")
+    print(f"RESULT | wall total   {total_ms:>8.0f} ms")
+    return 0 if not remaining else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/image_service/cache.py
+++ b/services/image_service/cache.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from services.image_service.priorities import PRIORITY_BACKGROUND
 from services.image_service.schemas import CardImageRequest
 
 if TYPE_CHECKING:
@@ -35,8 +36,14 @@ class ImageCacheMixin(_Base):
     ) -> None:
         self._on_printings_loaded = callback
 
-    def queue_card_image_download(self, request: CardImageRequest, *, prioritize: bool) -> bool:
-        enqueued = self._download_queue.enqueue(request, prioritize=prioritize)
+    def queue_card_image_download(
+        self,
+        request: CardImageRequest,
+        *,
+        prioritize: bool,
+        priority: int = PRIORITY_BACKGROUND,
+    ) -> bool:
+        enqueued = self._download_queue.enqueue(request, prioritize=prioritize, priority=priority)
         logger.debug(
             "Queue image request for %s (set=%s, size=%s, collector=%s) -> %s",
             request.card_name,
@@ -50,17 +57,30 @@ class ImageCacheMixin(_Base):
     def set_selected_card_request(self, request: CardImageRequest | None) -> None:
         self._download_queue.set_selected_request(request)
 
-    def prefetch_card_images(self, source: str, names: Iterable[str]) -> None:
+    def prefetch_card_images(
+        self,
+        source: str,
+        names: Iterable[str],
+        *,
+        priority: int = PRIORITY_BACKGROUND,
+        on_batch: Callable[[str, list[str], list[str]], None] | None = None,
+    ) -> None:
         """Batch-prefetch images for the cards a user is likely to view next.
 
         Coalesces per ``source`` and runs off the UI thread; see
         :class:`~services.image_service.prefetcher.ImagePrefetcher`.
         """
-        self._prefetcher.prefetch(source, names)
+        self._prefetcher.prefetch(source, names, priority=priority, on_batch=on_batch)
 
-    def prefetch_card_images_lazy(self, source: str, provider: Callable[[], Iterable[str]]) -> None:
+    def prefetch_card_images_lazy(
+        self,
+        source: str,
+        provider: Callable[[], Iterable[str]],
+        *,
+        priority: int = PRIORITY_BACKGROUND,
+    ) -> None:
         """Batch-prefetch with ``provider`` evaluated on the prefetch thread."""
-        self._prefetcher.prefetch_lazy(source, provider)
+        self._prefetcher.prefetch_lazy(source, provider, priority=priority)
 
     def _handle_image_downloaded(self, request: CardImageRequest) -> None:
         if not self._on_image_downloaded:

--- a/services/image_service/cache.py
+++ b/services/image_service/cache.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -49,6 +49,18 @@ class ImageCacheMixin(_Base):
 
     def set_selected_card_request(self, request: CardImageRequest | None) -> None:
         self._download_queue.set_selected_request(request)
+
+    def prefetch_card_images(self, source: str, names: Iterable[str]) -> None:
+        """Batch-prefetch images for the cards a user is likely to view next.
+
+        Coalesces per ``source`` and runs off the UI thread; see
+        :class:`~services.image_service.prefetcher.ImagePrefetcher`.
+        """
+        self._prefetcher.prefetch(source, names)
+
+    def prefetch_card_images_lazy(self, source: str, provider: Callable[[], Iterable[str]]) -> None:
+        """Batch-prefetch with ``provider`` evaluated on the prefetch thread."""
+        self._prefetcher.prefetch_lazy(source, provider)
 
     def _handle_image_downloaded(self, request: CardImageRequest) -> None:
         if not self._on_image_downloaded:

--- a/services/image_service/disk_cache.py
+++ b/services/image_service/disk_cache.py
@@ -234,9 +234,45 @@ class CardImageCache:
                 (card_name, set_code, size),
             )
             row = cursor.fetchone()
-            if not row:
-                return None
-            return self._resolve_path(row[0])
+            if row:
+                return self._resolve_path(row[0])
+            # Split/adventure/prepare layouts store their single image under the
+            # combined "Front // Back" name, so a face-name + set request (the
+            # shape the card inspector's hover path produces) must fall back to
+            # the combined-name row — mirroring get_image_path's alias fallback.
+            # Without this the download queue never sees such cards as cached
+            # and re-downloads them on every hover (issue #951).
+            return self._lookup_double_faced_alias_for_printing(conn, card_name, set_code, size)
+
+    def _lookup_double_faced_alias_for_printing(
+        self, conn: sqlite3.Connection, card_name: str, set_code: str, size: str
+    ) -> Path | None:
+        alias = (card_name or "").strip()
+        if not alias or "//" in alias:
+            return None
+
+        alias_lower = alias.lower()
+        patterns = (
+            f"{alias_lower} // %",
+            f"% // {alias_lower}",
+        )
+        for pattern in patterns:
+            cursor = conn.execute(
+                """
+                SELECT file_path
+                FROM card_images
+                WHERE LOWER(name) LIKE ? AND LOWER(set_code) = LOWER(?) AND image_size = ?
+                ORDER BY face_index
+                LIMIT 1
+                """,
+                (pattern, set_code, size),
+            )
+            row = cursor.fetchone()
+            if row:
+                path = self._resolve_path(row[0])
+                if path.exists():
+                    return path
+        return None
 
     def get_image_by_uuid(
         self, uuid: str, size: str = "normal", face_index: int | None = 0

--- a/services/image_service/download_queue.py
+++ b/services/image_service/download_queue.py
@@ -153,7 +153,10 @@ class CardImageDownloadQueue:
             started_at = time.monotonic()
             try:
                 success, msg = self._downloader.download_card_image_by_name(
-                    request.card_name, request.size, set_code=request.set_code
+                    request.card_name,
+                    request.size,
+                    set_code=request.set_code,
+                    uuid=request.uuid,
                 )
             except Exception as exc:
                 success = False
@@ -282,6 +285,13 @@ class CardImageDownloadQueue:
     def _is_cached(self, request: CardImageRequest) -> bool:
         if not request.card_name:
             return False
+        # A uuid pins the request to one exact printing. Check it first: the
+        # name/set lookups can miss split-layout cards stored under their
+        # combined name. Fall through to the name/set checks on a uuid miss so
+        # a printing satisfied under another identity (e.g. resolved from
+        # stale bulk data) still counts as cached.
+        if request.uuid and self._cache.is_cached(request.uuid, request.size, face_index=0):
+            return True
         if request.set_code:
             return (
                 self._cache.get_image_path_for_printing(

--- a/services/image_service/download_queue.py
+++ b/services/image_service/download_queue.py
@@ -50,9 +50,7 @@ class CardImageDownloadQueue:
         # urgent non-empty tier first, so a batch enqueued in display order
         # resolves in display order and background warm-up traffic can never
         # delay the selected deck's images (issue #951).
-        self._tiers: dict[int, deque[CardImageRequest]] = {
-            tier: deque() for tier in PRIORITY_TIERS
-        }
+        self._tiers: dict[int, deque[CardImageRequest]] = {tier: deque() for tier in PRIORITY_TIERS}
         # key -> priority tier its pending request currently sits in.
         self._pending_priorities: dict[tuple[str, ...], int] = {}
         self._inflight_keys: set[tuple[str, ...]] = set()

--- a/services/image_service/download_queue.py
+++ b/services/image_service/download_queue.py
@@ -11,6 +11,11 @@ from concurrent.futures import ThreadPoolExecutor
 from loguru import logger
 
 from services.image_service.downloader import BulkImageDownloader
+from services.image_service.priorities import (
+    PRIORITY_BACKGROUND,
+    PRIORITY_HOVER,
+    PRIORITY_TIERS,
+)
 from services.image_service.schemas import CardImageRequest
 from utils.constants.timing import (
     IMAGE_DOWNLOAD_INITIAL_BACKOFF_SECONDS,
@@ -39,8 +44,15 @@ class CardImageDownloadQueue:
         self._downloader = BulkImageDownloader(cache)
         self._on_downloaded = on_downloaded
         self._on_failed = on_failed
-        self._queue: deque[CardImageRequest] = deque()
-        self._pending_keys: set[tuple[str, ...]] = set()
+        # One FIFO deque per priority tier; the worker always drains the most
+        # urgent non-empty tier first, so a batch enqueued in display order
+        # resolves in display order and background warm-up traffic can never
+        # delay the selected deck's images (issue #951).
+        self._tiers: dict[int, deque[CardImageRequest]] = {
+            tier: deque() for tier in PRIORITY_TIERS
+        }
+        # key -> priority tier its pending request currently sits in.
+        self._pending_priorities: dict[tuple[str, ...], int] = {}
         self._inflight_keys: set[tuple[str, ...]] = set()
         self._inflight_count = 0
         self._selected_request: CardImageRequest | None = None
@@ -71,11 +83,27 @@ class CardImageDownloadQueue:
             self._selected_request = request
             self._ensure_selected_priority_locked()
 
-    def enqueue(self, request: CardImageRequest, *, prioritize: bool = False) -> bool:
+    def enqueue(
+        self,
+        request: CardImageRequest,
+        *,
+        prioritize: bool = False,
+        priority: int = PRIORITY_BACKGROUND,
+    ) -> bool:
+        """Queue ``request`` at ``priority`` (lower = sooner; FIFO within a tier).
+
+        ``prioritize=True`` is the hover path: the request goes to the *front*
+        of the most urgent tier. A request already pending at a less urgent
+        tier is promoted (moved, never duplicated) when re-enqueued at a more
+        urgent one; re-enqueues at the same or a less urgent tier are dropped.
+        """
         if not request.can_fetch():
             return False
         if self._is_cached(request):
             return False
+        if prioritize:
+            priority = PRIORITY_HOVER
+        priority = self._clamp_priority(priority)
         not_found_key = self._not_found_key(request)
         key = request.queue_key()
         with self._condition:
@@ -91,30 +119,56 @@ class CardImageDownloadQueue:
                 return False
             if key in self._inflight_keys:
                 return False
-            if key in self._pending_keys:
-                if prioritize:
+            pending_priority = self._pending_priorities.get(key)
+            if pending_priority is not None:
+                if priority < pending_priority or prioritize:
                     self._remove_request_by_key_locked(key)
                 else:
                     return False
             if prioritize:
-                self._queue.appendleft(request)
+                self._tiers[priority].appendleft(request)
             else:
-                self._queue.append(request)
-            self._pending_keys.add(key)
+                self._tiers[priority].append(request)
+            self._pending_priorities[key] = priority
             self._condition.notify()
         return True
+
+    @staticmethod
+    def _clamp_priority(priority: int) -> int:
+        return min(max(priority, PRIORITY_TIERS[0]), PRIORITY_TIERS[-1])
+
+    @property
+    def _queue(self) -> tuple[CardImageRequest, ...]:
+        """Flattened snapshot of all pending requests in pop order."""
+        return tuple(request for tier in PRIORITY_TIERS for request in self._tiers[tier])
+
+    @property
+    def _pending_keys(self) -> set[tuple[str, ...]]:
+        return set(self._pending_priorities)
+
+    def _pop_next_locked(self) -> CardImageRequest | None:
+        for tier in PRIORITY_TIERS:
+            if self._tiers[tier]:
+                return self._tiers[tier].popleft()
+        return None
+
+    def _has_pending_locked(self) -> bool:
+        return any(self._tiers[tier] for tier in PRIORITY_TIERS)
 
     def _run(self) -> None:
         while not self._stop_event.is_set():
             with self._condition:
                 while (
-                    not self._queue or self._inflight_count >= self._MAX_CONCURRENT_DOWNLOADS
+                    not self._has_pending_locked()
+                    or self._inflight_count >= self._MAX_CONCURRENT_DOWNLOADS
                 ) and not self._stop_event.is_set():
                     self._condition.wait(timeout=IMAGE_DOWNLOAD_QUEUE_IDLE_WAIT_SECONDS)
                 if self._stop_event.is_set():
                     break
-                request = self._queue.popleft()
-                self._pending_keys.discard(request.queue_key())
+                request = self._pop_next_locked()
+                if request is None:
+                    continue
+                self._pending_priorities.pop(request.queue_key(), None)
                 self._inflight_keys.add(request.queue_key())
                 self._inflight_count += 1
 
@@ -269,17 +323,20 @@ class CardImageDownloadQueue:
         key = request.queue_key()
         if key in self._inflight_keys:
             return
-        if key in self._pending_keys:
+        if key in self._pending_priorities:
             self._remove_request_by_key_locked(key)
-        self._queue.appendleft(request)
-        self._pending_keys.add(key)
+        self._tiers[PRIORITY_HOVER].appendleft(request)
+        self._pending_priorities[key] = PRIORITY_HOVER
         self._condition.notify()
 
     def _remove_request_by_key_locked(self, key: tuple[str, ...]) -> None:
-        for request in list(self._queue):
+        tier = self._pending_priorities.get(key)
+        if tier is None:
+            return
+        for request in self._tiers[tier]:
             if request.queue_key() == key:
-                self._queue.remove(request)
-                self._pending_keys.discard(key)
+                self._tiers[tier].remove(request)
+                self._pending_priorities.pop(key, None)
                 return
 
     def _is_cached(self, request: CardImageRequest) -> bool:

--- a/services/image_service/download_queue.py
+++ b/services/image_service/download_queue.py
@@ -40,8 +40,8 @@ class CardImageDownloadQueue:
         self._on_downloaded = on_downloaded
         self._on_failed = on_failed
         self._queue: deque[CardImageRequest] = deque()
-        self._pending_keys: set[tuple[str, str, str, str]] = set()
-        self._inflight_keys: set[tuple[str, str, str, str]] = set()
+        self._pending_keys: set[tuple[str, ...]] = set()
+        self._inflight_keys: set[tuple[str, ...]] = set()
         self._inflight_count = 0
         self._selected_request: CardImageRequest | None = None
         self._stop_event = threading.Event()
@@ -275,7 +275,7 @@ class CardImageDownloadQueue:
         self._pending_keys.add(key)
         self._condition.notify()
 
-    def _remove_request_by_key_locked(self, key: tuple[str, str, str, str]) -> None:
+    def _remove_request_by_key_locked(self, key: tuple[str, ...]) -> None:
         for request in list(self._queue):
             if request.queue_key() == key:
                 self._queue.remove(request)

--- a/services/image_service/download_queue.py
+++ b/services/image_service/download_queue.py
@@ -39,9 +39,11 @@ class CardImageDownloadQueue:
         *,
         on_downloaded: Callable[[CardImageRequest], None] | None = None,
         on_failed: Callable[[CardImageRequest, str], None] | None = None,
+        warm_local_index: bool = False,
     ) -> None:
         self._cache = cache
         self._downloader = BulkImageDownloader(cache)
+        self._warm_local_index = warm_local_index
         self._on_downloaded = on_downloaded
         self._on_failed = on_failed
         # One FIFO deque per priority tier; the worker always drains the most
@@ -156,6 +158,14 @@ class CardImageDownloadQueue:
         return any(self._tiers[tier] for tier in PRIORITY_TIERS)
 
     def _run(self) -> None:
+        if self._warm_local_index and not self._stop_event.is_set():
+            # Build the bulk-data image index up front (~2s CPU, off the UI
+            # thread) so the first wave of downloads doesn't stall behind the
+            # lazy build under the index lock (issue #951).
+            try:
+                self._downloader.warm_local_index()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug(f"Local image index warm-up failed: {exc}")
         while not self._stop_event.is_set():
             with self._condition:
                 while (

--- a/services/image_service/downloader.py
+++ b/services/image_service/downloader.py
@@ -64,9 +64,9 @@ class BulkImageDownloader(
         self._local_image_index_lock = threading.Lock()
 
     def download_card_image_by_name(
-        self, name: str, size: str = "normal", set_code: str | None = None
+        self, name: str, size: str = "normal", set_code: str | None = None, uuid: str | None = None
     ) -> tuple[bool, str]:
-        card = self._resolve_card_locally(name, set_code=set_code)
+        card = self._resolve_card_locally(name, set_code=set_code, uuid=uuid)
         if card is None:
             card = self.fetch_card_by_name(name, set_code=set_code)
         return self._download_single_image(card, size)

--- a/services/image_service/local_resolver.py
+++ b/services/image_service/local_resolver.py
@@ -53,6 +53,16 @@ class LocalResolverMixin(_Base):
             params = None
         return results
 
+    def warm_local_index(self) -> None:
+        """Build the local name -> image index now instead of on first use.
+
+        The build parses the full bulk-data file (~2s); triggered lazily it
+        stalls the first wave of image downloads behind the index lock, so
+        callers that know downloads are coming (the download queue at app
+        startup) warm it up front on a background thread (issue #951).
+        """
+        self._get_local_image_index()
+
     def _resolve_card_locally(
         self, name: str, set_code: str | None = None, uuid: str | None = None
     ) -> BulkCardImage | None:

--- a/services/image_service/local_resolver.py
+++ b/services/image_service/local_resolver.py
@@ -53,7 +53,9 @@ class LocalResolverMixin(_Base):
             params = None
         return results
 
-    def _resolve_card_locally(self, name: str, set_code: str | None = None) -> BulkCardImage | None:
+    def _resolve_card_locally(
+        self, name: str, set_code: str | None = None, uuid: str | None = None
+    ) -> BulkCardImage | None:
         """Resolve a card's image metadata from the locally-cached bulk data.
 
         Returns ``None`` on any miss (no bulk data, name absent, or no
@@ -66,6 +68,13 @@ class LocalResolverMixin(_Base):
         entries = index.get((name or "").strip().lower())
         if not entries:
             return None
+        if uuid:
+            wanted_uuid = uuid.strip().lower()
+            for entry in entries:
+                if (entry.id or "").strip().lower() == wanted_uuid:
+                    return entry
+            # The exact printing isn't in the local bulk data; fall through to
+            # the set/name resolution below rather than failing outright.
         if set_code:
             wanted = set_code.strip().lower()
             for entry in entries:
@@ -109,6 +118,17 @@ class LocalResolverMixin(_Base):
                 self._local_image_index_mtime = mtime
                 return self._local_image_index
 
+            # A face name that is *also* a real standalone card must not alias
+            # into that card's entry list (e.g. "Emeritus of Conflict //
+            # Lightning Bolt" must not resolve for "Lightning Bolt"), matching
+            # the guard build_printing_index applies (issue #792). Without it
+            # this index and the printing index disagree, so the hover path can
+            # download a different card than the one the inspector shows.
+            primary_names = {
+                (card.name or "").strip().lower()
+                for card in cards
+                if (card.name or "").strip() and card.id
+            }
             index: dict[str, list[BulkCardImage]] = {}
             for card in cards:
                 name = (card.name or "").strip()
@@ -121,7 +141,7 @@ class LocalResolverMixin(_Base):
                 # mirroring Scryfall's exact-name face matching.
                 for alias in _collect_face_aliases(card, name):
                     alias_key = alias.lower()
-                    if alias_key != key:
+                    if alias_key != key and alias_key not in primary_names:
                         index.setdefault(alias_key, []).append(card)
             self._local_image_index = index
             self._local_image_index_mtime = mtime

--- a/services/image_service/prefetcher.py
+++ b/services/image_service/prefetcher.py
@@ -1,0 +1,146 @@
+"""Predictive batch prefetch of card images (issue #951).
+
+UI surfaces submit the cards a user is *likely* to look at next — the loaded
+deck's zones, the top visible decks of the research tab, the visible window of
+the card search — and a single background worker feeds them through the shared
+:class:`~services.image_service.download_queue.CardImageDownloadQueue` in
+bounded batches, so images are already on disk by the time the user hovers.
+
+Submissions coalesce per ``source``: a scroll storm on the search list ends up
+as one batch (the latest window), never a backlog. Batches are capped at
+:data:`IMAGE_PREFETCH_BATCH_LIMIT` requests so a huge search result can never
+commit the app to downloading thousands of images.
+
+The on-hover single-image behavior is unchanged — hover requests keep going
+through :meth:`ImageService.queue_card_image_download` with ``prioritize=True``
+and therefore always jump ahead of prefetch traffic in the queue.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterable
+
+from loguru import logger
+
+from services.image_service.schemas import CardImageRequest
+from utils.constants.timing import (
+    IMAGE_PREFETCH_BATCH_LIMIT,
+    IMAGE_PREFETCH_IDLE_WAIT_SECONDS,
+    IMAGE_PREFETCH_STOP_TIMEOUT_SECONDS,
+)
+
+# A provider is called on the worker thread and returns the card names to
+# prefetch. Lazy providers let a surface defer expensive work (e.g. fetching a
+# research deck's text) off the UI thread until the batch is actually run.
+NamesProvider = Callable[[], Iterable[str]]
+
+
+class ImagePrefetcher:
+    """Coalescing background feeder for the card-image download queue."""
+
+    def __init__(
+        self,
+        enqueue: Callable[[CardImageRequest], bool],
+        *,
+        batch_limit: int = IMAGE_PREFETCH_BATCH_LIMIT,
+        size: str = "normal",
+    ) -> None:
+        self._enqueue = enqueue
+        self._batch_limit = batch_limit
+        self._size = size
+        # Latest pending provider per source; newer submissions replace older
+        # ones so only the most recent prediction for each surface runs.
+        self._pending: dict[str, NamesProvider] = {}
+        # Names already fed to the queue this session. The queue dedupes
+        # pending/in-flight requests itself, but each enqueue of an
+        # already-cached name costs a SQLite lookup — this keeps repeated
+        # submissions of the same window (scrolling back and forth) free.
+        self._submitted: set[str] = set()
+        self._stop_event = threading.Event()
+        self._condition = threading.Condition()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="card-image-prefetcher",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = IMAGE_PREFETCH_STOP_TIMEOUT_SECONDS) -> None:
+        self._stop_event.set()
+        with self._condition:
+            self._condition.notify_all()
+        self._thread.join(timeout=timeout)
+
+    def prefetch(self, source: str, names: Iterable[str]) -> None:
+        """Prefetch ``names`` (deduped, capped) on behalf of ``source``."""
+        snapshot = list(names)
+        self.prefetch_lazy(source, lambda: snapshot)
+
+    def prefetch_lazy(self, source: str, provider: NamesProvider) -> None:
+        """Like :meth:`prefetch`, but ``provider`` runs on the worker thread.
+
+        Use when producing the names is itself expensive (network, disk) and
+        must not run on the caller's thread.
+        """
+        if self._stop_event.is_set():
+            return
+        with self._condition:
+            self._pending[source] = provider
+            self._condition.notify()
+
+    # ------------------------------------------------------------------ worker
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            with self._condition:
+                while not self._pending and not self._stop_event.is_set():
+                    self._condition.wait(timeout=IMAGE_PREFETCH_IDLE_WAIT_SECONDS)
+                if self._stop_event.is_set():
+                    return
+                source, provider = self._pending.popitem()
+            self._run_batch(source, provider)
+
+    def _run_batch(self, source: str, provider: NamesProvider) -> None:
+        try:
+            names = provider()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug(f"Image prefetch provider for {source} failed: {exc}")
+            return
+        batch: list[str] = []
+        seen: set[str] = set()
+        for name in names:
+            cleaned = (name or "").strip()
+            key = cleaned.lower()
+            if not cleaned or key in seen or key in self._submitted:
+                continue
+            seen.add(key)
+            batch.append(cleaned)
+            if len(batch) >= self._batch_limit:
+                break
+        if not batch:
+            return
+        enqueued = 0
+        for name in batch:
+            if self._stop_event.is_set():
+                return
+            self._submitted.add(name.lower())
+            try:
+                if self._enqueue(
+                    CardImageRequest(
+                        card_name=name,
+                        uuid=None,
+                        set_code=None,
+                        collector_number=None,
+                        size=self._size,
+                    )
+                ):
+                    enqueued += 1
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug(f"Image prefetch enqueue for {name} failed: {exc}")
+        if enqueued:
+            logger.debug(
+                f"Image prefetch [{source}]: queued {enqueued}/{len(batch)} candidate cards"
+            )
+
+
+__all__ = ["ImagePrefetcher"]

--- a/services/image_service/prefetcher.py
+++ b/services/image_service/prefetcher.py
@@ -6,6 +6,13 @@ the card search — and a single background worker feeds them through the shared
 :class:`~services.image_service.download_queue.CardImageDownloadQueue` in
 bounded batches, so images are already on disk by the time the user hovers.
 
+Every submission carries a priority tier (see
+:mod:`services.image_service.priorities`) that travels with each request into
+the download queue, so the selected deck's batch always drains ahead of
+research/warm-up traffic. User-driven batches (``priority <=
+PRIORITY_USER_DRIVEN_MAX``) run immediately; background ones idle through a
+short startup grace delay so they never compete with the app's initial loads.
+
 Submissions coalesce per ``source``: a scroll storm on the search list ends up
 as one batch (the latest window), never a backlog. Batches are capped at
 :data:`IMAGE_PREFETCH_BATCH_LIMIT` requests so a huge search result can never
@@ -19,10 +26,15 @@ and therefore always jump ahead of prefetch traffic in the queue.
 from __future__ import annotations
 
 import threading
+import time
 from collections.abc import Callable, Iterable
 
 from loguru import logger
 
+from services.image_service.priorities import (
+    PRIORITY_BACKGROUND,
+    PRIORITY_USER_DRIVEN_MAX,
+)
 from services.image_service.schemas import CardImageRequest
 from utils.constants.timing import (
     IMAGE_PREFETCH_BATCH_LIMIT,
@@ -36,13 +48,18 @@ from utils.constants.timing import (
 # research deck's text) off the UI thread until the batch is actually run.
 NamesProvider = Callable[[], Iterable[str]]
 
+# Optional per-batch feedback: called on the worker thread after a batch runs
+# with (source, enqueued_names, skipped_names). Skipped names were already
+# cached, already queued, or previously submitted at an equal-or-better tier.
+BatchCallback = Callable[[str, list[str], list[str]], None]
+
 
 class ImagePrefetcher:
     """Coalescing background feeder for the card-image download queue."""
 
     def __init__(
         self,
-        enqueue: Callable[[CardImageRequest], bool],
+        enqueue: Callable[[CardImageRequest, int], bool],
         *,
         batch_limit: int = IMAGE_PREFETCH_BATCH_LIMIT,
         size: str = "normal",
@@ -51,15 +68,22 @@ class ImagePrefetcher:
         self._enqueue = enqueue
         self._batch_limit = batch_limit
         self._size = size
-        self._start_delay = start_delay
-        # Latest pending provider per source; newer submissions replace older
-        # ones so only the most recent prediction for each surface runs.
-        self._pending: dict[str, NamesProvider] = {}
-        # Names already fed to the queue this session. The queue dedupes
-        # pending/in-flight requests itself, but each enqueue of an
-        # already-cached name costs a SQLite lookup — this keeps repeated
-        # submissions of the same window (scrolling back and forth) free.
-        self._submitted: set[str] = set()
+        # Background batches idle until this deadline so prefetch downloads
+        # never compete with the app's initial loads or first paint;
+        # user-driven batches (selected deck, visible research decks) ignore
+        # it — those are the images the user is waiting on right now.
+        self._background_deadline = time.monotonic() + start_delay
+        # Latest pending (priority, provider, on_batch) per source; newer
+        # submissions replace older ones so only the most recent prediction
+        # for each surface runs.
+        self._pending: dict[str, tuple[int, NamesProvider, BatchCallback | None]] = {}
+        # Best (numerically lowest) priority each name has been fed to the
+        # queue with this session. The queue dedupes pending/in-flight
+        # requests itself, but each enqueue of an already-cached name costs a
+        # SQLite lookup — this keeps repeated submissions of the same window
+        # (scrolling back and forth) free, while still letting a name be
+        # re-submitted at a *better* tier (the queue promotes it in place).
+        self._submitted: dict[str, int] = {}
         self._stop_event = threading.Event()
         self._condition = threading.Condition()
         self._thread = threading.Thread(
@@ -75,12 +99,26 @@ class ImagePrefetcher:
             self._condition.notify_all()
         self._thread.join(timeout=timeout)
 
-    def prefetch(self, source: str, names: Iterable[str]) -> None:
+    def prefetch(
+        self,
+        source: str,
+        names: Iterable[str],
+        *,
+        priority: int = PRIORITY_BACKGROUND,
+        on_batch: BatchCallback | None = None,
+    ) -> None:
         """Prefetch ``names`` (deduped, capped) on behalf of ``source``."""
         snapshot = list(names)
-        self.prefetch_lazy(source, lambda: snapshot)
+        self.prefetch_lazy(source, lambda: snapshot, priority=priority, on_batch=on_batch)
 
-    def prefetch_lazy(self, source: str, provider: NamesProvider) -> None:
+    def prefetch_lazy(
+        self,
+        source: str,
+        provider: NamesProvider,
+        *,
+        priority: int = PRIORITY_BACKGROUND,
+        on_batch: BatchCallback | None = None,
+    ) -> None:
         """Like :meth:`prefetch`, but ``provider`` runs on the worker thread.
 
         Use when producing the names is itself expensive (network, disk) and
@@ -89,50 +127,82 @@ class ImagePrefetcher:
         if self._stop_event.is_set():
             return
         with self._condition:
-            self._pending[source] = provider
+            self._pending[source] = (priority, provider, on_batch)
             self._condition.notify()
 
     # ------------------------------------------------------------------ worker
     def _run(self) -> None:
-        # Idle before the first batch so prefetch downloads never compete with
-        # the app's initial loads or first paint (same pattern as CacheWarmer).
-        # Submissions arriving during the delay are held in _pending and run
-        # once it elapses; a stop request interrupts the wait immediately.
-        if self._stop_event.wait(self._start_delay):
-            return
         while not self._stop_event.is_set():
             with self._condition:
-                while not self._pending and not self._stop_event.is_set():
-                    self._condition.wait(timeout=IMAGE_PREFETCH_IDLE_WAIT_SECONDS)
+                batch = self._next_batch_locked()
+                while batch is None and not self._stop_event.is_set():
+                    self._condition.wait(timeout=self._wait_timeout_locked())
+                    batch = self._next_batch_locked()
                 if self._stop_event.is_set():
                     return
-                source, provider = self._pending.popitem()
-            self._run_batch(source, provider)
+                source, (priority, provider, on_batch) = batch
+            self._run_batch(source, provider, priority=priority, on_batch=on_batch)
 
-    def _run_batch(self, source: str, provider: NamesProvider) -> None:
+    def _next_batch_locked(self) -> tuple[str, tuple[int, NamesProvider, BatchCallback | None]] | None:
+        """Pop the most urgent runnable submission, or None to keep waiting.
+
+        Background-tier submissions are held until the startup grace deadline;
+        user-driven ones run immediately, even during the delay.
+        """
+        if not self._pending:
+            return None
+        source = min(self._pending, key=lambda s: self._pending[s][0])
+        priority = self._pending[source][0]
+        if priority > PRIORITY_USER_DRIVEN_MAX and time.monotonic() < self._background_deadline:
+            return None
+        return source, self._pending.pop(source)
+
+    def _wait_timeout_locked(self) -> float:
+        """Wait timeout: shortened while background work waits out the delay."""
+        if not self._pending:
+            return IMAGE_PREFETCH_IDLE_WAIT_SECONDS
+        remaining = self._background_deadline - time.monotonic()
+        return min(IMAGE_PREFETCH_IDLE_WAIT_SECONDS, max(remaining, 0.05))
+
+    def _run_batch(
+        self,
+        source: str,
+        provider: NamesProvider,
+        *,
+        priority: int = PRIORITY_BACKGROUND,
+        on_batch: BatchCallback | None = None,
+    ) -> None:
         try:
             names = provider()
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug(f"Image prefetch provider for {source} failed: {exc}")
             return
         batch: list[str] = []
+        skipped: list[str] = []
         seen: set[str] = set()
         for name in names:
             cleaned = (name or "").strip()
             key = cleaned.lower()
-            if not cleaned or key in seen or key in self._submitted:
+            if not cleaned or key in seen:
                 continue
             seen.add(key)
+            # Skip names already fed to the queue at this tier or better; a
+            # strictly better tier re-submits so the queue promotes them.
+            if self._submitted.get(key, PRIORITY_BACKGROUND + 1) <= priority:
+                skipped.append(cleaned)
+                continue
             batch.append(cleaned)
             if len(batch) >= self._batch_limit:
                 break
         if not batch:
+            if on_batch:
+                self._safe_on_batch(on_batch, source, [], skipped)
             return
-        enqueued = 0
+        enqueued: list[str] = []
         for name in batch:
             if self._stop_event.is_set():
                 return
-            self._submitted.add(name.lower())
+            self._submitted[name.lower()] = priority
             try:
                 if self._enqueue(
                     CardImageRequest(
@@ -141,15 +211,31 @@ class ImagePrefetcher:
                         set_code=None,
                         collector_number=None,
                         size=self._size,
-                    )
+                    ),
+                    priority,
                 ):
-                    enqueued += 1
+                    enqueued.append(name)
+                else:
+                    skipped.append(name)
             except Exception as exc:  # pragma: no cover - defensive
                 logger.debug(f"Image prefetch enqueue for {name} failed: {exc}")
+                skipped.append(name)
         if enqueued:
             logger.debug(
-                f"Image prefetch [{source}]: queued {enqueued}/{len(batch)} candidate cards"
+                f"Image prefetch [{source}] (tier {priority}): queued "
+                f"{len(enqueued)}/{len(batch)} candidate cards"
             )
+        if on_batch:
+            self._safe_on_batch(on_batch, source, enqueued, skipped)
+
+    @staticmethod
+    def _safe_on_batch(
+        on_batch: BatchCallback, source: str, enqueued: list[str], skipped: list[str]
+    ) -> None:
+        try:
+            on_batch(source, enqueued, skipped)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug(f"Image prefetch on_batch for {source} failed: {exc}")
 
 
 __all__ = ["ImagePrefetcher"]

--- a/services/image_service/prefetcher.py
+++ b/services/image_service/prefetcher.py
@@ -27,6 +27,7 @@ from services.image_service.schemas import CardImageRequest
 from utils.constants.timing import (
     IMAGE_PREFETCH_BATCH_LIMIT,
     IMAGE_PREFETCH_IDLE_WAIT_SECONDS,
+    IMAGE_PREFETCH_START_DELAY_SECONDS,
     IMAGE_PREFETCH_STOP_TIMEOUT_SECONDS,
 )
 
@@ -45,10 +46,12 @@ class ImagePrefetcher:
         *,
         batch_limit: int = IMAGE_PREFETCH_BATCH_LIMIT,
         size: str = "normal",
+        start_delay: float = IMAGE_PREFETCH_START_DELAY_SECONDS,
     ) -> None:
         self._enqueue = enqueue
         self._batch_limit = batch_limit
         self._size = size
+        self._start_delay = start_delay
         # Latest pending provider per source; newer submissions replace older
         # ones so only the most recent prediction for each surface runs.
         self._pending: dict[str, NamesProvider] = {}
@@ -91,6 +94,12 @@ class ImagePrefetcher:
 
     # ------------------------------------------------------------------ worker
     def _run(self) -> None:
+        # Idle before the first batch so prefetch downloads never compete with
+        # the app's initial loads or first paint (same pattern as CacheWarmer).
+        # Submissions arriving during the delay are held in _pending and run
+        # once it elapses; a stop request interrupts the wait immediately.
+        if self._stop_event.wait(self._start_delay):
+            return
         while not self._stop_event.is_set():
             with self._condition:
                 while not self._pending and not self._stop_event.is_set():

--- a/services/image_service/prefetcher.py
+++ b/services/image_service/prefetcher.py
@@ -143,7 +143,9 @@ class ImagePrefetcher:
                 source, (priority, provider, on_batch) = batch
             self._run_batch(source, provider, priority=priority, on_batch=on_batch)
 
-    def _next_batch_locked(self) -> tuple[str, tuple[int, NamesProvider, BatchCallback | None]] | None:
+    def _next_batch_locked(
+        self,
+    ) -> tuple[str, tuple[int, NamesProvider, BatchCallback | None]] | None:
         """Pop the most urgent runnable submission, or None to keep waiting.
 
         Background-tier submissions are held until the startup grace deadline;

--- a/services/image_service/priorities.py
+++ b/services/image_service/priorities.py
@@ -1,0 +1,48 @@
+"""Priority tiers for the card-image download queue (issue #951).
+
+Lower value = downloaded sooner. The queue is FIFO within a tier, so a batch
+submitted in display order resolves in display order. The tiers encode how
+likely the user is to look at the image next:
+
+- ``PRIORITY_HOVER`` — the card under the cursor / shown in the inspector.
+- ``PRIORITY_SELECTED_DECK`` — every card of the deck currently open in the
+  UI; the whole deck is visible-or-one-hover-away the moment it loads.
+- ``PRIORITY_RESEARCH_VISIBLE`` — the top decks of the research results list
+  for the *selected* format and the visible window of the card search.
+- ``PRIORITY_RESEARCH_FORMATS`` — the decks the research panel would show
+  for the other formats (warmed alphabetically by format).
+- ``PRIORITY_FORMAT_ALL`` — every remaining deck of the selected format.
+- ``PRIORITY_BACKGROUND`` — every deck of every other format; the exhaustive
+  "each competitively played card eventually" sweep.
+"""
+
+PRIORITY_HOVER = 0
+PRIORITY_SELECTED_DECK = 1
+PRIORITY_RESEARCH_VISIBLE = 2
+PRIORITY_RESEARCH_FORMATS = 3
+PRIORITY_FORMAT_ALL = 4
+PRIORITY_BACKGROUND = 5
+
+PRIORITY_TIERS = (
+    PRIORITY_HOVER,
+    PRIORITY_SELECTED_DECK,
+    PRIORITY_RESEARCH_VISIBLE,
+    PRIORITY_RESEARCH_FORMATS,
+    PRIORITY_FORMAT_ALL,
+    PRIORITY_BACKGROUND,
+)
+
+# Batches at or above this urgency (numerically <=) are user-driven: they run
+# immediately, bypassing the prefetcher's startup grace delay.
+PRIORITY_USER_DRIVEN_MAX = PRIORITY_RESEARCH_VISIBLE
+
+__all__ = [
+    "PRIORITY_BACKGROUND",
+    "PRIORITY_FORMAT_ALL",
+    "PRIORITY_HOVER",
+    "PRIORITY_RESEARCH_FORMATS",
+    "PRIORITY_RESEARCH_VISIBLE",
+    "PRIORITY_SELECTED_DECK",
+    "PRIORITY_TIERS",
+    "PRIORITY_USER_DRIVEN_MAX",
+]

--- a/services/image_service/protocol.py
+++ b/services/image_service/protocol.py
@@ -9,6 +9,7 @@ from typing import Any, Protocol
 from services.image_service.disk_cache import CardImageCache
 from services.image_service.download_queue import CardImageDownloadQueue
 from services.image_service.downloader import BulkImageDownloader
+from services.image_service.prefetcher import ImagePrefetcher
 from services.image_service.process_worker import ProcessHandle, ProcessWorker
 from services.image_service.schemas import CardImageRequest
 
@@ -26,6 +27,7 @@ class ImageServiceProto(Protocol):
     _on_printings_loaded: Callable[[str, list[dict[str, Any]]], None] | None
 
     _download_queue: CardImageDownloadQueue
+    _prefetcher: ImagePrefetcher
     _printings_lock: threading.Lock
     _printings_inflight: set[str]
 

--- a/services/image_service/schemas.py
+++ b/services/image_service/schemas.py
@@ -180,12 +180,16 @@ class CardImageRequest:
     collector_number: str | None
     size: str = "normal"
 
-    def queue_key(self) -> tuple[str, str, str, str]:
+    def queue_key(self) -> tuple[str, str, str, str, str]:
         if self.uuid:
-            return ("uuid", self.uuid.lower(), self.size, "")
+            return ("uuid", self.uuid.lower(), self.size, "", "")
+        # The card name MUST be part of the key: prefetch/warmup requests
+        # carry neither uuid nor set/collector, and without the name every
+        # such request collapses onto one key — the queue then drops all but
+        # the first card of a 100-card batch as a "duplicate" (issue #951).
         set_code = (self.set_code or "").lower()
         collector = (self.collector_number or "").lower()
-        return ("set", set_code, collector, self.size)
+        return ("set", (self.card_name or "").lower(), set_code, collector, self.size)
 
     def can_fetch(self) -> bool:
         return bool((self.card_name or "").strip())

--- a/services/image_service/service.py
+++ b/services/image_service/service.py
@@ -38,7 +38,9 @@ class ImageService(
             on_failed=self._handle_image_download_failed,
         )
         self._prefetcher = ImagePrefetcher(
-            enqueue=lambda request: self._download_queue.enqueue(request, prioritize=False)
+            enqueue=lambda request, priority: self._download_queue.enqueue(
+                request, priority=priority
+            )
         )
         self._printings_lock = threading.Lock()
         self._printings_inflight: set[str] = set()

--- a/services/image_service/service.py
+++ b/services/image_service/service.py
@@ -25,7 +25,7 @@ class ImageService(
 ):
     """Service for managing card image bulk data and printing indices."""
 
-    def __init__(self):
+    def __init__(self, *, warm_image_index: bool = True):
         self.image_cache = get_cache()
         self.image_downloader: BulkImageDownloader | None = None
         self.bulk_data_by_name: dict[str, list[dict[str, Any]]] | None = None
@@ -36,6 +36,7 @@ class ImageService(
             self.image_cache,
             on_downloaded=self._handle_image_downloaded,
             on_failed=self._handle_image_download_failed,
+            warm_local_index=warm_image_index,
         )
         self._prefetcher = ImagePrefetcher(
             enqueue=lambda request, priority: self._download_queue.enqueue(

--- a/services/image_service/service.py
+++ b/services/image_service/service.py
@@ -11,6 +11,7 @@ from services.image_service.cache import ImageCacheMixin
 from services.image_service.download_queue import CardImageDownloadQueue
 from services.image_service.downloader import BulkImageDownloader, get_cache
 from services.image_service.metadata import PrintingsFetchMixin
+from services.image_service.prefetcher import ImagePrefetcher
 from services.image_service.printing_index import PrintingIndexMixin
 from services.image_service.process_worker import ProcessHandle, ProcessWorker
 from services.image_service.schemas import CardImageRequest
@@ -36,6 +37,9 @@ class ImageService(
             on_downloaded=self._handle_image_downloaded,
             on_failed=self._handle_image_download_failed,
         )
+        self._prefetcher = ImagePrefetcher(
+            enqueue=lambda request: self._download_queue.enqueue(request, prioritize=False)
+        )
         self._printings_lock = threading.Lock()
         self._printings_inflight: set[str] = set()
         self._on_printings_loaded: Callable[[str, list[dict[str, Any]]], None] | None = None
@@ -44,6 +48,7 @@ class ImageService(
         self._printings_handle: ProcessHandle | None = None
 
     def shutdown(self) -> None:
+        self._prefetcher.stop()
         self._download_queue.stop()
         if self._bulk_download_handle:
             self._process_worker.terminate(self._bulk_download_handle)

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -37,6 +37,7 @@ def _make_warmer(
 
     fetched: list[str] = []
     queued: list[str] = []
+    queued_priorities: dict[str, int] = {}
 
     def get_archetypes(fmt: str) -> list[dict[str, Any]]:
         return archetypes.get(fmt, [])
@@ -57,8 +58,9 @@ def _make_warmer(
                 names.append(parts[1])
         return names
 
-    def enqueue(request) -> None:
+    def enqueue(request, priority) -> None:
         queued.append(request.card_name)
+        queued_priorities[request.card_name] = priority
 
     warmer = CacheWarmer(
         get_current_format=lambda: current_format,
@@ -74,6 +76,7 @@ def _make_warmer(
         top_decks_per_format=6,
         progress_interval=50,
     )
+    warmer._queued_priorities = queued_priorities  # test-only introspection
     return warmer, fetched, queued
 
 
@@ -95,16 +98,56 @@ def test_ordered_formats_dedupes_case_insensitively():
     assert warmer._ordered_formats() == ["legacy", "Modern"]
 
 
-def test_warm_images_uses_first_deck_per_archetype_selected_format_first():
+def test_warm_images_phases_research_panel_then_selected_format_then_rest():
+    from services.image_service.priorities import (
+        PRIORITY_BACKGROUND,
+        PRIORITY_FORMAT_ALL,
+        PRIORITY_RESEARCH_FORMATS,
+    )
+
     warmer, fetched, queued = _make_warmer()
 
     warmer._warm_images()
 
-    # Legacy archetypes (A, B) processed before Modern (C); each uses decks[0].
-    assert fetched == ["1", "3", "4"]
+    # Phase 1 (research-panel decks, formats A→Z): Legacy decks 1, 3 then
+    # Modern deck 4. Phase 2 (all of selected Legacy): adds deck 2. Phase 3
+    # (all of remaining Modern): adds deck 5. No deck scanned twice.
+    assert fetched == ["1", "3", "4", "2", "5"]
     # Basic land "Island" from deck 1 is skipped; real cards are queued.
     assert "Island" not in queued
-    assert set(queued) == {"Card One", "Card Three", "Card Four"}
+    assert set(queued) == {"Card One", "Card Two", "Card Three", "Card Four", "Card Five"}
+    # Each phase enqueues at its download-queue tier.
+    assert warmer._queued_priorities == {
+        "Card One": PRIORITY_RESEARCH_FORMATS,
+        "Card Three": PRIORITY_RESEARCH_FORMATS,
+        "Card Four": PRIORITY_RESEARCH_FORMATS,
+        "Card Two": PRIORITY_FORMAT_ALL,
+        "Card Five": PRIORITY_BACKGROUND,
+    }
+
+
+def test_warm_images_deep_phases_use_cache_only_deck_texts():
+    """With a cache-only getter injected, phases 2/3 never hit the network
+    path — decks whose text is not local are skipped, not scraped."""
+    warmer, fetched, queued = _make_warmer()
+    local_texts = {"5": "4 Card Five\n"}  # deck 2 (Legacy) has no local text
+    lookups: list[str] = []
+
+    def cached_text(deck):
+        number = str(deck.get("number"))
+        lookups.append(number)
+        return local_texts.get(number, "")
+
+    warmer._get_cached_deck_text = cached_text
+
+    warmer._warm_images()
+
+    # Phase 1 still fetches through the network-capable path (decks 1, 3, 4);
+    # the deep phases only consult the local cache (decks 2 and 5).
+    assert fetched == ["1", "3", "4"]
+    assert lookups == ["2", "5"]
+    # Deck 2's text is not local, so "Card Two" is never queued this session.
+    assert set(queued) == {"Card One", "Card Three", "Card Four", "Card Five"}
 
 
 def test_warm_decklists_phases_and_dedup():
@@ -228,9 +271,10 @@ def test_failing_deck_source_swallowed_and_other_archetypes_continue():
 
     warmer._warm_images()
 
-    # _safe_decks swallows A's failure (no deck 1); B (deck 3) and C (deck 4) warm.
-    assert fetched == ["3", "4"]
-    assert set(queued) == {"Card Three", "Card Four"}
+    # _safe_decks swallows A's failure (no decks 1/2); B (deck 3) and C
+    # (decks 4, then 5 in the deep pass) still warm normally.
+    assert fetched == ["3", "4", "5"]
+    assert set(queued) == {"Card Three", "Card Four", "Card Five"}
 
 
 def test_failing_deck_text_counts_as_failed_and_warming_continues():

--- a/tests/test_card_images_cache.py
+++ b/tests/test_card_images_cache.py
@@ -530,6 +530,16 @@ def _write_bulk_data(cache_dir, monkeypatch):
                     "card_faces": [{"name": "Fire"}, {"name": "Ice"}],
                     "image_uris": {"normal": "http://img/fireice.jpg"},
                 },
+                # Prepare-layout card whose second face shares its name with a
+                # real standalone card (issues #792/#951).
+                {
+                    "name": "Emeritus of Conflict // Lightning Bolt",
+                    "id": "u-prepare",
+                    "set": "sos",
+                    "collector_number": "103",
+                    "card_faces": [{"name": "Emeritus of Conflict"}, {"name": "Lightning Bolt"}],
+                    "image_uris": {"normal": "http://img/emeritus-sos.jpg"},
+                },
             ]
         ),
         encoding="utf-8",
@@ -584,6 +594,81 @@ def test_resolve_card_locally_resolves_face_name(tmp_path, monkeypatch):
     card = downloader._resolve_card_locally("Fire")
     assert card is not None
     assert card.get("id") == "u-fireice"
+
+
+def test_resolve_card_locally_prefers_uuid(tmp_path, monkeypatch):
+    """A uuid pins resolution to the exact printing, beating name/set order."""
+    cache_dir = tmp_path / "card_images"
+    _write_bulk_data(cache_dir, monkeypatch)
+    cache = card_images.CardImageCache(cache_dir=cache_dir, db_path=cache_dir / "images.db")
+    downloader = card_images.BulkImageDownloader(cache)
+
+    card = downloader._resolve_card_locally("Lightning Bolt", set_code="LEA", uuid="u-m11")
+    assert card is not None
+    assert card.get("id") == "u-m11"
+
+
+def test_resolve_card_locally_uuid_miss_falls_back_to_set(tmp_path, monkeypatch):
+    """A uuid absent from local bulk data falls back to set/name resolution."""
+    cache_dir = tmp_path / "card_images"
+    _write_bulk_data(cache_dir, monkeypatch)
+    cache = card_images.CardImageCache(cache_dir=cache_dir, db_path=cache_dir / "images.db")
+    downloader = card_images.BulkImageDownloader(cache)
+
+    card = downloader._resolve_card_locally("Lightning Bolt", set_code="M11", uuid="u-unknown")
+    assert card is not None
+    assert card.get("id") == "u-m11"
+
+
+def test_local_index_face_alias_never_shadows_real_card(tmp_path, monkeypatch):
+    """A face name that is also a real standalone card must resolve to the
+    real card, matching the printing index's primary-name guard (#792): the
+    prepare card "Emeritus of Conflict // Lightning Bolt" must never be
+    returned for "Lightning Bolt"."""
+    cache_dir = tmp_path / "card_images"
+    _write_bulk_data(cache_dir, monkeypatch)
+    cache = card_images.CardImageCache(cache_dir=cache_dir, db_path=cache_dir / "images.db")
+    downloader = card_images.BulkImageDownloader(cache)
+
+    index = downloader._get_local_image_index()
+    bolt_ids = {entry.get("id") for entry in index["lightning bolt"]}
+    assert bolt_ids == {"u-lea", "u-m11"}
+
+    # The face name unique to the prepare card still aliases to it.
+    card = downloader._resolve_card_locally("Emeritus of Conflict")
+    assert card is not None
+    assert card.get("id") == "u-prepare"
+
+
+def test_hover_request_for_prepare_face_downloads_and_registers_cached(tmp_path, monkeypatch):
+    """Regression for issue #951's hover 'beep': a face-name + set request for
+    a prepare-layout card must download locally AND be visible to the download
+    queue's cache check afterwards, or every hover re-downloads the card."""
+    cache_dir = tmp_path / "card_images"
+    _write_bulk_data(cache_dir, monkeypatch)
+    cache = card_images.CardImageCache(cache_dir=cache_dir, db_path=cache_dir / "images.db")
+    downloader = card_images.BulkImageDownloader(cache)
+    downloader.session = _FakeSession()
+
+    def _no_api(*_args, **_kwargs):
+        raise AssertionError("fetch_card_by_name should not be called on a local hit")
+
+    monkeypatch.setattr(downloader, "fetch_card_by_name", _no_api)
+
+    success, message = downloader.download_card_image_by_name(
+        "Emeritus of Conflict", "normal", set_code="SOS"
+    )
+    assert success is True, message
+    assert downloader.session.calls == ["http://img/emeritus-sos.jpg"]
+
+    # Stored under the combined name…
+    assert cache.get_image_path("Emeritus of Conflict // Lightning Bolt", "normal") is not None
+    # …and the printing-scoped lookup used by CardImageDownloadQueue._is_cached
+    # resolves it through the split-name alias fallback for either face.
+    assert cache.get_image_path_for_printing("Emeritus of Conflict", "SOS", "normal") is not None
+    assert cache.get_image_path_for_printing("Lightning Bolt", "SOS", "normal") is not None
+    # A different set still misses.
+    assert cache.get_image_path_for_printing("Emeritus of Conflict", "ZZZ", "normal") is None
 
 
 def test_download_by_name_uses_local_index_before_api(tmp_path, monkeypatch):
@@ -1200,9 +1285,9 @@ def test_download_all_images_downloads_every_card_from_bulk_file(tmp_path, monke
     result = downloader.download_all_images("normal")
 
     assert result["success"] is True
-    # The seeded bulk file holds three cards.
-    assert result["total"] == 3
-    assert result["downloaded"] == 3
+    # The seeded bulk file holds four cards.
+    assert result["total"] == 4
+    assert result["downloaded"] == 4
     assert result["skipped"] == 0
     assert result["failed"] == 0
     # Every card's image URL was fetched and persisted to the cache.
@@ -1210,10 +1295,12 @@ def test_download_all_images_downloads_every_card_from_bulk_file(tmp_path, monke
         "http://img/bolt-lea.jpg",
         "http://img/bolt-m11.jpg",
         "http://img/fireice.jpg",
+        "http://img/emeritus-sos.jpg",
     }
     assert cache.get_image_by_uuid("u-lea", "normal").exists()
     assert cache.get_image_by_uuid("u-m11", "normal").exists()
     assert cache.get_image_by_uuid("u-fireice", "normal").exists()
+    assert cache.get_image_by_uuid("u-prepare", "normal").exists()
 
 
 def test_download_all_images_skips_already_cached_cards(tmp_path, monkeypatch):
@@ -1225,14 +1312,14 @@ def test_download_all_images_skips_already_cached_cards(tmp_path, monkeypatch):
     downloader.session = _FakeSession()
 
     first = downloader.download_all_images("normal")
-    assert first["downloaded"] == 3
+    assert first["downloaded"] == 4
 
     # Fresh session so any re-fetch would be visible in calls.
     downloader.session = _FakeSession()
     second = downloader.download_all_images("normal")
 
     assert second["success"] is True
-    assert second["skipped"] == 3
+    assert second["skipped"] == 4
     assert second["downloaded"] == 0
     assert downloader.session.calls == []
 
@@ -1433,13 +1520,13 @@ def test_download_all_images_honours_max_cards(tmp_path, monkeypatch):
 def test_download_all_images_invokes_progress_callback(tmp_path, monkeypatch):
     """The progress_callback is invoked with (completed, total, message)."""
     cache_dir = tmp_path / "card_images"
-    _write_bulk_data(cache_dir, monkeypatch)  # three cards
+    _write_bulk_data(cache_dir, monkeypatch)  # four cards
     cache = card_images.CardImageCache(cache_dir=cache_dir, db_path=cache_dir / "images.db")
     downloader = card_images.BulkImageDownloader(cache)
     downloader.session = _FakeSession()
 
     # The callback fires every SCRYFALL_DOWNLOAD_PROGRESS_INTERVAL completions;
-    # pin the interval to 1 so each of the three cards triggers a call.
+    # pin the interval to 1 so each of the four cards triggers a call.
     monkeypatch.setattr(
         card_images.downloader, "SCRYFALL_DOWNLOAD_PROGRESS_INTERVAL", 1, raising=False
     )
@@ -1449,8 +1536,8 @@ def test_download_all_images_invokes_progress_callback(tmp_path, monkeypatch):
 
     assert captured, "progress_callback should have been invoked"
     # Each call reports the running completed count out of the fixed total.
-    assert all(total == 3 for _completed, total, _msg in captured)
-    assert captured[-1][0] == 3
+    assert all(total == 4 for _completed, total, _msg in captured)
+    assert captured[-1][0] == 4
 
 
 def test_download_all_images_returns_error_dict_on_load_failure(tmp_path, monkeypatch):

--- a/tests/test_image_prefetcher.py
+++ b/tests/test_image_prefetcher.py
@@ -1,0 +1,112 @@
+"""Tests for the predictive card-image prefetcher (issue #951)."""
+
+from __future__ import annotations
+
+import threading
+
+from services.image_service.prefetcher import ImagePrefetcher
+
+
+def _stopped_prefetcher(enqueue, **kwargs) -> ImagePrefetcher:
+    """Build a prefetcher with its worker thread already stopped.
+
+    Batches are then driven synchronously through ``_run_batch`` so tests are
+    deterministic (no sleeps, no cross-thread races). The stop event is
+    cleared after the (dead) worker thread joins so ``_run_batch`` doesn't
+    bail out of its enqueue loop.
+    """
+    prefetcher = ImagePrefetcher(enqueue, **kwargs)
+    prefetcher.stop()
+    prefetcher._stop_event.clear()
+    return prefetcher
+
+
+def test_run_batch_enqueues_normal_size_requests():
+    requests = []
+    prefetcher = _stopped_prefetcher(lambda req: requests.append(req) or True)
+
+    prefetcher._run_batch("deck", lambda: ["Lightning Bolt", "Ponder"])
+
+    assert [req.card_name for req in requests] == ["Lightning Bolt", "Ponder"]
+    assert all(req.size == "normal" for req in requests)
+    assert all(req.uuid is None and req.set_code is None for req in requests)
+
+
+def test_run_batch_caps_at_batch_limit():
+    requests = []
+    prefetcher = _stopped_prefetcher(lambda req: requests.append(req) or True, batch_limit=5)
+
+    prefetcher._run_batch("search", lambda: [f"Card {i}" for i in range(50)])
+
+    assert len(requests) == 5
+
+
+def test_run_batch_dedupes_within_and_across_batches():
+    requests = []
+    prefetcher = _stopped_prefetcher(lambda req: requests.append(req) or True)
+
+    prefetcher._run_batch("deck", lambda: ["Ponder", "ponder", "  Ponder  ", "Opt"])
+    assert [req.card_name for req in requests] == ["Ponder", "Opt"]
+
+    # A later batch (any source) skips names already fed to the queue.
+    prefetcher._run_batch("search", lambda: ["Ponder", "Brainstorm"])
+    assert [req.card_name for req in requests] == ["Ponder", "Opt", "Brainstorm"]
+
+
+def test_run_batch_skips_blank_names_and_tolerates_provider_errors():
+    requests = []
+    prefetcher = _stopped_prefetcher(lambda req: requests.append(req) or True)
+
+    prefetcher._run_batch("deck", lambda: ["", "   ", None, "Opt"])
+    assert [req.card_name for req in requests] == ["Opt"]
+
+    def _boom():
+        raise RuntimeError("provider failed")
+
+    prefetcher._run_batch("deck", _boom)  # must not raise
+    assert len(requests) == 1
+
+
+def test_run_batch_tolerates_enqueue_errors():
+    calls = []
+
+    def _enqueue(request):
+        calls.append(request.card_name)
+        if request.card_name == "Bad Card":
+            raise RuntimeError("enqueue failed")
+        return True
+
+    prefetcher = _stopped_prefetcher(_enqueue)
+    prefetcher._run_batch("deck", lambda: ["Bad Card", "Opt"])
+    assert calls == ["Bad Card", "Opt"]
+
+
+def test_prefetch_runs_batch_on_worker_thread():
+    done = threading.Event()
+    requests = []
+
+    def _enqueue(request):
+        requests.append(request)
+        if len(requests) == 2:
+            done.set()
+        return True
+
+    prefetcher = ImagePrefetcher(_enqueue)
+    try:
+        prefetcher.prefetch("deck", ["Lightning Bolt", "Ponder"])
+        assert done.wait(timeout=5.0), "prefetch batch never ran"
+    finally:
+        prefetcher.stop()
+    assert sorted(req.card_name for req in requests) == ["Lightning Bolt", "Ponder"]
+
+
+def test_prefetch_after_stop_is_a_noop():
+    requests = []
+    prefetcher = ImagePrefetcher(lambda req: requests.append(req) or True)
+    prefetcher.stop()
+
+    prefetcher.prefetch("deck", ["Lightning Bolt"])
+
+    with prefetcher._condition:
+        assert not prefetcher._pending
+    assert requests == []

--- a/tests/test_image_prefetcher.py
+++ b/tests/test_image_prefetcher.py
@@ -6,6 +6,11 @@ import threading
 import time
 
 from services.image_service.prefetcher import ImagePrefetcher
+from services.image_service.priorities import (
+    PRIORITY_BACKGROUND,
+    PRIORITY_RESEARCH_VISIBLE,
+    PRIORITY_SELECTED_DECK,
+)
 
 
 def _stopped_prefetcher(enqueue, **kwargs) -> ImagePrefetcher:
@@ -24,7 +29,7 @@ def _stopped_prefetcher(enqueue, **kwargs) -> ImagePrefetcher:
 
 def test_run_batch_enqueues_normal_size_requests():
     requests = []
-    prefetcher = _stopped_prefetcher(lambda req: requests.append(req) or True)
+    prefetcher = _stopped_prefetcher(lambda req, prio: requests.append(req) or True)
 
     prefetcher._run_batch("deck", lambda: ["Lightning Bolt", "Ponder"])
 
@@ -35,7 +40,7 @@ def test_run_batch_enqueues_normal_size_requests():
 
 def test_run_batch_caps_at_batch_limit():
     requests = []
-    prefetcher = _stopped_prefetcher(lambda req: requests.append(req) or True, batch_limit=5)
+    prefetcher = _stopped_prefetcher(lambda req, prio: requests.append(req) or True, batch_limit=5)
 
     prefetcher._run_batch("search", lambda: [f"Card {i}" for i in range(50)])
 
@@ -44,7 +49,7 @@ def test_run_batch_caps_at_batch_limit():
 
 def test_run_batch_dedupes_within_and_across_batches():
     requests = []
-    prefetcher = _stopped_prefetcher(lambda req: requests.append(req) or True)
+    prefetcher = _stopped_prefetcher(lambda req, prio: requests.append(req) or True)
 
     prefetcher._run_batch("deck", lambda: ["Ponder", "ponder", "  Ponder  ", "Opt"])
     assert [req.card_name for req in requests] == ["Ponder", "Opt"]
@@ -56,7 +61,7 @@ def test_run_batch_dedupes_within_and_across_batches():
 
 def test_run_batch_skips_blank_names_and_tolerates_provider_errors():
     requests = []
-    prefetcher = _stopped_prefetcher(lambda req: requests.append(req) or True)
+    prefetcher = _stopped_prefetcher(lambda req, prio: requests.append(req) or True)
 
     prefetcher._run_batch("deck", lambda: ["", "   ", None, "Opt"])
     assert [req.card_name for req in requests] == ["Opt"]
@@ -71,7 +76,7 @@ def test_run_batch_skips_blank_names_and_tolerates_provider_errors():
 def test_run_batch_tolerates_enqueue_errors():
     calls = []
 
-    def _enqueue(request):
+    def _enqueue(request, priority):
         calls.append(request.card_name)
         if request.card_name == "Bad Card":
             raise RuntimeError("enqueue failed")
@@ -86,7 +91,7 @@ def test_prefetch_runs_batch_on_worker_thread():
     done = threading.Event()
     requests = []
 
-    def _enqueue(request):
+    def _enqueue(request, priority):
         requests.append(request)
         if len(requests) == 2:
             done.set()
@@ -101,16 +106,16 @@ def test_prefetch_runs_batch_on_worker_thread():
     assert sorted(req.card_name for req in requests) == ["Lightning Bolt", "Ponder"]
 
 
-def test_worker_idles_through_start_delay_and_stop_interrupts_it():
+def test_background_batches_idle_through_start_delay_and_stop_interrupts_it():
     requests = []
-    prefetcher = ImagePrefetcher(lambda req: requests.append(req) or True, start_delay=60.0)
+    prefetcher = ImagePrefetcher(lambda req, prio: requests.append(req) or True, start_delay=60.0)
     try:
-        prefetcher.prefetch("deck", ["Lightning Bolt"])
+        prefetcher.prefetch("warmup", ["Lightning Bolt"], priority=PRIORITY_BACKGROUND)
         time.sleep(0.2)
-        # Still inside the start delay: the submission is held, not run.
+        # Still inside the start delay: the background submission is held.
         assert requests == []
         with prefetcher._condition:
-            assert "deck" in prefetcher._pending
+            assert "warmup" in prefetcher._pending
     finally:
         started = time.monotonic()
         prefetcher.stop()
@@ -118,9 +123,68 @@ def test_worker_idles_through_start_delay_and_stop_interrupts_it():
         assert time.monotonic() - started < 5.0
 
 
+def test_user_driven_batch_bypasses_start_delay():
+    """A selected-deck batch must run immediately, even during the delay."""
+    done = threading.Event()
+    prefetcher = ImagePrefetcher(
+        lambda req, prio: done.set() or True, start_delay=60.0
+    )
+    try:
+        prefetcher.prefetch("deck", ["Lightning Bolt"], priority=PRIORITY_SELECTED_DECK)
+        assert done.wait(timeout=5.0), "user-driven batch was held by the start delay"
+    finally:
+        prefetcher.stop()
+
+
+def test_most_urgent_pending_source_runs_first():
+    """With several sources pending, the lowest-priority-value one runs first."""
+    order = []
+    prefetcher = _stopped_prefetcher(lambda req, prio: order.append((req.card_name, prio)) or True)
+    prefetcher._background_deadline = 0.0  # grace delay already elapsed
+    with prefetcher._condition:
+        prefetcher.prefetch("search", ["Opt"], priority=PRIORITY_RESEARCH_VISIBLE)
+        prefetcher.prefetch("deck", ["Ponder"], priority=PRIORITY_SELECTED_DECK)
+    for _ in range(2):
+        with prefetcher._condition:
+            source, (priority, provider, on_batch) = prefetcher._next_batch_locked()
+        prefetcher._run_batch(source, provider, priority=priority, on_batch=on_batch)
+    assert order == [("Ponder", PRIORITY_SELECTED_DECK), ("Opt", PRIORITY_RESEARCH_VISIBLE)]
+
+
+def test_submitted_name_resubmitted_at_better_tier_only():
+    """A name fed at a background tier re-enqueues at a better tier (promotion),
+    but never again at the same or a worse tier."""
+    calls = []
+    prefetcher = _stopped_prefetcher(lambda req, prio: calls.append((req.card_name, prio)) or True)
+
+    prefetcher._run_batch("warmup", lambda: ["Ponder"], priority=PRIORITY_BACKGROUND)
+    prefetcher._run_batch("warmup", lambda: ["Ponder"], priority=PRIORITY_BACKGROUND)
+    prefetcher._run_batch("deck", lambda: ["Ponder"], priority=PRIORITY_SELECTED_DECK)
+    prefetcher._run_batch("deck", lambda: ["Ponder"], priority=PRIORITY_SELECTED_DECK)
+
+    assert calls == [
+        ("Ponder", PRIORITY_BACKGROUND),
+        ("Ponder", PRIORITY_SELECTED_DECK),
+    ]
+
+
+def test_on_batch_reports_enqueued_and_skipped():
+    outcomes = []
+    prefetcher = _stopped_prefetcher(lambda req, prio: req.card_name == "Ponder")
+
+    prefetcher._run_batch(
+        "deck",
+        lambda: ["Ponder", "Opt"],
+        priority=PRIORITY_SELECTED_DECK,
+        on_batch=lambda source, enqueued, skipped: outcomes.append((source, enqueued, skipped)),
+    )
+
+    assert outcomes == [("deck", ["Ponder"], ["Opt"])]
+
+
 def test_prefetch_after_stop_is_a_noop():
     requests = []
-    prefetcher = ImagePrefetcher(lambda req: requests.append(req) or True)
+    prefetcher = ImagePrefetcher(lambda req, prio: requests.append(req) or True)
     prefetcher.stop()
 
     prefetcher.prefetch("deck", ["Lightning Bolt"])

--- a/tests/test_image_prefetcher.py
+++ b/tests/test_image_prefetcher.py
@@ -126,9 +126,7 @@ def test_background_batches_idle_through_start_delay_and_stop_interrupts_it():
 def test_user_driven_batch_bypasses_start_delay():
     """A selected-deck batch must run immediately, even during the delay."""
     done = threading.Event()
-    prefetcher = ImagePrefetcher(
-        lambda req, prio: done.set() or True, start_delay=60.0
-    )
+    prefetcher = ImagePrefetcher(lambda req, prio: done.set() or True, start_delay=60.0)
     try:
         prefetcher.prefetch("deck", ["Lightning Bolt"], priority=PRIORITY_SELECTED_DECK)
         assert done.wait(timeout=5.0), "user-driven batch was held by the start delay"

--- a/tests/test_image_prefetcher.py
+++ b/tests/test_image_prefetcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 
 from services.image_service.prefetcher import ImagePrefetcher
 
@@ -91,13 +92,30 @@ def test_prefetch_runs_batch_on_worker_thread():
             done.set()
         return True
 
-    prefetcher = ImagePrefetcher(_enqueue)
+    prefetcher = ImagePrefetcher(_enqueue, start_delay=0.0)
     try:
         prefetcher.prefetch("deck", ["Lightning Bolt", "Ponder"])
         assert done.wait(timeout=5.0), "prefetch batch never ran"
     finally:
         prefetcher.stop()
     assert sorted(req.card_name for req in requests) == ["Lightning Bolt", "Ponder"]
+
+
+def test_worker_idles_through_start_delay_and_stop_interrupts_it():
+    requests = []
+    prefetcher = ImagePrefetcher(lambda req: requests.append(req) or True, start_delay=60.0)
+    try:
+        prefetcher.prefetch("deck", ["Lightning Bolt"])
+        time.sleep(0.2)
+        # Still inside the start delay: the submission is held, not run.
+        assert requests == []
+        with prefetcher._condition:
+            assert "deck" in prefetcher._pending
+    finally:
+        started = time.monotonic()
+        prefetcher.stop()
+        # stop() must interrupt the start delay rather than wait it out.
+        assert time.monotonic() - started < 5.0
 
 
 def test_prefetch_after_stop_is_a_noop():

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -395,20 +395,27 @@ def test_image_service_prefetch_delegates_to_prefetcher(image_service_instance):
     received = []
 
     class _FakePrefetcher:
-        def prefetch(self, source, names):
-            received.append(("eager", source, list(names)))
+        def prefetch(self, source, names, *, priority=None, on_batch=None):
+            received.append(("eager", source, list(names), priority))
 
-        def prefetch_lazy(self, source, provider):
-            received.append(("lazy", source, provider))
+        def prefetch_lazy(self, source, provider, *, priority=None, on_batch=None):
+            received.append(("lazy", source, provider, priority))
 
         def stop(self, timeout=None):
             pass
 
+    from services.image_service.priorities import PRIORITY_RESEARCH_VISIBLE, PRIORITY_SELECTED_DECK
+
     image_service_instance._prefetcher = _FakePrefetcher()
-    image_service_instance.prefetch_card_images("deck", ["Ponder"])
+    image_service_instance.prefetch_card_images("deck", ["Ponder"], priority=PRIORITY_SELECTED_DECK)
     provider = lambda: ["Opt"]  # noqa: E731
-    image_service_instance.prefetch_card_images_lazy("research", provider)
-    assert received == [("eager", "deck", ["Ponder"]), ("lazy", "research", provider)]
+    image_service_instance.prefetch_card_images_lazy(
+        "research", provider, priority=PRIORITY_RESEARCH_VISIBLE
+    )
+    assert received == [
+        ("eager", "deck", ["Ponder"], PRIORITY_SELECTED_DECK),
+        ("lazy", "research", provider, PRIORITY_RESEARCH_VISIBLE),
+    ]
 
 
 def test_enqueue_uuid_miss_falls_back_to_name_set_cache_check():
@@ -592,6 +599,71 @@ def test_request_queue_key_distinguishes_name_only_requests():
     assert bolt.queue_key() != ponder.queue_key()
     # The same card requested twice still dedupes (case-insensitive).
     assert bolt.queue_key() == _request(card_name="lightning bolt", set_code=None).queue_key()
+
+
+def test_enqueue_priority_tiers_drain_most_urgent_first():
+    """Selected-deck requests pop before background warm-up requests that
+    were enqueued earlier, and FIFO order holds within a tier."""
+    from services.image_service.priorities import (
+        PRIORITY_BACKGROUND,
+        PRIORITY_SELECTED_DECK,
+    )
+
+    queue = _build_queue()
+    try:
+        queue.stop()
+        queue.enqueue(_request(card_name="Warmup A", set_code=None), priority=PRIORITY_BACKGROUND)
+        queue.enqueue(_request(card_name="Warmup B", set_code=None), priority=PRIORITY_BACKGROUND)
+        queue.enqueue(_request(card_name="Deck 1", set_code=None), priority=PRIORITY_SELECTED_DECK)
+        queue.enqueue(_request(card_name="Deck 2", set_code=None), priority=PRIORITY_SELECTED_DECK)
+        with queue._condition:
+            popped = [queue._pop_next_locked().card_name for _ in range(4)]
+        assert popped == ["Deck 1", "Deck 2", "Warmup A", "Warmup B"]
+    finally:
+        queue.stop()
+
+
+def test_enqueue_promotes_pending_request_to_better_tier():
+    """Re-enqueueing a pending background request at a better tier moves it
+    (no duplicate); re-enqueueing at the same or a worse tier is a no-op."""
+    from services.image_service.priorities import (
+        PRIORITY_BACKGROUND,
+        PRIORITY_SELECTED_DECK,
+    )
+
+    queue = _build_queue()
+    try:
+        queue.stop()
+        request = _request(card_name="Ponder", set_code=None)
+        assert queue.enqueue(request, priority=PRIORITY_BACKGROUND) is True
+        # Same tier again: duplicate, dropped.
+        assert queue.enqueue(request, priority=PRIORITY_BACKGROUND) is False
+        # Better tier: promoted in place.
+        assert queue.enqueue(request, priority=PRIORITY_SELECTED_DECK) is True
+        with queue._condition:
+            assert len(queue._queue) == 1
+            assert queue._pending_priorities[request.queue_key()] == PRIORITY_SELECTED_DECK
+        # Worse tier afterwards: dropped, stays promoted.
+        assert queue.enqueue(request, priority=PRIORITY_BACKGROUND) is False
+        with queue._condition:
+            assert queue._pending_priorities[request.queue_key()] == PRIORITY_SELECTED_DECK
+    finally:
+        queue.stop()
+
+
+def test_enqueue_prioritize_beats_selected_deck_tier():
+    """The hover path (prioritize=True) still jumps ahead of everything."""
+    from services.image_service.priorities import PRIORITY_SELECTED_DECK
+
+    queue = _build_queue()
+    try:
+        queue.stop()
+        queue.enqueue(_request(card_name="Deck 1", set_code=None), priority=PRIORITY_SELECTED_DECK)
+        queue.enqueue(_request(card_name="Hovered", set_code=None), prioritize=True)
+        with queue._condition:
+            assert queue._queue[0].card_name == "Hovered"
+    finally:
+        queue.stop()
 
 
 def test_enqueue_name_only_batch_keeps_every_card():

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -112,10 +112,12 @@ def test_is_loading_when_loading(image_service_instance):
 
 
 class _FakeCache:
-    def __init__(self, cached_keys=None):
+    def __init__(self, cached_keys=None, cached_uuids=None):
         # Set of (card_name, set_code, size) / (card_name, size) tuples to
         # report as already cached.
         self._cached_keys = set(cached_keys or ())
+        # Set of (uuid, size) tuples reported cached by is_cached().
+        self._cached_uuids = set(cached_uuids or ())
 
     def get_image_path_for_printing(self, card_name, set_code, size):
         if (card_name, set_code, size) in self._cached_keys:
@@ -127,14 +129,19 @@ class _FakeCache:
             return "path"
         return None
 
+    def is_cached(self, uuid, size="normal", face_index=0):
+        return (uuid, size) in self._cached_uuids
+
 
 class _FakeDownloader:
     def __init__(self, responses):
         self._responses = list(responses)
         self.calls = 0
+        self.uuids: list[str | None] = []
 
-    def download_card_image_by_name(self, name, size, set_code=None):
+    def download_card_image_by_name(self, name, size, set_code=None, uuid=None):
         self.calls += 1
+        self.uuids.append(uuid)
         response = self._responses[self.calls - 1]
         if isinstance(response, Exception):
             raise response
@@ -351,6 +358,66 @@ def test_enqueue_already_cached_returns_false():
         assert queue.enqueue(_request()) is False
         with queue._condition:
             assert len(queue._queue) == 0
+    finally:
+        queue.stop()
+
+
+def test_download_request_passes_uuid_through_to_downloader():
+    """The queue must not discard the printing uuid the inspector selected.
+
+    Resolving purely by name+set can pick a different printing than the one
+    displayed, so the uuid travels with the request (issue #951).
+    """
+    downloader = _FakeDownloader([(True, "ok")])
+    queue = _build_queue(downloader)
+    try:
+        assert queue._download_request(_request(uuid="u-123")) is True
+    finally:
+        queue.stop()
+    assert downloader.uuids == ["u-123"]
+
+
+def test_enqueue_uuid_cached_returns_false():
+    """A request whose exact printing is cached by uuid is skipped, even when
+    the name/set lookup would miss it (split cards are stored under their
+    combined name)."""
+    cache = _FakeCache(cached_uuids={("u-prepare", "normal")})
+    queue = _build_queue(cache=cache)
+    try:
+        assert queue.enqueue(_request(card_name="Emeritus of Conflict", uuid="u-prepare")) is False
+        with queue._condition:
+            assert len(queue._queue) == 0
+    finally:
+        queue.stop()
+
+
+def test_image_service_prefetch_delegates_to_prefetcher(image_service_instance):
+    received = []
+
+    class _FakePrefetcher:
+        def prefetch(self, source, names):
+            received.append(("eager", source, list(names)))
+
+        def prefetch_lazy(self, source, provider):
+            received.append(("lazy", source, provider))
+
+        def stop(self, timeout=None):
+            pass
+
+    image_service_instance._prefetcher = _FakePrefetcher()
+    image_service_instance.prefetch_card_images("deck", ["Ponder"])
+    provider = lambda: ["Opt"]  # noqa: E731
+    image_service_instance.prefetch_card_images_lazy("research", provider)
+    assert received == [("eager", "deck", ["Ponder"]), ("lazy", "research", provider)]
+
+
+def test_enqueue_uuid_miss_falls_back_to_name_set_cache_check():
+    """A uuid miss still honours a name+set cache hit (stale-bulk resolution
+    may have stored the printing under a different uuid)."""
+    cache = _FakeCache(cached_keys={("Mirrorpool", "aeoe", "normal")})
+    queue = _build_queue(cache=cache)
+    try:
+        assert queue.enqueue(_request(uuid="u-other")) is False
     finally:
         queue.stop()
 

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -50,7 +50,9 @@ def image_service_instance():
     leak across the suite (the exact leaked-daemon-thread scenario that has
     crashed CI at interpreter shutdown).
     """
-    service = ImageService()
+    # warm_image_index=False: the eager bulk-index build is a ~2s parse of the
+    # real on-disk bulk data — pure overhead for unit tests.
+    service = ImageService(warm_image_index=False)
     try:
         yield service
     finally:

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -574,10 +574,40 @@ def test_request_queue_key_uses_uuid_when_present():
     with_uuid = _request(uuid="ABC-123", set_code="aaa", collector_number="7")
     other_set = _request(uuid="ABC-123", set_code="bbb", collector_number="9")
     # Same uuid + size collapse to the same key regardless of set/collector.
-    assert with_uuid.queue_key() == ("uuid", "abc-123", "normal", "")
+    assert with_uuid.queue_key() == ("uuid", "abc-123", "normal", "", "")
     assert with_uuid.queue_key() == other_set.queue_key()
     # A differing size yields a distinct key.
     assert _request(uuid="ABC-123", size="large").queue_key() != with_uuid.queue_key()
+
+
+def test_request_queue_key_distinguishes_name_only_requests():
+    """Name-only requests (no uuid/set) must NOT share a queue key.
+
+    Prefetch and warm-up submit bare card names; when the key omitted the
+    name, an entire 100-card batch collapsed onto one key and the queue
+    dropped all but the first card as a duplicate (issue #951).
+    """
+    bolt = _request(card_name="Lightning Bolt", set_code=None)
+    ponder = _request(card_name="Ponder", set_code=None)
+    assert bolt.queue_key() != ponder.queue_key()
+    # The same card requested twice still dedupes (case-insensitive).
+    assert bolt.queue_key() == _request(card_name="lightning bolt", set_code=None).queue_key()
+
+
+def test_enqueue_name_only_batch_keeps_every_card():
+    """A batch of distinct name-only requests all make it into the queue."""
+    queue = _build_queue()
+    try:
+        queue.stop()
+        names = [f"Card {i}" for i in range(10)]
+        results = [
+            queue.enqueue(_request(card_name=name, set_code=None)) for name in names
+        ]
+        assert results == [True] * len(names)
+        with queue._condition:
+            assert len(queue._queue) == len(names)
+    finally:
+        queue.stop()
 
 
 def test_image_service_download_callback_dispatched(image_service_instance):

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -674,9 +674,7 @@ def test_enqueue_name_only_batch_keeps_every_card():
     try:
         queue.stop()
         names = [f"Card {i}" for i in range(10)]
-        results = [
-            queue.enqueue(_request(card_name=name, set_code=None)) for name in names
-        ]
+        results = [queue.enqueue(_request(card_name=name, set_code=None)) for name in names]
         assert results == [True] * len(names)
         with queue._condition:
             assert len(queue._queue) == len(names)

--- a/tests/test_metagame_repository.py
+++ b/tests/test_metagame_repository.py
@@ -551,6 +551,89 @@ def test_get_decks_recovers_from_corrupt_cache(
     assert cached["modern-living-end"]["items"] == fresh_decks
 
 
+def test_get_decks_empty_cached_list_falls_back_to_live_scrape(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """A fresh-but-empty cached deck list must not block the live scrape.
+
+    The remote bundle publishes empty MTGGoldfish deck lists for archetypes
+    whose recent results are MTGO-only; treating that [] as a cache hit made
+    every such archetype permanently show "No decks" (issue observed after the
+    scrapes-repo restructure).
+    """
+    repo = MetagameRepository(
+        cache_ttl=3600,
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    _write_cache(
+        archetype_deck_cache_file,
+        {"modern-4c-hollowone": {"timestamp": time.time(), "items": []}},
+    )
+    fresh_decks = [{"name": "4c HollowOne", "date": "2026-07-24", "source": "mtggoldfish"}]
+    monkeypatch.setattr(
+        "repositories.metagame_repository.get_archetype_decks", lambda _href: fresh_decks
+    )
+
+    result = repo.get_decks_for_archetype({"href": "modern-4c-hollowone", "name": "4c HollowOne"})
+
+    assert result == fresh_decks
+    cached = json.loads(archetype_deck_cache_file.read_text(encoding="utf-8"))
+    assert cached["modern-4c-hollowone"]["items"] == fresh_decks
+
+
+def test_get_decks_empty_cached_list_scrape_failure_returns_empty(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """If the fallback scrape fails, a stale empty list renders as "no decks"
+    rather than surfacing an error dialog."""
+    repo = MetagameRepository(
+        cache_ttl=3600,
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    _write_cache(
+        archetype_deck_cache_file,
+        {"modern-4c-hollowone": {"timestamp": time.time(), "items": []}},
+    )
+
+    def _boom(_href):
+        raise RuntimeError("goldfish unreachable")
+
+    monkeypatch.setattr("repositories.metagame_repository.get_archetype_decks", _boom)
+
+    result = repo.get_decks_for_archetype({"href": "modern-4c-hollowone", "name": "4c HollowOne"})
+
+    assert result == []
+
+
+def test_get_decks_empty_cache_preserves_bundle_mtgo_entries(
+    archetype_cache_file, archetype_deck_cache_file, monkeypatch
+):
+    """A live refresh triggered by the empty-goldfish fallback must keep the
+    MTGO decks the bundle merged into the same cache entry."""
+    repo = MetagameRepository(
+        cache_ttl=3600,
+        archetype_list_cache_file=archetype_cache_file,
+        archetype_decks_cache_file=archetype_deck_cache_file,
+    )
+    mtgo_deck = {"name": "Ruby Storm", "number": "1", "date": "2026-07-24", "source": "mtgo"}
+    _write_cache(
+        archetype_deck_cache_file,
+        {"modern-ruby-storm": {"timestamp": time.time() - 7200, "items": [mtgo_deck]}},
+    )
+    fresh_decks = [
+        {"name": "Ruby Storm", "number": "2", "date": "2026-07-23", "source": "mtggoldfish"}
+    ]
+    monkeypatch.setattr(
+        "repositories.metagame_repository.get_archetype_decks", lambda _href: fresh_decks
+    )
+    # cache_ttl=3600 and the entry is 2h old -> expired -> live scrape path.
+    result = repo.get_decks_for_archetype({"href": "modern-ruby-storm", "name": "Ruby Storm"})
+
+    assert mtgo_deck in result and fresh_decks[0] in result
+
+
 # ============= Deck Date Parsing and Sorting Tests =============
 
 

--- a/utils/constants/timing.py
+++ b/utils/constants/timing.py
@@ -126,6 +126,14 @@ CACHE_WARMUP_PROGRESS_INTERVAL = 50
 IMAGE_PREFETCH_BATCH_LIMIT = 100  # max images enqueued per prefetch batch
 IMAGE_PREFETCH_IDLE_WAIT_SECONDS = 0.5  # condition wait timeout when no batches are queued
 IMAGE_PREFETCH_STOP_TIMEOUT_SECONDS = 2.0  # max seconds to wait for worker join on stop
+# The prefetch worker idles this long after startup before running its first
+# batch (mirrors CACHE_WARMUP_START_DELAY_SECONDS) so prefetch downloads never
+# compete with the initial archetype/deck/card-data loads or the first paint.
+IMAGE_PREFETCH_START_DELAY_SECONDS = 3.0
+# Downloaded-image UI refreshes are coalesced: completed downloads accumulate
+# and the deck tables repaint at most once per interval, so a mass download
+# (empty cache + warm-up) can never flood the UI event loop.
+IMAGE_REFRESH_COALESCE_MS = 250
 # Card search results: prefetch everything visible plus this many rows past the
 # bottom, so a small scroll still hits already-local images…
 SEARCH_PREFETCH_LOOKAHEAD_CARDS = 20

--- a/utils/constants/timing.py
+++ b/utils/constants/timing.py
@@ -119,6 +119,23 @@ CACHE_WARMUP_DEEP_PASS_MAX_DECKS = 150
 # without logging every individual fetch.
 CACHE_WARMUP_PROGRESS_INTERVAL = 50
 
+# Predictive card-image prefetch (issue #951) — UI surfaces submit the cards a
+# user is likely to look at next (loaded deck zones, top visible research
+# decks, the visible window of the card search) and a background worker feeds
+# them through the shared download queue in bounded batches.
+IMAGE_PREFETCH_BATCH_LIMIT = 100  # max images enqueued per prefetch batch
+IMAGE_PREFETCH_IDLE_WAIT_SECONDS = 0.5  # condition wait timeout when no batches are queued
+IMAGE_PREFETCH_STOP_TIMEOUT_SECONDS = 2.0  # max seconds to wait for worker join on stop
+# Card search results: prefetch everything visible plus this many rows past the
+# bottom, so a small scroll still hits already-local images…
+SEARCH_PREFETCH_LOOKAHEAD_CARDS = 20
+# …and always at least this many rows even when fewer are visible.
+SEARCH_PREFETCH_MIN_CARDS = 30
+SEARCH_PREFETCH_DEBOUNCE_MS = 250  # settle time after scroll/search before prefetching
+# Deck research: prefetch the card images of this many decks from the top of
+# the (filtered) results list — the decks the user is most likely to click.
+RESEARCH_PREFETCH_DECK_COUNT = 3
+
 # Card image download queue — retry and timing configuration
 IMAGE_DOWNLOAD_QUEUE_STOP_TIMEOUT_SECONDS = (
     2.0  # max seconds to wait for queue thread to join on stop

--- a/utils/constants/timing.py
+++ b/utils/constants/timing.py
@@ -126,9 +126,11 @@ CACHE_WARMUP_PROGRESS_INTERVAL = 50
 IMAGE_PREFETCH_BATCH_LIMIT = 100  # max images enqueued per prefetch batch
 IMAGE_PREFETCH_IDLE_WAIT_SECONDS = 0.5  # condition wait timeout when no batches are queued
 IMAGE_PREFETCH_STOP_TIMEOUT_SECONDS = 2.0  # max seconds to wait for worker join on stop
-# The prefetch worker idles this long after startup before running its first
-# batch (mirrors CACHE_WARMUP_START_DELAY_SECONDS) so prefetch downloads never
-# compete with the initial archetype/deck/card-data loads or the first paint.
+# Background-tier prefetch batches idle this long after startup (mirrors
+# CACHE_WARMUP_START_DELAY_SECONDS) so speculative downloads never compete
+# with the initial archetype/deck/card-data loads or the first paint.
+# User-driven batches (the selected deck, visible research decks) bypass the
+# delay — those are the images the user is waiting on right now.
 IMAGE_PREFETCH_START_DELAY_SECONDS = 3.0
 # Downloaded-image UI refreshes are coalesced: completed downloads accumulate
 # and the deck tables repaint at most once per interval, so a mass download

--- a/utils/i18n/_en_us/toolbar.py
+++ b/utils/i18n/_en_us/toolbar.py
@@ -9,7 +9,7 @@ MESSAGES: dict[str, str] = {
     "toolbar.radar": "Radar",
     "toolbar.settings": "Settings",
     "toolbar.load_collection": "Load Collection",
-    "toolbar.download_card_images": "Download Card Images",
+    "toolbar.download_card_images": "Enable Offline Images Mode",
     "toolbar.update_card_database": "Update Card Database",
     "toolbar.export_diagnostics": "Export Diagnostics",
     "toolbar.show_tutorial": "Show Tutorial",

--- a/utils/i18n/_pt_br/toolbar.py
+++ b/utils/i18n/_pt_br/toolbar.py
@@ -9,7 +9,7 @@ MESSAGES: dict[str, str] = {
     "toolbar.radar": "Radar",
     "toolbar.settings": "Configurações",
     "toolbar.load_collection": "Carregar Coleção",
-    "toolbar.download_card_images": "Baixar Imagens de Cartas",
+    "toolbar.download_card_images": "Ativar Modo de Imagens Offline",
     "toolbar.update_card_database": "Atualizar Banco de Cartas",
     "toolbar.export_diagnostics": "Exportar Diagnóstico",
     "toolbar.show_tutorial": "Mostrar Tutorial",

--- a/widgets/dialogs/image_download_dialog/dialog.py
+++ b/widgets/dialogs/image_download_dialog/dialog.py
@@ -1,4 +1,4 @@
-"""Dialog for downloading card images from Scryfall with progress tracking."""
+"""Dialog for enabling offline images mode (bulk card-image download)."""
 
 from __future__ import annotations
 
@@ -19,22 +19,14 @@ if TYPE_CHECKING:
 class ImageDownloadDialog(
     ImageDownloadDialogHandlersMixin, ImageDownloadDialogPropertiesMixin, wx.Dialog
 ):
-    """Dialog for configuring and executing bulk card image downloads."""
+    """Explains offline images mode and confirms the one-time bulk download.
 
-    QUALITY_OPTIONS = [
-        "Small (146x204, ~100KB/card, ~8GB total)",
-        "Normal (488x680, ~300KB/card, ~25GB total)",
-        "Large (672x936, ~500KB/card, ~40GB total)",
-        "PNG (745x1040, ~700KB/card, ~55GB total)",
-    ]
-
-    AMOUNT_OPTIONS = [
-        "Test mode (first 100 cards)",
-        "First 1,000 cards",
-        "First 5,000 cards",
-        "First 10,000 cards",
-        "All cards (~80,000+)",
-    ]
+    The app works without this: images are prefetched in the background and
+    fetched on demand as cards are browsed (issue #951). Enabling offline mode
+    trades ~12 GB of disk for having *every* card image local, so nothing ever
+    needs the network again. Only the medium ("normal") Scryfall size is
+    downloaded — it reads well on both low- and high-resolution monitors.
+    """
 
     def __init__(
         self,
@@ -44,7 +36,7 @@ class ImageDownloadDialog(
         bulk_data_cache_path: Path,
         on_status_update: Callable[[str], None] | None = None,
     ):
-        super().__init__(parent, title="Download Card Images", size=(450, 320))
+        super().__init__(parent, title="Offline Images Mode", size=(460, 320))
         self.SetBackgroundColour(DARK_BG)
 
         self.image_cache = image_cache
@@ -61,7 +53,7 @@ class ImageDownloadDialog(
         panel.SetSizer(sizer)
 
         # Title
-        title = wx.StaticText(panel, label="Download Card Images from Scryfall")
+        title = wx.StaticText(panel, label="Enable Offline Images Mode")
         title.SetForegroundColour(LIGHT_TEXT)
         title_font = title.GetFont()
         title_font.PointSize += 2
@@ -69,36 +61,35 @@ class ImageDownloadDialog(
         title.SetFont(title_font)
         sizer.Add(title, 0, wx.ALL, 10)
 
-        # Image quality selection
-        quality_label = wx.StaticText(panel, label="Image Quality:")
-        quality_label.SetForegroundColour(LIGHT_TEXT)
-        sizer.Add(quality_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
-
-        self.quality_choice = wx.Choice(panel, choices=self.QUALITY_OPTIONS)
-        self.quality_choice.SetSelection(1)  # Default to Normal
-        sizer.Add(self.quality_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
-
-        # Download amount selection
-        amount_label = wx.StaticText(panel, label="Download Amount:")
-        amount_label.SetForegroundColour(LIGHT_TEXT)
-        sizer.Add(amount_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
-
-        self.amount_choice = wx.Choice(panel, choices=self.AMOUNT_OPTIONS)
-        self.amount_choice.SetSelection(0)  # Default to Test mode
-        sizer.Add(self.amount_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
-
-        # Info text
-        info_text = wx.StaticText(
+        # What this is for
+        purpose_text = wx.StaticText(
             panel,
             label=(
-                "Note: Images are downloaded from Scryfall's CDN (no rate limits).\n"
-                "This may take 30-60 minutes for all cards depending on your connection.\n"
-                "You can use the app while downloading."
+                "Normally, card images are fetched over the internet as you browse — "
+                "the app predicts what you are about to look at and downloads those "
+                "images a few seconds ahead of you.\n\n"
+                "Offline images mode instead downloads a medium-quality image for every "
+                "Magic card (100,000+ images) up front, so every card displays instantly "
+                "and keeps working with no internet connection at all."
             ),
         )
-        info_text.SetForegroundColour(SUBDUED_TEXT)
-        info_text.Wrap(420)
-        sizer.Add(info_text, 0, wx.ALL, 10)
+        purpose_text.SetForegroundColour(LIGHT_TEXT)
+        purpose_text.Wrap(430)
+        sizer.Add(purpose_text, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+
+        # The tradeoff
+        tradeoff_text = wx.StaticText(
+            panel,
+            label=(
+                "Tradeoff: this uses about 12.2 GB of disk space. The download runs in "
+                "the background and typically takes 30-60 minutes depending on your "
+                "connection; you can keep using the app while it runs. If it is "
+                "interrupted, enabling it again skips the images you already have."
+            ),
+        )
+        tradeoff_text.SetForegroundColour(SUBDUED_TEXT)
+        tradeoff_text.Wrap(430)
+        sizer.Add(tradeoff_text, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         # Buttons
         button_sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -107,9 +98,9 @@ class ImageDownloadDialog(
         cancel_btn = wx.Button(panel, wx.ID_CANCEL, label="Cancel")
         button_sizer.Add(cancel_btn, 0, wx.RIGHT, 6)
 
-        download_btn = wx.Button(panel, wx.ID_OK, label="Download")
-        download_btn.SetDefault()
-        button_sizer.Add(download_btn, 0)
+        enable_btn = wx.Button(panel, wx.ID_OK, label="Enable Offline Mode")
+        enable_btn.SetDefault()
+        button_sizer.Add(enable_btn, 0)
 
         sizer.Add(button_sizer, 0, wx.EXPAND | wx.ALL, 10)
 

--- a/widgets/dialogs/image_download_dialog/properties.py
+++ b/widgets/dialogs/image_download_dialog/properties.py
@@ -1,21 +1,13 @@
-"""Selection accessors for the image download dialog."""
+"""Selection accessors for the offline images mode dialog."""
 
 from __future__ import annotations
-
-import wx
 
 
 class ImageDownloadDialogPropertiesMixin:
     """Option accessors for :class:`ImageDownloadDialog`."""
 
-    quality_choice: wx.Choice
-    amount_choice: wx.Choice
-
     def get_selected_options(self) -> tuple[str, int | None]:
-        quality_map = {0: "small", 1: "normal", 2: "large", 3: "png"}
-        quality = quality_map[self.quality_choice.GetSelection()]
-
-        amount_map = {0: 100, 1: 1000, 2: 5000, 3: 10000, 4: None}
-        max_cards = amount_map[self.amount_choice.GetSelection()]
-
-        return quality, max_cards
+        # Offline images mode is deliberately choice-free: always the medium
+        # ("normal") Scryfall size — good enough on low- and high-res monitors —
+        # and always the full card set (issue #951).
+        return "normal", None

--- a/widgets/frames/app_frame/frame/__init__.py
+++ b/widgets/frames/app_frame/frame/__init__.py
@@ -144,6 +144,10 @@ class AppFrame(
 
         self._save_timer: wx.Timer | None = None
         self._filter_debounce_timer: wx.Timer | None = None
+        # Coalesced downloaded-image refreshes: completed downloads accumulate
+        # here and the deck tables repaint in one pass per timer tick.
+        self._pending_image_refresh_names: set[str] = set()
+        self._image_refresh_timer: wx.Timer | None = None
         self.mana_icons = ManaIconFactory()
         self.tracker_window: MTGOpponentDeckSpy | None = None
         self.timer_window: TimerAlertFrame | None = None

--- a/widgets/frames/app_frame/frame/__init__.py
+++ b/widgets/frames/app_frame/frame/__init__.py
@@ -148,6 +148,10 @@ class AppFrame(
         # here and the deck tables repaint in one pass per timer tick.
         self._pending_image_refresh_names: set[str] = set()
         self._image_refresh_timer: wx.Timer | None = None
+        # PERF tracking (issue #951): deck-load → all-deck-images-local timing.
+        # Set when a deck's zone prefetch is submitted; cleared when the last
+        # of its images lands (or replaced by the next deck load).
+        self._deck_image_perf: dict[str, Any] | None = None
         self.mana_icons = ManaIconFactory()
         self.tracker_window: MTGOpponentDeckSpy | None = None
         self.timer_window: TimerAlertFrame | None = None

--- a/widgets/frames/app_frame/frame/left_panel.py
+++ b/widgets/frames/app_frame/frame/left_panel.py
@@ -97,6 +97,9 @@ class LeftPanelBuilderMixin(_Base):
             on_add_to_main=lambda name, count=1: self._handle_zone_delta("main", name, count),
             on_add_to_side=lambda name, count=1: self._handle_zone_delta("side", name, count),
             on_add_to_active_zone=self._add_search_card_to_active_zone,
+            on_prefetch_images=lambda names: self.controller.image_service.prefetch_card_images(
+                "search", names
+            ),
             locale=self.locale,
         )
         self.left_stack.AddPage(self.builder_panel, self._t("app.label.left_panel.builder"))

--- a/widgets/frames/app_frame/frame/left_panel.py
+++ b/widgets/frames/app_frame/frame/left_panel.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import wx
 
+from services.image_service.priorities import PRIORITY_RESEARCH_VISIBLE
 from utils.constants import DARK_PANEL, FORMAT_OPTIONS
 from utils.perf import timed
 from widgets.panels.deck_builder_panel import DeckBuilderPanel
@@ -98,7 +99,7 @@ class LeftPanelBuilderMixin(_Base):
             on_add_to_side=lambda name, count=1: self._handle_zone_delta("side", name, count),
             on_add_to_active_zone=self._add_search_card_to_active_zone,
             on_prefetch_images=lambda names: self.controller.image_service.prefetch_card_images(
-                "search", names
+                "search", names, priority=PRIORITY_RESEARCH_VISIBLE
             ),
             locale=self.locale,
         )

--- a/widgets/frames/app_frame/frame/right_panel.py
+++ b/widgets/frames/app_frame/frame/right_panel.py
@@ -82,6 +82,9 @@ class RightPanelBuilderMixin(_Base):
             self.controller.image_service.fetch_printings_by_name_async
         )
         self.controller.image_service.set_image_download_callback(self._handle_image_downloaded)
+        self.controller.image_service.set_image_download_failed_callback(
+            self._handle_image_download_failed
+        )
         self.controller.image_service.set_printings_loaded_callback(
             self.card_inspector_panel.handle_printings_loaded
         )

--- a/widgets/frames/app_frame/handlers/app_frame.py
+++ b/widgets/frames/app_frame/handlers/app_frame.py
@@ -9,6 +9,7 @@ import wx
 from loguru import logger
 
 from utils.constants import APP_FRAME_MIN_SIZE, APP_FRAME_SIZE
+from utils.constants.timing import IMAGE_REFRESH_COALESCE_MS
 from utils.i18n import LOCALE_LABELS
 from utils.runtime_flags import is_automation_enabled
 from widgets.dialogs.help_dialog import show_help
@@ -161,11 +162,28 @@ class AppFrameHandlersMixin(_Base):
         self._schedule_settings_save()
 
     def _handle_image_downloaded(self, request: CardImageRequest) -> None:
+        # The inspector update is cheap (a no-op unless the download matches
+        # the card currently shown) and hover latency matters, so it stays
+        # immediate. The table refreshes are coalesced: a mass download (empty
+        # cache + warm-up/prefetch) completes hundreds of images per minute,
+        # and repainting per image floods the UI event loop enough to make the
+        # app unusable until the downloads drain.
         self.card_inspector_panel.handle_image_downloaded(request)
-        self.main_table.refresh_card_image(request.card_name)
-        self.side_table.refresh_card_image(request.card_name)
-        if self.out_table:
-            self.out_table.refresh_card_image(request.card_name)
+        self._pending_image_refresh_names.add(request.card_name)
+        if self._image_refresh_timer is None:
+            self._image_refresh_timer = wx.Timer(self)
+            self.Bind(wx.EVT_TIMER, self._flush_image_refreshes, self._image_refresh_timer)
+        if not self._image_refresh_timer.IsRunning():
+            self._image_refresh_timer.StartOnce(IMAGE_REFRESH_COALESCE_MS)
+
+    def _flush_image_refreshes(self, _event: wx.TimerEvent | None = None) -> None:
+        names = self._pending_image_refresh_names
+        self._pending_image_refresh_names = set()
+        for name in names:
+            self.main_table.refresh_card_image(name)
+            self.side_table.refresh_card_image(name)
+            if self.out_table:
+                self.out_table.refresh_card_image(name)
 
     def _prefetch_deck_zone_images(self) -> None:
         """Queue image downloads for every card in the loaded deck's zones.

--- a/widgets/frames/app_frame/handlers/app_frame.py
+++ b/widgets/frames/app_frame/handlers/app_frame.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -170,12 +171,18 @@ class AppFrameHandlersMixin(_Base):
         # and repainting per image floods the UI event loop enough to make the
         # app unusable until the downloads drain.
         self.card_inspector_panel.handle_image_downloaded(request)
+        self._note_deck_image_progress(request.card_name)
         self._pending_image_refresh_names.add(request.card_name)
         if self._image_refresh_timer is None:
             self._image_refresh_timer = wx.Timer(self)
             self.Bind(wx.EVT_TIMER, self._flush_image_refreshes, self._image_refresh_timer)
         if not self._image_refresh_timer.IsRunning():
             self._image_refresh_timer.StartOnce(IMAGE_REFRESH_COALESCE_MS)
+
+    def _handle_image_download_failed(self, request: CardImageRequest, message: str) -> None:
+        # Keep the perf tracker honest: a failed download still resolves the
+        # name, otherwise one 404 would leave the deck timer dangling forever.
+        self._note_deck_image_progress(request.card_name, failed=True)
 
     def _flush_image_refreshes(self, _event: wx.TimerEvent | None = None) -> None:
         names = self._pending_image_refresh_names
@@ -199,9 +206,76 @@ class AppFrameHandlersMixin(_Base):
             for card in self.zone_cards.get(zone) or []
         ]
         if names:
+            # PERF: t0 for the deck-load → all-images-local interval. The
+            # previous deck's tracker (if unfinished) is superseded here.
+            perf = self._deck_image_perf
+            if perf and perf.get("pending"):
+                logger.info(
+                    "PERF | deck images superseded with {} of {} still pending",
+                    len(perf["pending"]),
+                    perf.get("enqueued", 0),
+                )
+            self._deck_image_perf = {
+                "t0": time.perf_counter(),
+                "total_names": len({name.lower() for name in names}),
+                "pending": None,  # filled by _on_deck_prefetch_batch
+                "enqueued": 0,
+                "failed": 0,
+            }
             self.controller.image_service.prefetch_card_images(
-                "deck", names, priority=PRIORITY_SELECTED_DECK
+                "deck",
+                names,
+                priority=PRIORITY_SELECTED_DECK,
+                on_batch=self._on_deck_prefetch_batch,
             )
+
+    def _on_deck_prefetch_batch(
+        self, source: str, enqueued: list[str], skipped: list[str]
+    ) -> None:
+        # Fires on the prefetcher worker thread; marshal to the UI thread.
+        wx.CallAfter(self._begin_deck_image_tracking, enqueued, skipped)
+
+    def _begin_deck_image_tracking(self, enqueued: list[str], skipped: list[str]) -> None:
+        perf = self._deck_image_perf
+        if perf is None:
+            return
+        perf["enqueued"] = len(enqueued)
+        perf["cached"] = len(skipped)
+        if not enqueued:
+            elapsed_ms = (time.perf_counter() - perf["t0"]) * 1000.0
+            logger.info(
+                "PERF | {:>7.1f} ms | === deck images all local "
+                "({} cards, 0 downloads needed) ===",
+                elapsed_ms,
+                perf["total_names"],
+            )
+            self._deck_image_perf = None
+            return
+        perf["pending"] = {name.lower() for name in enqueued}
+
+    def _note_deck_image_progress(self, card_name: str, *, failed: bool = False) -> None:
+        perf = self._deck_image_perf
+        if not perf or not perf.get("pending"):
+            return
+        key = (card_name or "").lower()
+        pending: set[str] = perf["pending"]
+        if key not in pending:
+            return
+        pending.discard(key)
+        if failed:
+            perf["failed"] += 1
+        if pending:
+            return
+        elapsed_ms = (time.perf_counter() - perf["t0"]) * 1000.0
+        logger.info(
+            "PERF | {:>7.1f} ms | === deck images all local "
+            "({} downloaded, {} already cached, {} failed) ===",
+            elapsed_ms,
+            perf["enqueued"] - perf["failed"],
+            perf.get("cached", 0),
+            perf["failed"],
+        )
+        self._deck_image_perf = None
 
     # ------------------------------------------------------------------ Left panel helpers -------------------------------------------------
     def _show_left_panel(self, mode: str, force: bool = False) -> None:

--- a/widgets/frames/app_frame/handlers/app_frame.py
+++ b/widgets/frames/app_frame/handlers/app_frame.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import wx
 from loguru import logger
 
+from services.image_service.priorities import PRIORITY_SELECTED_DECK
 from utils.constants import APP_FRAME_MIN_SIZE, APP_FRAME_SIZE
 from utils.constants.timing import IMAGE_REFRESH_COALESCE_MS
 from utils.i18n import LOCALE_LABELS
@@ -198,7 +199,9 @@ class AppFrameHandlersMixin(_Base):
             for card in self.zone_cards.get(zone) or []
         ]
         if names:
-            self.controller.image_service.prefetch_card_images("deck", names)
+            self.controller.image_service.prefetch_card_images(
+                "deck", names, priority=PRIORITY_SELECTED_DECK
+            )
 
     # ------------------------------------------------------------------ Left panel helpers -------------------------------------------------
     def _show_left_panel(self, mode: str, force: bool = False) -> None:

--- a/widgets/frames/app_frame/handlers/app_frame.py
+++ b/widgets/frames/app_frame/handlers/app_frame.py
@@ -229,9 +229,7 @@ class AppFrameHandlersMixin(_Base):
                 on_batch=self._on_deck_prefetch_batch,
             )
 
-    def _on_deck_prefetch_batch(
-        self, source: str, enqueued: list[str], skipped: list[str]
-    ) -> None:
+    def _on_deck_prefetch_batch(self, source: str, enqueued: list[str], skipped: list[str]) -> None:
         # Fires on the prefetcher worker thread; marshal to the UI thread.
         wx.CallAfter(self._begin_deck_image_tracking, enqueued, skipped)
 

--- a/widgets/frames/app_frame/handlers/app_frame.py
+++ b/widgets/frames/app_frame/handlers/app_frame.py
@@ -167,6 +167,21 @@ class AppFrameHandlersMixin(_Base):
         if self.out_table:
             self.out_table.refresh_card_image(request.card_name)
 
+    def _prefetch_deck_zone_images(self) -> None:
+        """Queue image downloads for every card in the loaded deck's zones.
+
+        The whole deck is "potentially visible" the moment it loads (grid view
+        shows art immediately; hover can land on any row), so batch-prefetch it
+        instead of waiting for per-card mouseover requests (issue #951).
+        """
+        names = [
+            card["name"]
+            for zone in ("main", "side", "out")
+            for card in self.zone_cards.get(zone) or []
+        ]
+        if names:
+            self.controller.image_service.prefetch_card_images("deck", names)
+
     # ------------------------------------------------------------------ Left panel helpers -------------------------------------------------
     def _show_left_panel(self, mode: str, force: bool = False) -> None:
         target = "builder" if mode == "builder" else "research"
@@ -424,6 +439,7 @@ class AppFrameHandlersMixin(_Base):
         self.side_table.set_cards(self.zone_cards["side"])
         if self.out_table:
             self.out_table.set_cards(self.zone_cards["out"])
+        self._prefetch_deck_zone_images()
         deck_text = self.controller.deck_repo.get_current_deck_text()
         if deck_text:
             self._update_stats(deck_text)

--- a/widgets/frames/app_frame/handlers/deck_content.py
+++ b/widgets/frames/app_frame/handlers/deck_content.py
@@ -234,6 +234,9 @@ class DeckContentHandlers(_Base):
             self.zone_cards["out"] = self._load_outboard_for_current()
         with perf_phase("main_table.set_cards"):
             self.main_table.set_cards(self.zone_cards["main"])
+        # Batch-prefetch every zone's images right away (runs on a background
+        # thread) so art streams in while the tables render (issue #951).
+        self._prefetch_deck_zone_images()
         # Defer the secondary zones to the next event-loop turn so the mainboard
         # — the zone the user is looking at — paints first. They fill in a frame
         # later, which removes their cost from the click-to-visible interval.

--- a/widgets/frames/app_frame/handlers/research.py
+++ b/widgets/frames/app_frame/handlers/research.py
@@ -131,7 +131,11 @@ class DeckResearchHandlers(_Base):
         show_source = self.controller.get_deck_data_source() == "both"
         rows = [
             (
-                (("🐠" if deck.get("source") == "mtggoldfish" else "🧙🏾‍♂️") if show_source else ""),
+                (
+                    ("🐠" if deck.get("source") == "mtggoldfish" else "🧙🏾‍♂️")
+                    if show_source
+                    else ""
+                ),
                 deck.get("player", "Unknown"),
                 slug_to_name.get(deck.get("name", ""), deck.get("name", "")),
                 strip_extra_dates(deck.get("event", "")),

--- a/widgets/frames/app_frame/handlers/research.py
+++ b/widgets/frames/app_frame/handlers/research.py
@@ -65,6 +65,26 @@ class DeckResearchHandlers(_Base):
         self._load_decks(scope="archetype", archetype=archetype)
         self._load_radar_in_background(archetype)
 
+    def on_bundle_decks_ready(self: AppFrame) -> None:
+        """Refresh the deck list after the remote bundle hydrates the caches.
+
+        On a cold cache the optimistic startup deck load races ahead of the
+        bundle apply and finds nothing; once the bundle lands, reload the
+        current selection — but only when the list is actually empty, so a
+        healthy startup never repeats its (expensive) deck load.
+        """
+        if self._all_loaded_decks:
+            return
+        with self._loading_lock:
+            if self.loading_archetypes or self.loading_decks:
+                return
+        idx = self.research_panel.get_selected_archetype_index()
+        if 0 < idx <= len(self.filtered_archetypes):
+            archetype = self.filtered_archetypes[idx - 1]
+            self._load_decks(scope="archetype", archetype=archetype)
+        else:
+            self._load_decks(scope="all")
+
     def on_event_type_filter_changed(self: AppFrame) -> None:
         self._apply_deck_filters()
 

--- a/widgets/frames/app_frame/handlers/research.py
+++ b/widgets/frames/app_frame/handlers/research.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import wx
 from loguru import logger
 
+from utils.constants.timing import RESEARCH_PREFETCH_DECK_COUNT
 from widgets.frames.app_frame.handlers.deck_formatting import (
     normalize_date,
     simple_summary_html,
@@ -109,11 +110,7 @@ class DeckResearchHandlers(_Base):
         show_source = self.controller.get_deck_data_source() == "both"
         rows = [
             (
-                (
-                    ("🐠" if deck.get("source") == "mtggoldfish" else "🧙🏾‍♂️")
-                    if show_source
-                    else ""
-                ),
+                (("🐠" if deck.get("source") == "mtggoldfish" else "🧙🏾‍♂️") if show_source else ""),
                 deck.get("player", "Unknown"),
                 slug_to_name.get(deck.get("name", ""), deck.get("name", "")),
                 strip_extra_dates(deck.get("event", "")),
@@ -124,6 +121,38 @@ class DeckResearchHandlers(_Base):
         ]
         self.deck_list.set_decks(rows)
         self.deck_list.Enable()
+        self._prefetch_visible_deck_images(filtered)
+
+    def _prefetch_visible_deck_images(self: AppFrame, decks: list[dict[str, Any]]) -> None:
+        """Prefetch card images for the decks at the top of the results list.
+
+        Those are the decks the user is most likely to click next, so their
+        card images should already be local when the deck opens (issue #951).
+        The deck texts are fetched cache-first on the prefetch thread; the
+        text cache dedupes, so a warm start costs no network at all.
+        """
+        top_decks = [dict(deck) for deck in decks[:RESEARCH_PREFETCH_DECK_COUNT]]
+        if not top_decks:
+            return
+        download_deck_text = self.controller.metagame_repo.download_deck_content
+        analyze_deck = self.controller.deck_service.analyze_deck
+
+        def _provider() -> list[str]:
+            names: list[str] = []
+            for deck in top_decks:
+                try:
+                    deck_text = download_deck_text(deck) or ""
+                except Exception as exc:
+                    logger.debug(f"Prefetch: failed to fetch deck {deck.get('number')}: {exc}")
+                    continue
+                if not deck_text:
+                    continue
+                analysis = analyze_deck(deck_text)
+                cards = analysis.get("mainboard_cards", []) + analysis.get("sideboard_cards", [])
+                names.extend(name for name, _qty in cards)
+            return names
+
+        self.controller.image_service.prefetch_card_images_lazy("research", _provider)
 
     # Async Callback Handlers
     def _on_archetypes_loaded(self: AppFrame, items: list[dict[str, Any]]) -> None:

--- a/widgets/frames/app_frame/handlers/research.py
+++ b/widgets/frames/app_frame/handlers/research.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import wx
 from loguru import logger
 
+from services.image_service.priorities import PRIORITY_RESEARCH_VISIBLE
 from utils.constants.timing import RESEARCH_PREFETCH_DECK_COUNT
 from widgets.frames.app_frame.handlers.deck_formatting import (
     normalize_date,
@@ -172,7 +173,9 @@ class DeckResearchHandlers(_Base):
                 names.extend(name for name, _qty in cards)
             return names
 
-        self.controller.image_service.prefetch_card_images_lazy("research", _provider)
+        self.controller.image_service.prefetch_card_images_lazy(
+            "research", _provider, priority=PRIORITY_RESEARCH_VISIBLE
+        )
 
     # Async Callback Handlers
     def _on_archetypes_loaded(self: AppFrame, items: list[dict[str, Any]]) -> None:

--- a/widgets/frames/app_frame/protocol.py
+++ b/widgets/frames/app_frame/protocol.py
@@ -87,6 +87,7 @@ class AppFrameProto(Protocol):
     _filter_debounce_timer: wx.Timer | None
     _pending_image_refresh_names: set[str]
     _image_refresh_timer: wx.Timer | None
+    _deck_image_perf: dict[str, Any] | None
     _inspector_hover_timer: wx.Timer | None
     _pending_hover: tuple[str, dict[str, Any]] | None
     _pending_deck_restore: bool

--- a/widgets/frames/app_frame/protocol.py
+++ b/widgets/frames/app_frame/protocol.py
@@ -85,6 +85,8 @@ class AppFrameProto(Protocol):
     # Timers and pending state
     _save_timer: wx.Timer | None
     _filter_debounce_timer: wx.Timer | None
+    _pending_image_refresh_names: set[str]
+    _image_refresh_timer: wx.Timer | None
     _inspector_hover_timer: wx.Timer | None
     _pending_hover: tuple[str, dict[str, Any]] | None
     _pending_deck_restore: bool

--- a/widgets/panels/deck_builder_panel/frame/__init__.py
+++ b/widgets/panels/deck_builder_panel/frame/__init__.py
@@ -50,6 +50,7 @@ class DeckBuilderPanel(
         on_add_to_main: Callable[..., None] | None = None,
         on_add_to_side: Callable[..., None] | None = None,
         on_add_to_active_zone: Callable[[str], None] | None = None,
+        on_prefetch_images: Callable[[list[str]], None] | None = None,
         locale: str | None = None,
     ) -> None:
         super().__init__(parent)
@@ -68,6 +69,7 @@ class DeckBuilderPanel(
         self._on_add_to_main = on_add_to_main
         self._on_add_to_side = on_add_to_side
         self._on_add_to_active_zone = on_add_to_active_zone
+        self._on_prefetch_images = on_prefetch_images
 
         # State variables
         self.inputs: dict[str, wx.TextCtrl] = {}
@@ -87,6 +89,9 @@ class DeckBuilderPanel(
         self.results_cache: list[dict[str, Any]] = []
         self._search_timer = wx.Timer(self)
         self.Bind(wx.EVT_TIMER, self._on_search_timer, self._search_timer)
+        # Debounces image prefetch while the results list scrolls or refills.
+        self._prefetch_timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self._on_prefetch_timer, self._prefetch_timer)
 
         # Radar state
         self.active_radar: RadarData | None = None

--- a/widgets/panels/deck_builder_panel/frame/results_pane.py
+++ b/widgets/panels/deck_builder_panel/frame/results_pane.py
@@ -99,6 +99,9 @@ class ResultsPaneBuilderMixin(_Base):
         results.Bind(wx.EVT_LEFT_DOWN, self._on_results_left_down)
         results.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self._on_result_activated)
         results.Bind(wx.EVT_KEY_DOWN, self._on_result_key_down)
+        # The virtual list emits cache hints for each row range it is about to
+        # draw — the scroll signal driving image prefetch (issue #951).
+        results.Bind(wx.EVT_LIST_CACHE_HINT, self._on_results_cache_hint)
         parent_sizer.Add(results, 1, wx.EXPAND | wx.LEFT, PADDING_MD)
         self.results_ctrl = results
 

--- a/widgets/panels/deck_builder_panel/handlers.py
+++ b/widgets/panels/deck_builder_panel/handlers.py
@@ -7,6 +7,12 @@ from typing import TYPE_CHECKING, Any
 import wx
 
 from utils.constants import BUILDER_SEARCH_DEBOUNCE_MS
+from utils.constants.timing import (
+    IMAGE_PREFETCH_BATCH_LIMIT,
+    SEARCH_PREFETCH_DEBOUNCE_MS,
+    SEARCH_PREFETCH_LOOKAHEAD_CARDS,
+    SEARCH_PREFETCH_MIN_CARDS,
+)
 from widgets.wx_layout import set_shown
 
 if TYPE_CHECKING:
@@ -185,6 +191,49 @@ class DeckBuilderPanelHandlersMixin(_Base):
         if self.status_label:
             count = len(results)
             self.status_label.SetLabel(f"Showing {count} card{'s' if count != 1 else ''}.")
+        self._schedule_results_prefetch()
+
+    # ============= Image prefetch (issue #951) =============
+
+    def _on_results_cache_hint(self, event: wx.ListEvent) -> None:
+        # Fired by the virtual list whenever it is about to draw a new range of
+        # rows — i.e. on every scroll. Debounced so a scroll storm collapses
+        # into one prefetch of the final window.
+        event.Skip()
+        self._schedule_results_prefetch()
+
+    def _schedule_results_prefetch(self) -> None:
+        if not self._on_prefetch_images or not self._prefetch_timer:
+            return
+        if self._prefetch_timer.IsRunning():
+            self._prefetch_timer.Stop()
+        self._prefetch_timer.StartOnce(SEARCH_PREFETCH_DEBOUNCE_MS)
+
+    def _on_prefetch_timer(self, _event: wx.TimerEvent) -> None:
+        self._flush_results_prefetch()
+
+    def _flush_results_prefetch(self) -> None:
+        """Prefetch images for the search rows the user can see or soon will.
+
+        The window runs from the top of the list down to a little past the
+        visible bottom (so a small scroll still lands on cached images), never
+        fewer than SEARCH_PREFETCH_MIN_CARDS when results are short, and never
+        more than IMAGE_PREFETCH_BATCH_LIMIT so a browse-all search can't
+        commit the app to downloading thousands of images.
+        """
+        if not self._on_prefetch_images or not self.results_ctrl:
+            return
+        results = self.results_cache
+        if not results:
+            return
+        top = max(0, self.results_ctrl.GetTopItem())
+        per_page = max(0, self.results_ctrl.GetCountPerPage())
+        end = top + per_page + SEARCH_PREFETCH_LOOKAHEAD_CARDS
+        end = min(len(results), max(end, SEARCH_PREFETCH_MIN_CARDS))
+        start = max(0, end - IMAGE_PREFETCH_BATCH_LIMIT)
+        names = [card.get("name", "") for card in results[start:end] if card.get("name")]
+        if names:
+            self._on_prefetch_images(names)
 
     def clear_result_selection(self) -> None:
         if not self.results_ctrl:

--- a/widgets/panels/deck_builder_panel/protocol.py
+++ b/widgets/panels/deck_builder_panel/protocol.py
@@ -29,6 +29,7 @@ class DeckBuilderPanelProto(Protocol):
     _on_add_to_main: Callable[..., None] | None
     _on_add_to_side: Callable[..., None] | None
     _on_add_to_active_zone: Callable[[str], None] | None
+    _on_prefetch_images: Callable[[list[str]], None] | None
 
     inputs: dict[str, wx.TextCtrl]
     mana_exact_cb: wx.CheckBox | None
@@ -46,6 +47,7 @@ class DeckBuilderPanelProto(Protocol):
     _adv_toggle_btn: wx.Button | None
     results_cache: list[dict[str, Any]]
     _search_timer: wx.Timer
+    _prefetch_timer: wx.Timer
 
     active_radar: RadarData | None
     radar_enabled: bool


### PR DESCRIPTION
Closes #951.

## What this does

**Predictive image prefetch.** Instead of downloading images one at a time on mouseover, the app now predicts which cards the user is about to look at and batch-prefetches them through the existing background download queue (batches capped at 100 requests; the queue's 10 parallel workers drain them, same machinery as the bulk downloader):

- **Deck load** → every card in mainboard/sideboard/outboard is queued the moment the deck renders, so grid art and hover previews stream in immediately.
- **Deck research tab** → the top 3 decks of the (filtered) results list get their decklists fetched cache-first on a background thread and their card images queued — the decks the user is most likely to click open with images already local.
- **Card search** → the visible window plus a 20-row scroll lookahead is prefetched, debounced on scroll (via the virtual list's cache-hint events). Min/max logic: at least 30 rows when results are short, never more than 100 per batch so a browse-all search can't commit the app to thousands of downloads.

Submissions coalesce per surface (a scroll storm collapses into one batch of the final window), already-submitted names are skipped, and the queue itself dedupes against pending/in-flight/cached work. **On-hover downloads are preserved** and still enqueue with priority, so they always jump ahead of prefetch traffic.

**Startup stays responsive during mass downloads.** The prefetch worker idles 3s after startup before its first batch (same pattern as CacheWarmer), and downloaded-image UI refreshes are coalesced into one batched table repaint per 250ms instead of one `wx.CallAfter` (×3 tables) per image — with an empty cache the per-image callbacks were saturating the UI event loop until the warm-up drained.

**Split-card hover fix ("Emeritus of Conflict" beep).** Prepare/split/adventure layouts store their single image under the combined "A // B" name, but the hover path requests *face name + set code*. `get_image_path_for_printing` had no `//`-alias fallback, so the queue never saw those cards as cached — every hover re-downloaded from Scryfall and the UI was never notified. Fixed three ways so hover and bulk paths agree:
- `get_image_path_for_printing` now falls back to `"face // %"` / `"% // face"` rows (set-scoped), mirroring `get_image_path`.
- The download queue passes the request's printing **uuid** through, and the local bulk-data resolver matches by uuid first — the exact printing the inspector shows is what gets downloaded, and the queue's cached-check verifies by uuid first.
- The lazy local image index now applies the same primary-name collision guard as `build_printing_index` (#792), so a face name that is also a real card ("Lightning Bolt") never resolves to the prepare card.

**"Enable Offline Images Mode" dialog.** The old "Download Card Images" dialog is reframed: it explains that images normally stream in on demand a few seconds ahead of the user, and that offline mode trades **~12.2 GB** of disk for having every card image local with no internet needed. The high/low/PNG quality choices and card-count options are removed — only the medium ("normal", 488x680) size is used anywhere.

**Decklists restored after the MTGO_Tools_Data restructure.** The data repo now partitions MTGGoldfish scraping to paper events and sources MTGO results from the Videre API, so its client bundle hydrates *empty* goldfish deck lists for MTGO-only archetypes (225/355 in today's bundle). Two cache layers treated that `[]` as a valid hit (`get_decks_for_archetype` and the goldfish scraper's own cache), permanently blocking the live-scrape fallback — clicking such an archetype showed "No decks" forever. Both now treat an empty cached list as a miss (verified against the real data-publish bundle: 4c HollowOne 0 → 44 decks). Also closes the cold-cache startup race where the optimistic "Any" deck load ran before the bundle apply finished and never reloaded: the apply now fires `on_bundle_decks_ready`, and the frame reloads only when its deck list is empty.

## Tests

- New `tests/test_image_prefetcher.py`: batch cap, in/cross-batch dedupe, blank-name filtering, provider/enqueue error tolerance, worker-thread end-to-end, start-delay + stop semantics.
- `tests/test_card_images_cache.py`: prepare-layout card added to the bulk fixture; uuid-first resolution, primary-name guard, and an end-to-end regression proving a face-name+set hover request downloads once and registers as cached.
- `tests/test_image_service.py`: uuid passthrough to the downloader, uuid-based cached-skip, uuid-miss fallback, service→prefetcher delegation.
- `tests/test_metagame_repository.py`: empty-cached-list falls back to live scrape, scrape-failure returns empty instead of raising, bundle MTGO entries preserved across a live refresh.

Full suite: 1799 passed, 5 skipped. Ruff clean. Decklist fixes verified end-to-end against the live data-publish bundle in an isolated cache dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)