### PR TITLE
refactor(versioning): bump on the PR branch instead of pushing to main

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,96 +1,96 @@
-# Automated semantic versioning from conventional-commit messages.
+# Automated semantic versioning, committed onto the PR branch.
 #
-# On every push to main this recomputes the version from the commits landed
-# since the last vX.Y.Z tag (see scripts/next_version.py):
-#   feat: -> minor, fix:/perf: -> patch, <type>!: or "BREAKING CHANGE" -> major.
-# When a release-worthy change is present it bumps the repo-root VERSION file,
-# commits it as "chore(release): vX.Y.Z [skip ci]", and pushes a matching tag.
-# The build reads VERSION, so the next installer is versioned automatically.
+# Work here is gated behind PRs and nothing bot-driven pushes to main. So instead
+# of bumping the version after merge, this computes the version a PR should carry
+# and commits it ONTO THE PR BRANCH, relative to the branch it targets:
 #
-# REQUIREMENTS / CAVEATS (needs a one-time repo setting):
-#   * This job pushes a commit + tag to main. It needs `contents: write` (set
-#     below) AND the ability to push to main. If main has branch protection that
-#     blocks direct pushes, either allow github-actions[bot] to bypass it, or
-#     switch this job to open a PR instead of pushing. Without that, the push
-#     step fails (the version simply won't advance; nothing else breaks).
-#   * Pushes made with GITHUB_TOKEN do not themselves trigger further workflow
-#     runs, so this cannot loop. The [skip ci] guard is belt-and-suspenders.
+#   feat: -> minor, fix:/perf: -> patch, <type>!: or "BREAKING CHANGE" -> major
+#   (see scripts/next_version.py). The base version is VERSION as it exists on
+#   the target branch; the bump is the largest across the PR's commits.
+#
+# Runs once per PR: the moment VERSION on the branch differs from the base it is
+# considered "already bumped" and every later run is a no-op, so the number set
+# when the PR first earned a bump is the number it keeps, even as more commits
+# land. The build reads VERSION, so the resulting installer is versioned to match.
+#
+# TOKEN / CI NOTE (one-time choice):
+#   A commit pushed with the default GITHUB_TOKEN does NOT trigger other
+#   workflows, so on a checks-gated repo the bump commit would sit on the PR
+#   without CI and block merge. To avoid that, set a repo secret
+#   VERSION_BOT_TOKEN = a fine-grained PAT with "Contents: read/write" on this
+#   repo; the push then triggers CI normally on the bump commit. Without the
+#   secret this falls back to GITHUB_TOKEN and still commits the bump, but you
+#   must re-run CI on that commit yourself before merging. The bot only ever
+#   pushes to PR branches, never to main.
 name: Versioning
 
 on:
-  push:
-    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
 
 concurrency:
-  group: versioning
+  group: versioning-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   bump:
-    name: Bump version from commits
+    name: Bump version on the PR branch
     runs-on: ubuntu-latest
