### PR TITLE
fix(updates): stop advertising a release that no longer exists

### DIFF
--- a/services/update_service.py
+++ b/services/update_service.py
@@ -25,6 +25,11 @@ timestamp and re-checked at most once per
 mean repeatedly hitting an API whose unauthenticated budget is 60 requests per
 hour per IP.
 
+*A pulled release stops being advertised.* A 404 from ``/releases/latest`` is an
+answer ("nothing is published"), not a failure, and is stamped as one — so a
+release that was deleted or unpublished clears on the next check instead of
+being recommended forever from a cache that never gets overwritten.
+
 *Downloading and applying the update is out of scope.* The UI points at the
 release page and the existing installer takes over from there.
 """
@@ -59,6 +64,22 @@ _API_HEADERS = {
     "Accept": "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
 }
+
+
+class _NoRelease:
+    """Type of :data:`NO_RELEASE`; see there."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid only
+        return "NO_RELEASE"
+
+
+#: GitHub answered authoritatively that this repository has no published release
+#: (every release is a draft or a pre-release, or there are none at all). This is
+#: a completed check with a known answer, which is why it is not ``None``: a
+#: transport failure means "ask again", while this means "forget what you knew".
+NO_RELEASE = _NoRelease()
 
 
 @dataclass(frozen=True)
@@ -151,22 +172,50 @@ class UpdateService:
             # interval. The retry rate is bounded by launches, not by a timer.
             return self._to_update_info(stamp)
 
+        if payload is NO_RELEASE:
+            # GitHub answered, and the answer is "nothing is published". That is
+            # a *completed* check, not a failed one, so it gets stamped and the
+            # previous answer is dropped. Without this the two are indistinguishable
+            # and a release that was deleted or pulled goes on being advertised
+            # forever — every launch re-asks, 404s, and falls back to the stale
+            # answer it should have discarded.
+            stamp = _CheckStamp(checked_at=time.time())
+            self._write_stamp(stamp)
+            return self._to_update_info(stamp)
+
         stamp = self._stamp_from_payload(payload)
         self._write_stamp(stamp)
         return self._to_update_info(stamp)
 
     # ------------------------------------------------------------------ network ------------------------------------------------------------------
-    def _fetch_latest_release(self) -> dict[str, Any] | None:
-        """GET the latest release payload, or ``None`` on any failure at all."""
+    def _fetch_latest_release(self) -> dict[str, Any] | _NoRelease | None:
+        """The latest release payload, :data:`NO_RELEASE`, or ``None``.
+
+        Three outcomes, because "I could not reach GitHub" and "GitHub says there
+        is nothing published" call for opposite handling and only one of them is
+        a failure. A 404 from this endpoint is an *answer*: the repository has no
+        published non-prerelease, non-draft release. Collapsing it into ``None``
+        alongside the transport failures is what let a deleted release keep being
+        advertised.
+        """
         try:
             response = requests.get(
                 self.api_url, headers=_API_HEADERS, timeout=self.request_timeout
             )
-            response.raise_for_status()
-            payload = response.json()
         except Exception as exc:
             # Having no connection is the ordinary case here, not a fault worth
             # an ERROR + traceback for a check the user never asked for.
+            logger.debug(f"Update check request failed: {exc}")
+            return None
+
+        if response.status_code == 404:
+            logger.info("Update check: no published release for this repository")
+            return NO_RELEASE
+
+        try:
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:
             logger.debug(f"Update check request failed: {exc}")
             return None
         if not isinstance(payload, dict):
