### PR TITLE
fix(installer): bundle the MTGO bridge instead of downloading it

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,38 +13,29 @@ The install is **per-user and requires no administrator privileges** (`Privilege
 
 **Debugging an installed build:** the shipped executable is windowed (no console), but `debugpy` is bundled so you can attach an IDE debugger the same way you would in the editor. Set `MTGO_TOOLS_INSTALL_DEBUG=1` (or `MTGO_TOOLS_INSTALL_DEBUG=<port>`) before launching to have it listen on 127.0.0.1:5678, then use your IDE's "attach to process/port". Set `MTGO_TOOLS_INSTALL_DEBUG_WAIT=1` to block startup until the debugger attaches (for breaking on early startup code). The hook is inert unless the env var is set. File logs are always written to `%LOCALAPPDATA%\MTGO Tools\logs`; set `MTGO_LOG_LEVEL=DEBUG` for verbose output.
 
-Prerequisites: Inno Setup 6, Python 3.11+ with PyInstaller, and optionally .NET 9 SDK (used to publish a self-contained bridge that bundles the .NET runtime). On Linux the build script uses Wine to run Inno Setup and will automatically download it if not present. Output is created at dist/installer/MTGOTools_Setup_v0.2.exe. The PyInstaller spec is `mtgo_tools.spec`, which produces a single-file `dist/mtgo_tools.exe`.
+Prerequisites: Inno Setup 6, Python 3.11+ with PyInstaller, and the **.NET 9 SDK** (required — used to publish the self-contained MTGO bridge that is shipped inside the installer). The SDK can be installed with no admin rights via `Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1; .\dotnet-install.ps1 -Channel 9.0`; the build script auto-detects a per-user SDK under `%LOCALAPPDATA%\Microsoft\dotnet`. On Linux the build script uses Wine to run Inno Setup and will automatically download it if not present. Output is created at dist/installer/MTGOTools_Setup_v0.2.exe. The PyInstaller spec is `mtgo_tools.spec`, which produces a single-file `dist/mtgo_tools.exe`.
 
 To customize edit installer.iss to change version, app name, included files, or shortcuts. For distribution sign the installer and generate checksums. The build and test scripts are CI/CD friendly.
 
 Notes:
 - Mana symbol assets are auto-fetched (and bundled) during the build if `assets/mana` is missing. They come from the `Pedrogush/mana` fork of `andrewgioia/mana`, which pins the source so upstream changes never affect us until the fork is synced. The app also self-fetches these assets on first run (see `scripts/fetch_mana_assets.py`).
 
-## Bridge release flow
+## MTGO bridge (bundled)
 
-The .NET `MTGOBridge` artifact is **downloaded at install time** rather than
-bundled inside the installer. This keeps the installer small and lets the
-bridge be re-released independently of the main app. To guarantee integrity
-the download is pinned to a tagged release URL **and** verified against a
-known SHA-256.
+The .NET `MTGOBridge` (source in `dotnet/MTGOBridge/`) is **built from source and
+shipped inside the installer** — there is no install-time download. `build_installer.ps1`
+publishes it self-contained (`dotnet publish -r win-x64 --self-contained -p:PublishSingleFile=true`),
+which bundles the .NET runtime, and `installer.iss` copies the publish output into
+`{app}\mtgo_integration\`. The app resolves it there at runtime
+(`services/mtgo_bridge_service/discovery.py`). This makes MTGO integration work out of
+the box on a clean machine: no network dependency at install time and no separate .NET
+runtime requirement for the user.
 
-`build_installer.ps1` still publishes the local bridge (used for local
-testing and for catching build breakage); the published binaries are *not*
-shipped in the installer.
+The bridge is **mandatory**: `build_installer.ps1` fails if the .NET 9 SDK is missing or
+the publish output is absent, rather than producing an installer without MTGO integration.
+Pass `-SkipDotNetBuild` to reuse an already-published bridge (e.g. for faster iteration on
+the installer itself); the published artifact must still exist or the build aborts.
 
-Cutting a new bridge release:
-
-1. Publish a release in the `Pedrogush/MTGOBridge` repo with a versioned zip
-   asset (e.g. `MTGOBridge-vX.Y.Z.zip`).
-2. Compute the SHA-256 of the published zip, e.g.
-   `Get-FileHash -Algorithm SHA256 MTGOBridge-vX.Y.Z.zip` (PowerShell) or
-   `sha256sum MTGOBridge-vX.Y.Z.zip` (Linux/macOS).
-3. Edit `packaging/installer.iss` and update the three pinned constants
-   together: `BRIDGE_RELEASE_URL`, `BRIDGE_ZIP_FILENAME`, and
-   `BRIDGE_ZIP_SHA256`.
-4. Rebuild the installer and confirm the post-install download succeeds with
-   the new checksum.
-
-If `BRIDGE_ZIP_SHA256` is empty the installer logs a warning and skips
-verification — this is only intended for local debugging. Production
-installers must ship with a populated hash.
+To change the bridge, edit the C# under `dotnet/MTGOBridge/` and rebuild the installer —
+the new binary is picked up automatically. The trade-off of bundling is installer size:
+the self-contained bridge adds the .NET runtime (~60-70 MB) to the setup .exe.

--- a/packaging/build_installer.ps1
+++ b/packaging/build_installer.ps1
@@ -4,10 +4,16 @@
 # Prerequisites:
 # - Inno Setup 6 installed (https://jrsoftware.org/isdl.php)
 # - PyInstaller installed (pip install pyinstaller)
-# - .NET 9 SDK (optional, if you want to rebuild the bridge)
+# - .NET 9 SDK (REQUIRED): the MTGO bridge is built self-contained and shipped
+#   inside the installer, so the build fails if it cannot be produced. A per-user
+#   SDK under %LOCALAPPDATA%\Microsoft\dotnet is detected automatically (install
+#   with no admin via https://dot.net/v1/dotnet-install.ps1 -Channel 9.0).
 
 param(
     [switch]$SkipPyInstaller = $false,
+    # Reuse an already-published bridge instead of rebuilding it. The bridge is
+    # still REQUIRED: if the published artifact is missing, the build fails
+    # rather than shipping an installer without MTGO integration.
     [switch]$SkipDotNetBuild = $false
 )
 
@@ -105,7 +111,17 @@ Write-Info "Updating vendor data..."
 Push-Location $ProjectRoot
 try {
     $VendorUpdateScript = Join-Path $ProjectRoot "scripts\update_vendor_data.py"
-    $VendorPython = Join-Path $ProjectRoot "env\Scripts\python.exe"
+    # Prefer the project virtualenv (which has the build deps like defusedxml and
+    # PyInstaller). The venv is named ".venv" here; "env" is kept as a fallback for
+    # other setups. A bare "python" on PATH is the last resort - on this machine
+    # that resolves to a uv-managed interpreter whose "pip install" is blocked.
+    $VendorPython = $null
+    foreach ($cand in @(
+        (Join-Path $ProjectRoot ".venv\Scripts\python.exe"),
+        (Join-Path $ProjectRoot "env\Scripts\python.exe")
+    )) {
+        if (Test-Path $cand) { $VendorPython = $cand; break }
+    }
     $FallbackPython = Get-Command python -ErrorAction SilentlyContinue
     $PythonPath = $null
     if (Test-Path $VendorPython) {
@@ -157,7 +173,7 @@ try {
         Write-Info "Mana assets missing; fetching from the Pedrogush/mana fork…"
         $FetchScript = Join-Path $ProjectRoot "scripts\fetch_mana_assets.py"
         if (Test-Path $FetchScript) {
-            if (Test-Path $VendorPython) {
+            if ($VendorPython -and (Test-Path $VendorPython)) {
                 & $VendorPython $FetchScript
             } elseif ($FallbackPython) {
                 & $FallbackPython.Source $FetchScript
@@ -222,11 +238,18 @@ Write-Info "Inno Setup found at: $InnoSetupPath"
 function Find-PyInstallerPath {
     param([string]$ProjectRoot)
 
-    $explicit = Join-Path $ProjectRoot "env\Scripts\pyinstaller.exe"
-    Write-Info "Looking for PyInstaller at explicit path: $explicit"
-    if (Test-Path $explicit) {
-        Write-Info "PyInstaller found explicitly."
-        return $explicit
+    # Prefer the project virtualenv (".venv" here, "env" as a fallback) before a
+    # PyInstaller on PATH, so the build uses the same interpreter that has the
+    # project's build dependencies installed.
+    foreach ($explicit in @(
+        (Join-Path $ProjectRoot ".venv\Scripts\pyinstaller.exe"),
+        (Join-Path $ProjectRoot "env\Scripts\pyinstaller.exe")
+    )) {
+        Write-Info "Looking for PyInstaller at explicit path: $explicit"
+        if (Test-Path $explicit) {
+            Write-Info "PyInstaller found explicitly."
+            return $explicit
+        }
     }
 
     $fromEnv = Get-Command pyinstaller -ErrorAction SilentlyContinue
@@ -289,34 +312,69 @@ if (-not $SkipPyInstaller) {
     Write-Info "Skipping PyInstaller build (using existing executable)"
 }
 
-# Step 4: Check for .NET bridge (optional)
-if (-not $SkipDotNetBuild) {
-    $BridgePath = Join-Path $ProjectRoot "dotnet\MTGOBridge\bin\Release\net9.0-windows7.0\win-x64\publish\MTGOBridge.exe"
-    if (-not (Test-Path $BridgePath)) {
-        Write-Info ".NET bridge not found at expected location; building..."
-
-        # Check for dotnet SDK
-        $DotNetCheck = Get-Command dotnet -ErrorAction SilentlyContinue
-        if ($DotNetCheck) {
-            Push-Location (Join-Path $ProjectRoot "dotnet\MTGOBridge")
-            Write-Info "Building .NET bridge as self-contained single file (bundles .NET runtime)..."
-            & dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -warnaserror
-            Pop-Location
-
-            if (-not (Test-Path $BridgePath)) {
-                Write-Error-Custom ".NET bridge build completed but executable not found at $BridgePath"
-                exit 1
-            }
-
-            Write-Info ".NET bridge build complete!"
-        } else {
-            Write-Error-Custom ".NET SDK not found. Install .NET 9 SDK or rerun with -SkipDotNetBuild."
-            exit 1
-        }
-    } else {
-        Write-Info ".NET bridge found at: $BridgePath"
+# Step 4: Build the .NET bridge (REQUIRED)
+#
+# The bridge is a self-contained .NET publish (bundles its own runtime) and is
+# shipped inside the installer by installer.iss. It is therefore mandatory: if
+# the published artifact cannot be produced or found, we fail rather than ship an
+# installer without MTGO integration.
+function Find-DotNetPath {
+    # Prefer an explicit dotnet on PATH, then the per-user install location used
+    # by dotnet-install.ps1 (%LOCALAPPDATA%\Microsoft\dotnet), then the standard
+    # machine-wide location. Mirrors how PyInstaller/Python are resolved above.
+    $fromEnv = Get-Command dotnet -ErrorAction SilentlyContinue
+    if ($fromEnv) {
+        Write-Info "dotnet found via PATH: $($fromEnv.Path)"
+        return $fromEnv.Source
     }
+    $candidates = @(
+        (Join-Path $env:LOCALAPPDATA "Microsoft\dotnet\dotnet.exe"),
+        (Join-Path $env:ProgramFiles "dotnet\dotnet.exe")
+    )
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path $candidate)) {
+            Write-Info "dotnet found at: $candidate"
+            return $candidate
+        }
+    }
+    return $null
 }
+
+$BridgeProject = Join-Path $ProjectRoot "dotnet\MTGOBridge"
+$BridgePublishDir = Join-Path $BridgeProject "bin\Release\net9.0-windows7.0\win-x64\publish"
+$BridgePath = Join-Path $BridgePublishDir "MTGOBridge.exe"
+
+if ($SkipDotNetBuild) {
+    Write-Info "Skipping .NET bridge build (-SkipDotNetBuild); reusing existing publish output."
+} else {
+    $DotNetPath = Find-DotNetPath
+    if (-not $DotNetPath) {
+        Write-Error-Custom ".NET 9 SDK not found. The bridge is shipped inside the installer and cannot be skipped."
+        Write-Error-Custom "Install it with no admin rights via:"
+        Write-Error-Custom "  Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1; .\dotnet-install.ps1 -Channel 9.0"
+        exit 1
+    }
+    Push-Location $BridgeProject
+    Write-Info "Building .NET bridge as self-contained single file (bundles .NET runtime)..."
+    & $DotNetPath publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -warnaserror
+    $BridgeExit = $LASTEXITCODE
+    Pop-Location
+    if ($BridgeExit -ne 0) {
+        Write-Error-Custom ".NET bridge build failed (exit code $BridgeExit)."
+        exit 1
+    }
+    Write-Info ".NET bridge build complete!"
+}
+
+# Hard requirement: the published bridge MUST exist before we compile the
+# installer, regardless of whether we just built it or reused an existing build.
+if (-not (Test-Path $BridgePath)) {
+    Write-Error-Custom "MTGO bridge not found at $BridgePath"
+    Write-Error-Custom "The installer ships the bridge from this path; refusing to build without it."
+    Write-Error-Custom "Run without -SkipDotNetBuild (and with the .NET 9 SDK installed) to build it."
+    exit 1
+}
+Write-Info "MTGO bridge ready: $BridgePath"
 Fail-On-Warnings
 
 # Step 5: Create installer output directory

--- a/packaging/build_installer.ps1
+++ b/packaging/build_installer.ps1
@@ -124,7 +124,7 @@ try {
     }
     $FallbackPython = Get-Command python -ErrorAction SilentlyContinue
     $PythonPath = $null
-    if (Test-Path $VendorPython) {
+    if ($VendorPython -and (Test-Path $VendorPython)) {
         $PythonPath = $VendorPython
     } elseif ($FallbackPython) {
         $PythonPath = $FallbackPython.Source

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -55,8 +55,18 @@ Source: "../dist/{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 ; installer bundles a copy of its own output directory (and any previously built
 ; setup .exe) into {app}\installer.
 Source: "../dist/*"; DestDir: "{app}"; Excludes: "installer,installer\*"; Flags: ignoreversion recursesubdirs createallsubdirs
+; MTGO integration bridge — a self-contained .NET publish that bundles its own
+; runtime. Built by build_installer.ps1 (dotnet publish -r win-x64
+; --self-contained) and shipped here so MTGO integration works out of the box:
+; no install-time download and no separate .NET runtime requirement on the user's
+; machine. The app resolves it at {app}\mtgo_integration\MTGOBridge.exe
+; (see services/mtgo_bridge_service/discovery.py). Intentionally NOT wrapped in a
+; #if DirExists guard: if the bridge was not built, ISCC must fail rather than
+; silently ship an installer without MTGO integration.
+Source: "../dotnet/MTGOBridge/bin/Release/net9.0-windows7.0/win-x64/publish/*"; DestDir: "{app}\mtgo_integration"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; Vendor data directories (if they exist)
-; NOTE: vendor/mtgosdk is intentionally excluded — the bridge is downloaded at install time.
+; NOTE: vendor/mtgosdk (C# SDK sources) is intentionally excluded; the compiled,
+; self-contained bridge is bundled above and needs nothing else at runtime.
 #if DirExists('../vendor/mtgo_format_data')
 Source: "../vendor/mtgo_format_data/*"; DestDir: "{app}/vendor/mtgo_format_data"; Flags: ignoreversion recursesubdirs createallsubdirs
 #endif
@@ -69,14 +79,15 @@ Source: "../LICENSE"; DestDir: "{app}"; Flags: ignoreversion
 
 [Dirs]
 ; Runtime data (config/cache/logs/data) lives under %LOCALAPPDATA%\{#MyAppName},
-; not under {app}, so those directories are created by the app at runtime rather
-; than here. Only the bridge download target lives inside the install directory.
-Name: "{app}\mtgo_integration"
+; not under {app}, so the app creates those directories at runtime. The bundled
+; MTGO bridge ships into {app}\mtgo_integration via the [Files] section above, so
+; nothing needs to be pre-created here.
 
 [UninstallDelete]
-; The MTGOBridge is downloaded into {app}\mtgo_integration *after* install (see
-; the [Code] section below), so Setup has no record of those files and the
-; uninstaller would otherwise leave them (and the non-empty {app} folder) behind.
+; The bundled bridge files in {app}\mtgo_integration are recorded by Setup and
+; removed automatically on uninstall. This entry additionally sweeps anything the
+; bridge writes next to itself at runtime, so the folder is left empty and removed
+; rather than orphaned.
 Type: filesandordirs; Name: "{app}\mtgo_integration"
 ; Regenerable per-user data: caches, logs, and downloaded card data. User
 ; settings (%LOCALAPPDATA%\{#MyAppName}\config) and saved decks
@@ -97,206 +108,3 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 [Run]
 ; Option to launch the application after installation
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-
-[Code]
-// ---------------------------------------------------------------------------
-// Bridge download constants
-//
-// The bridge artifact is intentionally downloaded at install time (rather than
-// bundled) so the installer stays small and the bridge can be republished
-// independently. The download is pinned to a specific release tag *and*
-// verified against a known SHA-256 to guarantee integrity. When publishing a
-// new bridge release, update all three values together: URL, ZIP filename,
-// and SHA-256. See packaging/README.md ("Bridge release flow") for details.
-// ---------------------------------------------------------------------------
-const
-  BRIDGE_RELEASE_URL   = 'https://github.com/Pedrogush/MTGOBridge/releases/download/v1.0.0/MTGOBridge-v1.0.0.zip';
-  BRIDGE_MANUAL_URL    = 'https://github.com/Pedrogush/MTGOBridge/releases/latest';
-  BRIDGE_ZIP_FILENAME  = 'MTGOBridge-v1.0.0.zip';
-  // SHA-256 of MTGOBridge-v1.0.0.zip. Empty string disables verification
-  // (only intended for local debugging — production builds MUST set this).
-  BRIDGE_ZIP_SHA256    = '';
-  DOTNET9_WINGET_ID    = 'Microsoft.DotNet.Runtime.9';
-
-// ---------------------------------------------------------------------------
-// .NET 9 detection
-// ---------------------------------------------------------------------------
-function IsDotNet9Installed: Boolean;
-var
-  ResultCode: Integer;
-begin
-  // dotnet --list-runtimes exits 0 even when no matching runtime is found;
-  // we use a simple presence check via "dotnet" availability and version list.
-  Result := Exec('powershell.exe',
-    '-NoProfile -NonInteractive -Command "dotnet --list-runtimes 2>$null | '
-    + 'Select-String ''Microsoft.NETCore.App 9\.''"',
-    '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
-end;
-
-// ---------------------------------------------------------------------------
-// PowerShell-based HTTP download helper
-// ---------------------------------------------------------------------------
-function DownloadFilePS(const Url, Dest: String): Boolean;
-var
-  ResultCode: Integer;
-  Script: String;
-begin
-  Script := Format(
-    'Invoke-WebRequest -Uri ''%s'' -OutFile ''%s'' -UseBasicParsing', [Url, Dest]);
-  Result := Exec('powershell.exe',
-    '-NoProfile -NonInteractive -Command "' + Script + '"',
-    '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
-end;
-
-// ---------------------------------------------------------------------------
-// PowerShell-based SHA-256 verification helper
-//
-// Returns True if the file at FilePath has a SHA-256 hash matching ExpectedHash
-// (case-insensitive). An empty ExpectedHash skips verification and returns True
-// — this is only intended for local/debug builds.
-// ---------------------------------------------------------------------------
-function VerifySha256PS(const FilePath, ExpectedHash: String): Boolean;
-var
-  ResultCode: Integer;
-  Script: String;
-begin
-  if Trim(ExpectedHash) = '' then
-  begin
-    Log('Bridge SHA-256 verification skipped (no expected hash configured).');
-    Result := True;
-    Exit;
-  end;
-
-  // Get-FileHash exits 0 regardless; we let PowerShell perform the comparison
-  // and translate the result into the process exit code.
-  // Keep the args array on the same line as the format string: Inno Setup reads
-  // any line beginning with '[' (even inside [Code]) as a section header, so a
-  // line that starts with '[FilePath, ExpectedHash]' aborts compilation.
-  Script := Format(
-    '$h = (Get-FileHash -Algorithm SHA256 -Path ''%s'').Hash; '
-    + 'if ($h -ieq ''%s'') { exit 0 } else { Write-Error "SHA256 mismatch: $h"; exit 1 }', [FilePath, ExpectedHash]);
-  Result := Exec('powershell.exe',
-    '-NoProfile -NonInteractive -Command "' + Script + '"',
-    '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
-end;
-
-// ---------------------------------------------------------------------------
-// PowerShell-based zip extraction helper
-// ---------------------------------------------------------------------------
-function ExtractZipPS(const ZipPath, DestDir: String): Boolean;
-var
-  ResultCode: Integer;
-  Script: String;
-begin
-  Script := Format(
-    'Expand-Archive -Path ''%s'' -DestinationPath ''%s'' -Force', [ZipPath, DestDir]);
-  Result := Exec('powershell.exe',
-    '-NoProfile -NonInteractive -Command "' + Script + '"',
-    '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
-end;
-
-// ---------------------------------------------------------------------------
-// Bridge download + extraction
-// ---------------------------------------------------------------------------
-procedure DownloadBridge;
-var
-  ZipPath, IntegrationDir: String;
-  DownloadOk, VerifyOk, ExtractOk: Boolean;
-begin
-  IntegrationDir := ExpandConstant('{app}\mtgo_integration');
-  ZipPath        := ExpandConstant('{tmp}\') + BRIDGE_ZIP_FILENAME;
-
-  Log('Downloading MTGOBridge from ' + BRIDGE_RELEASE_URL);
-  DownloadOk := DownloadFilePS(BRIDGE_RELEASE_URL, ZipPath);
-
-  if not DownloadOk then
-  begin
-    if not WizardSilent then
-      MsgBox(
-        'MTGO integration could not be downloaded automatically.' + #13#10 +
-        'You can install it manually later from:' + #13#10 +
-        BRIDGE_MANUAL_URL + #13#10#13#10 +
-        'The main application will work without it.' ,
-        mbInformation, MB_OK);
-    Log('Bridge download failed — MTGO integration will be unavailable.');
-    Exit;
-  end;
-
-  Log('Verifying MTGOBridge SHA-256 checksum');
-  VerifyOk := VerifySha256PS(ZipPath, BRIDGE_ZIP_SHA256);
-  if not VerifyOk then
-  begin
-    DeleteFile(ZipPath);
-    if not WizardSilent then
-      MsgBox(
-        'MTGOBridge download failed checksum verification and was discarded.' + #13#10 +
-        'You can install it manually from:' + #13#10 +
-        BRIDGE_MANUAL_URL + #13#10#13#10 +
-        'The main application will work without it.',
-        mbError, MB_OK);
-    Log('Bridge SHA-256 mismatch — MTGO integration will be unavailable.');
-    Exit;
-  end;
-
-  Log('Extracting MTGOBridge to ' + IntegrationDir);
-  ExtractOk := ExtractZipPS(ZipPath, IntegrationDir);
-
-  if not ExtractOk then
-  begin
-    if not WizardSilent then
-      MsgBox(
-        'MTGOBridge was downloaded but could not be extracted.' + #13#10 +
-        'You can install it manually from:' + #13#10 +
-        BRIDGE_MANUAL_URL,
-        mbInformation, MB_OK);
-    Log('Bridge extraction failed — MTGO integration will be unavailable.');
-  end;
-end;
-
-// ---------------------------------------------------------------------------
-// .NET 9 detection and prompt
-// ---------------------------------------------------------------------------
-procedure CheckAndPromptDotNet9;
-var
-  ResultCode: Integer;
-begin
-  if not IsDotNet9Installed then
-  begin
-    // Silent/unattended installs (e.g. the install/uninstall test harness) must
-    // not block on a prompt or mutate the machine by installing runtimes, so we
-    // only offer the interactive .NET install in a normal (visible) install.
-    // .NET is optional — the app runs without it, just without MTGO integration.
-    if WizardSilent then
-    begin
-      Log('.NET 9 not detected; skipping install prompt (silent install).');
-      Exit;
-    end;
-    if MsgBox(
-      'MTGO integration requires the .NET 9 Runtime, which was not detected.' + #13#10 +
-      'Would you like to install it now via winget?',
-      mbConfirmation, MB_YESNO) = IDYES then
-    begin
-      Exec('winget.exe',
-        'install --id ' + DOTNET9_WINGET_ID + ' --silent --accept-source-agreements'
-        + ' --accept-package-agreements',
-        '', SW_SHOW, ewWaitUntilTerminated, ResultCode);
-      if ResultCode <> 0 then
-        MsgBox(
-          'winget installation may not have completed.' + #13#10 +
-          'Please install .NET 9 Runtime manually from https://dotnet.microsoft.com/download/dotnet/9.0',
-          mbInformation, MB_OK);
-    end;
-  end;
-end;
-
-// ---------------------------------------------------------------------------
-// Post-install step
-// ---------------------------------------------------------------------------
-procedure CurStepChanged(CurStep: TSetupStep);
-begin
-  if CurStep = ssPostInstall then
-  begin
-    CheckAndPromptDotNet9;
-    DownloadBridge;
-  end;
-end;

--- a/packaging/test_install_uninstall.ps1
+++ b/packaging/test_install_uninstall.ps1
@@ -14,13 +14,13 @@
          run) under %LOCALAPPDATA%.
       4. Uninstalls silently.
       5. Asserts nothing is left behind: the uninstall registry key is gone, the
-         install directory (including the post-install bridge download) is gone,
-         and regenerable per-user data (cache/logs/data) is gone - while user
+         install directory (including the bundled bridge) is gone, and
+         regenerable per-user data (cache/logs/data) is gone - while user
          settings (config) and saved decks are intentionally preserved.
 
     This is what catches the classic installer bugs: an orphaned registry key,
-    or files created after install (the downloaded bridge, runtime caches) that
-    the uninstaller doesn't know to remove.
+    or files (the bundled bridge, runtime caches) that the uninstaller doesn't
+    know to remove.
 
 .NOTES
     Run on Windows in a normal (non-elevated) shell - the installer is a
@@ -157,6 +157,13 @@ Run-Test "App did NOT write data into the install dir" {
     -not (Test-Path (Join-Path $InstallDir "config")) -and
     -not (Test-Path (Join-Path $InstallDir "cache"))
 }
+Run-Test "MTGO bridge bundled in install dir" {
+    # The bridge is built from source and shipped inside the installer (see
+    # installer.iss / build_installer.ps1), not downloaded at install time. It
+    # must land where the app looks for it: {app}\mtgo_integration\MTGOBridge.exe
+    # (services/mtgo_bridge_service/discovery.py).
+    $InstallDir -and (Test-Path (Join-Path $InstallDir "mtgo_integration\MTGOBridge.exe"))
+}
 
 # --- Simulate runtime data ---------------------------------------------------
 # The app creates these on first run (utils/constants/paths.py). We seed marker
@@ -224,7 +231,7 @@ Run-Test "Uninstall registry key removed" { -not (Test-UninstallKeyPresent) }
 Run-Test "Install directory fully removed" {
     -not $InstallDir -or -not (Test-Path $InstallDir)
 }
-Run-Test "Downloaded bridge removed with install dir" {
+Run-Test "Bundled bridge removed with install dir" {
     -not $InstallDir -or -not (Test-Path (Join-Path $InstallDir "mtgo_integration"))
 }
 Run-Test "Regenerable cache removed on uninstall" { -not (Test-Path (Join-Path $DataDir "cache")) }


### PR DESCRIPTION
## Problem

`installer.iss` downloaded the MTGO bridge at install time from `MTGOBridge` release **`v1.0.0`**, which no longer exists — the URL returns **HTTP 404**. Every install silently lost MTGO integration (the installer degraded gracefully, so the app still ran, just without the bridge). Surfaced while running the issue #265 install/test/uninstall workflow.

## Fix

Build the bridge from source (`dotnet/MTGOBridge/`) and **ship it inside the installer** — no install-time download, and no separate .NET runtime requirement for the user.

- **`installer.iss`** — bundle the self-contained bridge publish into `{app}\mtgo_integration\` (where the app already looks: `services/mtgo_bridge_service/discovery.py`). Deleted the entire `[Code]` block: the GitHub download, SHA-256 verification, zip extraction, and the .NET 9 winget prompt (the self-contained bridge carries its own runtime).
- **`build_installer.ps1`** — the bridge build is now **mandatory**: a missing .NET 9 SDK or missing publish output is a hard error rather than a silent skip that ships an installer without integration. Auto-detects a per-user SDK under `%LOCALAPPDATA%\Microsoft\dotnet`. Also fixes a pre-existing issue where the script probed a nonexistent `env\` venv and died installing `defusedxml` — it now prefers the project's `.venv`.
- **`test_install_uninstall.ps1`** — adds a positive assertion that the bridge is bundled after install; renames the stale "downloaded bridge" cleanup check.
- **`README.md`** — documents the bundled-bridge model and the now-required .NET 9 SDK (installable with no admin via `dotnet-install.ps1`).

## Trade-off

Installer grows **~66 MB → ~103 MB** — MTGOSDK pulls in WPF, so the self-contained bridge bundles the .NET runtime plus native WPF DLLs (`wpfgfx_cor3.dll`, `PresentationNative_cor3.dll`, etc.), all required at runtime.

## Verification

- Full `build_installer.ps1` run (fresh): detects SDK → builds self-contained bridge → verifies → ISCC compresses it into `{app}\mtgo_integration\`. **BUILD exit 0**, installer 102.6 MB.
- Install/uninstall lifecycle harness: **15/15 passed**, including the new "MTGO bridge bundled in install dir" check and a clean uninstall (registry + dir removed, config + decks preserved).
- Bridge smoke test: shipped `MTGOBridge.exe` runs and exits 0 with no separate .NET runtime present → self-contained works on a clean machine.
- Registry values verified clean ASCII (issue #265's garbled/CJK-registry concern does not reproduce).

Known edge case: if the bridge was *just* executed, its `.exe` can be briefly file-locked and left behind on uninstall (clears within seconds). A normal install→uninstall is clean.

Refs #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)