-    # Don't run on our own release commit (defence in depth; GITHUB_TOKEN pushes
-    # already don't retrigger workflows).
-    if: >-
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !startsWith(github.event.head_commit.message, 'chore(release):')
+    # Same-repo PRs only: fork PRs get a read-only token and no secrets, so the
+    # bot cannot (and should not) push to a fork's branch.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Checkout (full history + tags)
+      - name: Checkout PR branch (full history)
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          # Prefer a PAT so the bump commit triggers CI; fall back to the
+          # built-in token (commits, but won't retrigger CI). See header note.
+          token: ${{ secrets.VERSION_BOT_TOKEN || github.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Compute version
-        id: ver
+      - name: Compute and commit version bump
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+          HEAD: ${{ github.event.pull_request.head.ref }}
         run: |
-          current=$(python scripts/next_version.py current)
-          next=$(python scripts/next_version.py next)
-          bump=$(python scripts/next_version.py bump)
-          echo "current=$current" >> "$GITHUB_OUTPUT"
-          echo "next=$next"       >> "$GITHUB_OUTPUT"
-          echo "bump=$bump"        >> "$GITHUB_OUTPUT"
-          echo "Current: $current | Bump: $bump | Next: $next"
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE"
 
-      - name: Configure git identity
-        run: |
+          base_ver="$(git show "origin/$BASE:VERSION" 2>/dev/null | tr -d '[:space:]' || true)"
+          if [ -z "$base_ver" ]; then
+            echo "Base branch '$BASE' has no VERSION file (bootstrap); nothing to do."
+            exit 0
+          fi
+
+          head_ver="$(tr -d '[:space:]' < VERSION)"
+          if [ "$head_ver" != "$base_ver" ]; then
+            echo "VERSION already bumped on this branch ($base_ver -> $head_ver); keeping it."
+            exit 0
+          fi
+
+          next="$(python scripts/next_version.py next --base "origin/$BASE")"
+          if [ "$next" = "$base_ver" ]; then
+            echo "No release-worthy commits vs origin/$BASE; version stays $base_ver."
+            exit 0
+          fi
+
+          python scripts/next_version.py apply --base "origin/$BASE"
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Ensure baseline tag exists
-        run: |
-          current="${{ steps.ver.outputs.current }}"
-          if git rev-parse -q --verify "refs/tags/v$current" >/dev/null; then
-            echo "Baseline tag v$current already exists."
-          else
-            echo "Creating baseline tag v$current at current HEAD."
-            git tag "v$current"
-            git push origin "v$current"
-          fi
-
-      - name: Apply bump, commit, and tag
-        if: steps.ver.outputs.next != steps.ver.outputs.current
-        run: |
-          next="${{ steps.ver.outputs.next }}"
-          python scripts/next_version.py apply
           git add VERSION
-          git commit -m "chore(release): v$next [skip ci]"
-          git tag "v$next"
-          git push origin HEAD:main
-          git push origin "v$next"
-          echo "Released v$next"
+          git commit -m "chore(version): set VERSION to $next"
+          git push origin "HEAD:$HEAD"
 
-      - name: Summary
-        run: |
-          if [ "${{ steps.ver.outputs.next }}" != "${{ steps.ver.outputs.current }}" ]; then
-            echo "### Released v${{ steps.ver.outputs.next }} (${{ steps.ver.outputs.bump }} bump)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "### No release-worthy commits since v${{ steps.ver.outputs.current }}; version unchanged." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          {
+            echo "### Version set to \`$next\` (was \`$base_ver\` on \`$BASE\`)"
+            echo "Committed to this PR branch. It stays fixed as more commits land."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -16,13 +16,11 @@ Everything else reads from it, so a bump is a one-line change in one place:
 | `packaging/test_installer*.{ps1,sh}`, `test_install_uninstall.ps1` | same filename derivation |
 | `pyproject.toml` | `version` is declared `dynamic`; `setup.py` supplies it by reading `VERSION` |
 
-`vX.Y.Z` git tags mark releases and are what the automation diffs against to
-decide the next number.
-
 ## How the number is computed
 
-`scripts/next_version.py` scans conventional-commit messages since the most
-recent `vX.Y.Z` tag and picks the largest applicable bump:
+`scripts/next_version.py` compares a PR against the branch it targets: the base
+version is `VERSION` **as it exists on the base branch**, and the bump is the
+largest applicable one across the PR's commits (`base..HEAD`):
 
 | Commit | Bump |
 | --- | --- |
@@ -31,37 +29,42 @@ recent `vX.Y.Z` tag and picks the largest applicable bump:
 | `fix: …` or `perf: …` | **patch** (`1.0.1`) |
 | `refactor`, `chore`, `docs`, `test`, `style`, `ci`, merges, … | no release |
 
-Precedence is major > minor > patch. If nothing release-worthy landed since the
-last tag, the version is unchanged.
+Precedence is major > minor > patch. If the PR has nothing release-worthy, the
+version is unchanged.
 
-Run it locally (no dependencies beyond git + Python):
+Run it locally (no dependencies beyond git + Python). `--base` points at the
+branch a PR targets:
 
 ```bash
-python scripts/next_version.py current   # what VERSION currently says
-python scripts/next_version.py bump      # major | minor | patch | none
-python scripts/next_version.py next      # the version the next release would get
-python scripts/next_version.py apply     # write the next version into VERSION
+python scripts/next_version.py current                  # what VERSION currently says
+python scripts/next_version.py bump --base origin/main   # major | minor | patch | none
+python scripts/next_version.py next --base origin/main   # version this PR should carry
+python scripts/next_version.py apply --base origin/main  # write that version into VERSION
 ```
 
 ## CI automation
 
-`.github/workflows/versioning.yml` runs on every push to `main`. It:
+Work is gated behind PRs and **nothing bot-driven pushes to `main`**. So the
+version is decided in the PR, not after merge. `.github/workflows/versioning.yml`
+runs on `pull_request` (opened / synchronize / reopened) and:
 
-1. ensures a baseline `v<current>` tag exists;
-2. computes the next version from the commits since the last tag;
-3. if a release is warranted, writes `VERSION`, commits it as
-   `chore(release): vX.Y.Z [skip ci]`, and pushes the commit plus a `vX.Y.Z` tag.
+1. computes the version this PR should carry, relative to its base branch;
+2. if a bump is warranted, writes `VERSION` and commits it **onto the PR branch**
+   as `chore(version): set VERSION to X.Y.Z`.
 
-Because the installer build reads `VERSION`, the next installer is versioned
-automatically — no manual edits.
+It runs **once**: as soon as the branch's `VERSION` differs from the base it is
+considered already-bumped, and later runs are no-ops. So the number set when the
+PR first earns a bump is the number it keeps as more commits land. Because the
+installer build reads `VERSION`, the PR's installer is versioned to match.
 
-> **One-time setup:** the job pushes a commit and tag to `main`, so it needs
-> `contents: write` (already set in the workflow) **and** permission to push to
-> `main`. If `main` has branch protection that blocks direct pushes, allow
-> `github-actions[bot]` to bypass it (or change the job to open a PR instead).
-> Without that, only the push step fails and the version simply won't advance —
-> nothing else breaks. Pushes made with `GITHUB_TOKEN` don't retrigger
-> workflows, so the release commit can't cause a loop.
+> **One-time setup (recommended):** a commit pushed with the default
+> `GITHUB_TOKEN` does **not** trigger other workflows, so on a checks-gated repo
+> the bump commit would sit on the PR without CI and block merge. Set a repo
+> secret **`VERSION_BOT_TOKEN`** = a fine-grained PAT with *Contents: read/write*
+> on this repo; the bump push then triggers CI normally. Without it, the bump is
+> still committed but you must re-run CI on that commit before merging. The bot
+> only ever pushes to **PR branches**, never to `main`. Fork PRs are skipped
+> (their token is read-only).
 
 ## What this means for you
 

--- a/scripts/next_version.py
+++ b/scripts/next_version.py
@@ -1,33 +1,35 @@
 #!/usr/bin/env python3
 """Derive the project's semantic version from conventional-commit history.
 
-Single source of truth:
-  * The repo-root ``VERSION`` file holds the current released version.
-  * ``vX.Y.Z`` git tags mark releases.
-
-The NEXT version is computed by scanning conventional-commit subjects (and
-bodies, for breaking-change footers) since the most recent ``vX.Y.Z`` tag:
+Single source of truth: the repo-root ``VERSION`` file (bare ``MAJOR.MINOR.PATCH``).
+Version numbers are never hand-picked; they are computed from
+[Conventional Commit](https://www.conventionalcommits.org) messages:
 
     <type>!: ...            -> MAJOR   (also any body with "BREAKING CHANGE")
     feat: ...               -> MINOR
     fix: ... / perf: ...    -> PATCH
     anything else           -> no release-worthy change
 
-Precedence is major > minor > patch. If nothing release-worthy landed since the
-last tag, the next version equals the current one (no release).
+Precedence is major > minor > patch.
 
-When no ``vX.Y.Z`` tag exists yet, this reports the current VERSION unchanged so
-the CI workflow can establish the baseline tag without a spurious bump.
+Two ways to pick the commit range and base version:
+
+  * ``--base REF`` (the model used by CI): the base is the PR's target branch.
+    The base version is ``VERSION`` **as it exists at REF**, and the bump is the
+    largest applicable one across commits in ``REF..HEAD``. This is how a PR's
+    version is computed relative to what it will merge into.
+
+  * no ``--base`` (handy locally): the base version is the current working-tree
+    ``VERSION`` and the range is "commits since the latest ``vX.Y.Z`` tag" (or
+    all history if there are no tags).
 
 Usage:
-    scripts/next_version.py current      # print current version (from VERSION)
-    scripts/next_version.py next         # print the computed next version
-    scripts/next_version.py bump         # print: major | minor | patch | none
-    scripts/next_version.py apply        # write the next version into VERSION
-                                         # (every other file derives from it)
+    scripts/next_version.py current                 # current VERSION (working tree)
+    scripts/next_version.py bump   [--base REF]     # major | minor | patch | none
+    scripts/next_version.py next   [--base REF]     # the computed next version
+    scripts/next_version.py apply  [--base REF]     # write the next version to VERSION
 
-The command is intentionally dependency-free (stdlib + git) so it runs the same
-locally and in CI.
+Dependency-free (stdlib + git) so it runs identically locally and in CI.
 """
 
 from __future__ import annotations
@@ -41,11 +43,14 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 VERSION_FILE = REPO_ROOT / "VERSION"
 
+Version = tuple[int, int, int]
+
 # type(scope)!: subject  ->  captures type and the optional breaking "!"
 _SUBJECT_RE = re.compile(r"^(?P<type>[a-zA-Z]+)(?:\([^)]*\))?(?P<bang>!)?:", re.IGNORECASE)
 _BREAKING_BODY_RE = re.compile(r"^BREAKING[ -]CHANGE:", re.IGNORECASE | re.MULTILINE)
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 
-# Order matters: index in this list is the bump rank (higher = bigger bump).
+# Order matters: index in this map is the bump rank (higher = bigger bump).
 _RANK = {None: 0, "patch": 1, "minor": 2, "major": 3}
 
 
@@ -64,18 +69,27 @@ def _git(*args: str) -> str:
     return out.stdout.strip()
 
 
-def read_current() -> tuple[int, int, int]:
-    raw = VERSION_FILE.read_text(encoding="utf-8").strip()
-    m = re.match(r"^(\d+)\.(\d+)\.(\d+)$", raw)
+def _parse(raw: str) -> Version:
+    m = _VERSION_RE.match(raw.strip())
     if not m:
-        raise SystemExit(
-            f"VERSION file must contain a bare MAJOR.MINOR.PATCH version, got: {raw!r}"
-        )
+        raise SystemExit(f"Expected a bare MAJOR.MINOR.PATCH version, got: {raw!r}")
     return int(m.group(1)), int(m.group(2)), int(m.group(3))
 
 
+def read_current() -> Version:
+    return _parse(VERSION_FILE.read_text(encoding="utf-8"))
+
+
+def version_at_ref(ref: str) -> Version:
+    """The VERSION recorded at a git ref; falls back to the working tree."""
+    raw = _git("show", f"{ref}:VERSION")
+    if raw:
+        return _parse(raw)
+    return read_current()
+
+
 def latest_release_tag() -> str | None:
-    """Return the highest ``vX.Y.Z`` tag, or None if there are none."""
+    """The highest ``vX.Y.Z`` tag, or None if there are none."""
     tags = _git("tag", "--list", "v[0-9]*.[0-9]*.[0-9]*", "--sort=-v:refname")
     for line in tags.splitlines():
         line = line.strip()
@@ -84,12 +98,11 @@ def latest_release_tag() -> str | None:
     return None
 
 
-def _commit_messages_since(ref: str | None) -> list[str]:
-    """Full commit messages (subject+body) since ref, newest first.
+def _commit_messages(rng: str) -> list[str]:
+    """Full commit messages (subject+body) for a range, newest first.
 
     Uses an ASCII record separator so multi-line bodies stay grouped.
     """
-    rng = f"{ref}..HEAD" if ref else "HEAD"
     sep = "\x1e"
     raw = _git("log", rng, f"--format=%B{sep}")
     if not raw:
@@ -115,20 +128,28 @@ def _classify(message: str) -> str | None:
     return None
 
 
-def bump_level_since(ref: str | None) -> str | None:
-    if ref is None:
-        # No release tag yet: don't invent a bump; the baseline tag is created
-        # at the current VERSION by the workflow.
-        return None
+def bump_level(base: str | None) -> str | None:
+    """Largest bump implied by commits in ``base..HEAD`` (or since the last tag).
+
+    ``base`` is an explicit ref (PR target branch) when given; otherwise we use
+    the latest release tag, and if there is none there is no release yet.
+    """
+    if base:
+        rng = f"{base}..HEAD"
+    else:
+        tag = latest_release_tag()
+        if tag is None:
+            return None
+        rng = f"{tag}..HEAD"
     highest: str | None = None
-    for message in _commit_messages_since(ref):
+    for message in _commit_messages(rng):
         level = _classify(message)
         if _RANK[level] > _RANK[highest]:
             highest = level
     return highest
 
 
-def apply_bump(cur: tuple[int, int, int], level: str | None) -> tuple[int, int, int]:
+def apply_bump(cur: Version, level: str | None) -> Version:
     major, minor, patch = cur
     if level == "major":
         return major + 1, 0, 0
@@ -139,32 +160,38 @@ def apply_bump(cur: tuple[int, int, int], level: str | None) -> tuple[int, int, 
     return cur
 
 
-def fmt(v: tuple[int, int, int]) -> str:
+def fmt(v: Version) -> str:
     return f"{v[0]}.{v[1]}.{v[2]}"
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", choices=["current", "next", "bump", "apply"])
+    parser.add_argument("command", choices=["current", "bump", "next", "apply"])
+    parser.add_argument(
+        "--base",
+        metavar="REF",
+        help="Target branch/ref to compute against (PR mode). Base version is "
+        "VERSION at REF; bump is computed across REF..HEAD.",
+    )
     args = parser.parse_args(argv)
 
-    current = read_current()
-    tag = latest_release_tag()
-    level = bump_level_since(tag)
-    nxt = apply_bump(current, level)
+    base_version = version_at_ref(args.base) if args.base else read_current()
+    level = bump_level(args.base)
+    nxt = apply_bump(base_version, level)
 
     if args.command == "current":
-        print(fmt(current))
+        print(fmt(read_current()))
     elif args.command == "bump":
         print(level or "none")
     elif args.command == "next":
         print(fmt(nxt))
     elif args.command == "apply":
-        if nxt == current:
-            print(f"No version change (current {fmt(current)}, last tag {tag or 'none'}).")
+        prev = read_current()
+        if nxt == prev:
+            print(f"No version change (stays {fmt(nxt)}).")
         else:
             VERSION_FILE.write_text(f"{fmt(nxt)}\n", encoding="utf-8")
-            print(f"VERSION {fmt(current)} -> {fmt(nxt)} (bump: {level})")
+            print(f"VERSION {fmt(prev)} -> {fmt(nxt)} (bump: {level})")
     return 0
 
 


### PR DESCRIPTION
## Why

The versioning workflow from #957 (already merged) pushes the version bump commit and tag **directly to `main`**. Since work here is gated behind PRs and nothing bot-driven should touch `main`, this replaces that model: the version is decided **in the PR** and committed **onto the PR branch**.

This effectively reverts the push-to-`main` behavior while keeping everything else from #957 (the `VERSION` single-source-of-truth wiring, 1.0.0, docs).

## New model

`.github/workflows/versioning.yml` now triggers on `pull_request` (opened / synchronize / reopened), same-repo only, and:

1. computes the version this PR should carry **relative to its base branch** (base version = `VERSION` on the base; bump = largest across the PR's commits);
2. if a bump is warranted, writes `VERSION` and commits it **onto the PR branch** as `chore(version): set VERSION to X.Y.Z`.

**Runs once / holds the number.** As soon as the branch's `VERSION` differs from base it's "already bumped" and every later run no-ops — so the number set when the PR first earns a bump stays fixed as more commits land, exactly as requested. Bootstrap-skips if the base has no `VERSION` file. **Never pushes to `main`.**

`scripts/next_version.py` gains a `--base REF` mode (base version from `VERSION@REF`, bump across `REF..HEAD`); the tag-based range remains as a no-`--base` local fallback.

## ⚠️ One-time setup (recommended)

A commit pushed with the default `GITHUB_TOKEN` doesn't trigger other workflows, so on a checks-gated repo the bump commit would sit without CI and block merge. Set a repo secret **`VERSION_BOT_TOKEN`** = a fine-grained PAT with *Contents: read/write* on this repo, and the bump push triggers CI normally. Without it the bump is still committed, but you'd re-run CI on that commit before merging. The workflow uses `${{ secrets.VERSION_BOT_TOKEN || github.token }}`. The bot only pushes to **PR branches**.

## Validation

Local `next_version.py --base origin/main`: no commits → `none`/`1.0.0`; `feat` → `minor`/`1.1.0`; `feat` + `!`/breaking → `major`/`2.0.0`; `VERSION@origin/main` → `1.0.0`. Workflow YAML parses; `black` + `ruff` clean.

> Note: a `v1.0.0` tag exists on `main` (created by the old push-to-main workflow's single run on the #957 merge). The PR model doesn't use tags; the leftover tag is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)