@@ -246,6 +295,7 @@ def reset_update_service() -> None:
 
 __all__ = [
     "LATEST_RELEASE_API_URL",
+    "NO_RELEASE",
     "RELEASES_PAGE_URL",
     "UpdateInfo",
     "UpdateService",

--- a/tests/test_update_service.py
+++ b/tests/test_update_service.py
@@ -15,6 +15,7 @@ from typing import Any
 import pytest
 
 from services.update_service import (
+    NO_RELEASE,
     RELEASES_PAGE_URL,
     UpdateInfo,
     UpdateService,
@@ -218,6 +219,71 @@ def test_a_failed_request_keeps_serving_the_last_known_answer(tmp_path: Path) ->
 
     assert result is not None
     assert result.version == "1.0.3"
+
+
+def test_a_deleted_release_stops_being_advertised(tmp_path: Path) -> None:
+    """The bug this guards: a pulled release recommended forever from a stale cache.
+
+    A 404 means "nothing is published", which is an answer. Treating it like a
+    transport failure made every later launch re-ask, 404, and fall back to the
+    very answer it should have thrown away.
+    """
+    service, calls = _service(
+        tmp_path,
+        check_interval=0.0,
+        responses=[_release_payload("v1.0.3"), NO_RELEASE],
+    )
+
+    assert service.check() is not None  # v1.0.3 is published and newer
+    # The release is then deleted, so GitHub starts answering 404.
+    assert service.check() is None
+    assert len(calls) == 2
+
+
+def test_a_deleted_release_stays_gone_across_restarts(tmp_path: Path) -> None:
+    """The cleared answer must be persisted, not just returned once."""
+    service, _calls = _service(
+        tmp_path, check_interval=0.0, responses=[_release_payload("v1.0.3"), NO_RELEASE]
+    )
+    service.check()
+    service.check()
+
+    # A fresh service reading the same stamp, with the throttle still holding.
+    restarted, calls = _service(tmp_path, check_interval=86400.0)
+
+    assert restarted.check() is None
+    assert not calls, "a stamped 'nothing published' must satisfy the throttle"
+
+
+def test_no_release_counts_as_a_completed_check(tmp_path: Path) -> None:
+    service, calls = _service(tmp_path, responses=[NO_RELEASE, _release_payload("v1.0.3")])
+
+    assert service.check() is None
+    # Throttled: the 404 was a real answer, so it holds the window like any other.
+    assert service.check() is None
+    assert len(calls) == 1
+
+
+def test_a_404_is_read_as_no_release_not_as_a_failure(tmp_path: Path, monkeypatch) -> None:
+    """The real ``requests`` seam: 404 must reach the NO_RELEASE path."""
+    import services.update_service as update_service
+
+    class _NotFound:
+        status_code = 404
+
+        def raise_for_status(self) -> None:  # pragma: no cover - never reached
+            raise AssertionError("404 must be handled before raise_for_status")
+
+        def json(self) -> Any:  # pragma: no cover - never reached
+            raise AssertionError("404 carries no payload worth reading")
+
+    monkeypatch.setattr(update_service.requests, "get", lambda *a, **k: _NotFound())
+    service = UpdateService(current_version="1.0.2", cache_path=tmp_path / "update_check.json")
+
+    assert service._fetch_latest_release() is update_service.NO_RELEASE
+    assert service.check() is None
+    # Stamped, unlike a transport failure — that is the whole distinction.
+    assert (tmp_path / "update_check.json").exists()
 
 
 def test_requests_failures_never_escape_the_service(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
You deleted the `v1.1.7` test fixture and the installed v1.1.6 build kept offering it. That is not the 24-hour throttle — a **48-hour-old** stamp reproduces it, so it was permanent, not merely slow.

## Cause

`/releases/latest` returns **404** when a repo has no published, non-prerelease release. `_fetch_latest_release` collapsed that into the same `None` as a DNS failure or a 5xx, and `check()` treats `None` as *"transient — keep serving the last known answer"*:

```python
payload = self._fetch_latest_release()
if payload is None:
    return self._to_update_info(stamp)   # <-- serves the stale answer, never re-stamps
```

So every launch re-asked, got the 404, and fell back to the answer it should have discarded. The comment on that branch even enumerates the cases it means to cover — *"Offline, DNS failure, rate limit, 5xx…"* — and 404 is not among them, but lands there anyway.

Reproduced against the live API with a 48h-old stamp:

```
after throttle expiry, live check -> UpdateInfo(version='1.1.7', release_url='…/tag/v1.1.7')
stamp on disk after the check     -> {"latest_version": "1.1.7", ...}   # unchanged
```

## Fix

A 404 is an *answer*, not a failure, so it gets its own outcome (`NO_RELEASE`). `check()` stamps it as a completed check carrying no version, which clears the notice and holds the throttle window like any other real answer.

Transport failures are untouched: still unstamped, still retried next launch, still serving the last answer.

Same scenario after the fix:

```
live check -> None
stamp now  -> {'checked_at': …, 'latest_version': None, 'release_url': None}
```

## Notes

- The notice clears on **next launch**, not mid-session — `check_for_update()` runs once at startup (`lifecycle.py:164`) and the status-bar text is set once. Clearing it live would mean a second check nobody asked for.
- Four regression tests added, including one driving the real `requests` seam with a 404 response to prove it reaches the new path rather than `raise_for_status`.
- 46 tests pass across `test_update_service.py` + `test_update_check_mixin.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)