### PR TITLE
fix(build): stop the installer build pulling a version bump out from under itself

### DIFF
--- a/packaging/build_installer.ps1
+++ b/packaging/build_installer.ps1
@@ -94,6 +94,18 @@ function Ensure-GitSync {
         return
     }
 
+    # Never in CI. A CI job must build exactly the commit it checked out, and
+    # since versioning moved after the merge (docs/VERSIONING.md) `main` grows a
+    # `chore(release): VERSION x.y.z` commit seconds after any merge lands. A
+    # pull here swallows it mid-build: the run that merged PR #1000 read VERSION
+    # as 1.1.6, pulled 1.1.7 into the tree, and then ISCC -- which reads the file
+    # again at compile time -- emitted MTGOTools_Setup_v1.1.7.exe while the
+    # script went looking for the 1.1.6 name it had already computed.
+    if ($env:CI) {
+        Write-Info "CI detected; building the checked-out commit without pulling."
+        return
+    }
+
     Write-Info "Syncing with remote branch..."
     $currentLocation = Get-Location
     Push-Location $ProjectRoot
@@ -108,6 +120,15 @@ function Ensure-GitSync {
 
 # Ensure we are on the latest branch before building
 Ensure-GitSync
+
+# Re-read VERSION after the sync. installer.iss reads the same file itself, at
+# ISCC compile time -- minutes later, and after this pull. Reading it once up top
+# left two readers of a file that had moved in between, and the only symptom was
+# the build "succeeding" and then failing on a filename that did not exist.
+# Defence in depth: the CI guard above already prevents the pull that caused it,
+# but a local build pulling a colleague's version bump would desync the same way.
+$AppVersion = (Get-Content -Raw $VersionFile).Trim()
+$InstallerFileName = "MTGOTools_Setup_v$AppVersion.exe"
 
 # Step 0: clean previous dist output
 Write-Info "Cleaning dist directory..."


### PR DESCRIPTION
**`main` is currently red, and will fail on every future release merge until this lands.**

## What broke

`build_installer.ps1` reads `VERSION` at line 41 to compute the expected installer filename. `Ensure-GitSync` runs `git pull --ff-only` at line ~110. `installer.iss` reads `VERSION` **again**, independently, through ISPP `FileRead` at ISCC compile time — minutes later.

Those two reads used to agree. Post-merge versioning broke that: `main` now grows a `chore(release): VERSION x.y.z` commit *seconds* after any merge lands. The CI run for the PR #1000 merge checked out `1.1.6`, pulled `1.1.7` into its own working tree mid-build, and then:

```
Successful compile (55.047 sec). Resulting Setup program filename is:
  D:\a\MTGO_Tools\MTGO_Tools\dist\installer\MTGOTools_Setup_v1.1.7.exe
[ERROR] Installer was not created at expected location:
  D:\a\MTGO_Tools\MTGO_Tools\dist\installer\MTGOTools_Setup_v1.1.6.exe
```

Every other CI job passed. Only `Build Windows Installer` failed, and its error names a missing file rather than a version conflict — which is why this reads as a packaging fault rather than the race it is.

Worth noting the Release workflow is immune by accident: it checks out an explicit SHA in detached HEAD, so the pull has no upstream and does nothing. Only CI, which checks out a branch, is affected.

## The fix

Two changes, covering different cases:

1. **Skip the pull when `$env:CI` is set.** A CI job must build the commit it checked out. Pulling anything is wrong there regardless of this bug.
2. **Re-read `VERSION` after the sync.** Defence in depth for local builds — a developer pulling a colleague's version bump would desync the same two readers, with the same confusing symptom.

## Verification

Not verifiable from this side — there is no Inno Setup or PowerShell build here. The change is exercised by CI on this PR: the `Build Windows Installer` job now takes the `$env:CI` branch, and passing means the checked-out commit is what gets built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)