### PR TITLE
fix(ui): keep the mainboard/sideboard sash dark through a live drag

### DIFF
--- a/docs/WXMSW_BEHAVIOUR.md
+++ b/docs/WXMSW_BEHAVIOUR.md
@@ -434,6 +434,34 @@ silently stops being draggable. Own-drawn via `EVT_PAINT` (uniquely safe on a sp
 the panes are child windows, so the only pixels the handler owns are the gutter). See
 `widgets.splitter`
 
+**`EVT_PAINT` is not the only place wx paints the sash.**
+`wxSplitterWindow::SizeWindows()` ends by drawing it **straight onto a `wxClientDC`** --
+an immediate, un-invalidated write to the window surface that never becomes a `WM_PAINT`
+and so never reaches a paint handler. That is not an edge case: it runs on every live-drag
+step, every resize and every `SetSashPosition`, which is most of the times the sash is
+painted at all. Traced off the surface, one drag step runs `OnMouseEvent(MOTION)` ->
+`EVT_PAINT` (own-drawn, dark) -> `OnInternalIdle` -> `SizeWindows()` (native, light), so the
+own-drawn colour is painted *first* and loses. Measured: **14 of 15** drag steps left the
+light sash on screen, a `--method screen` video of a real sweep caught it in **9 of 43**
+frames, and a freshly laid-out split sat on the native band indefinitely -- which is the
+"light when left alone, dark while you drag it" the bug was reported as.
+
+The fix is to repaint the gutter *after* `SizeWindows()`, on both of the paths that reach
+it: `OnInternalIdle` (a live drag defers `SizeWindows()` there -- `OnMouseEvent` only sets
+`m_needUpdating`) and a `SetSashPosition` override (a programmatic move and a resize run it
+inline). Two routes that look obvious do **not** work, and both were measured:
+
+| route | result |
+| --- | --- |
+| `SetSashInvisible(True)` (which *does* stop `DrawSash` at source) plus a Python `GetSashSize()` override to restore the hit test | **no effect.** `GetSashSize()` is not virtual across the Python boundary: with the override returning 7, C++ still laid pane two out for a 0px sash. The documented trap is not escapable this way |
+| a `wx.DelegateRendererNative` subclass overriding `DrawSplitterSash`, installed with `wx.RendererNative.Set()` | **never called.** wxPython builds no director for it, so `wxSplitterWindow::DrawSash` keeps reaching the native renderer |
+
+Note the measurement method: this defect is **invisible to a `PrintWindow` capture**, which
+re-renders the widget tree and therefore reports the pixels the paint handler *intends*.
+It has to be read back with a `ClientDC` blit or grabbed off the screen
+(`automation.cli start-video --method screen`). That is why six phases of screenshots
+walked past it. `tests/ui/test_splitter_sash_colour.py` pins it
+
 ### `wx.StaticBox`
 
 `SetForegroundColour` recolours **only the label**; `SetBackgroundColour` fills the

--- a/tests/ui/test_splitter_sash_colour.py
+++ b/tests/ui/test_splitter_sash_colour.py
@@ -120,9 +120,9 @@ def test_sash_is_border_subtle_at_rest(split_frame: DarkSplitter, wx_app: wx.App
     gutter = _read_gutter(split_frame)
     assert gutter, "no gutter pixels were read back; the frame has no surface"
     assert _native_rows(gutter) == 0, f"native sash colours at rest: {gutter}"
-    assert gutter.count(SUBTLE) >= len(gutter) - 1, (
-        f"the sash gutter is not BORDER_SUBTLE {SUBTLE}: {gutter}"
-    )
+    assert (
+        gutter.count(SUBTLE) >= len(gutter) - 1
+    ), f"the sash gutter is not BORDER_SUBTLE {SUBTLE}: {gutter}"
 
 
 def test_sash_stays_dark_through_a_live_mouse_drag(
@@ -205,6 +205,6 @@ def test_sash_survives_a_resize(split_frame: DarkSplitter, wx_app: wx.App) -> No
         if _native_rows(_read_gutter(splitter)) >= 3:
             offenders.append(width)
 
-    assert offenders == [], (
-        f"a resize left the native near-white sash on the surface at widths {offenders}"
-    )
+    assert (
+        offenders == []
+    ), f"a resize left the native near-white sash on the surface at widths {offenders}"

--- a/tests/ui/test_splitter_sash_colour.py
+++ b/tests/ui/test_splitter_sash_colour.py
@@ -1,0 +1,210 @@
+"""The mainboard/sideboard sash stayed dark for the whole of a live drag.
+
+What broke
+----------
+:class:`widgets.splitter.DarkSplitter` own-draws the sash gutter because wxMSW's
+native one is a near-white ``#F0F0F0``/``#FFFFFF`` band and no colour call
+reaches it (``docs/WXMSW_BEHAVIOUR.md``). It did that from ``EVT_PAINT`` alone,
+and ``EVT_PAINT`` is not the only place wx paints the sash:
+``wxSplitterWindow::SizeWindows()`` ends by drawing it **straight onto a
+``wxClientDC``**, an immediate un-invalidated write that never becomes a
+``WM_PAINT``.
+
+Traced off the window surface, one step of a live drag ran in this order:
+
+1. ``OnMouseEvent(MOTION)`` moved the panes,
+2. ``EVT_PAINT`` filled the gutter with ``BORDER_SUBTLE``,
+3. ``OnInternalIdle`` ran ``SizeWindows()``, which painted the native band on
+   top of it.
+
+The own-drawn colour lost every step because it was painted *first*. Measured on
+the deck workspace, **14 of 15** drag steps left the light sash on screen, and a
+screen-grabbed video of a real sweep caught it in 9 of 43 frames -- so the
+divider strobed between ``#39424E`` and near-white at mouse-move cadence, the
+brightest thing in a dark-themed window and a large flickering area.
+
+What is pinned here
+-------------------
+The surface itself, which is the only thing that can see this. Every assertion
+below reads pixels back with a ``ClientDC`` blit, deliberately **not** a
+``PrintWindow`` capture: ``PrintWindow`` re-renders the widget tree, so it
+reports the pixels the paint handler *intends* and hides this defect completely.
+That is why the redesign's own screenshots walked past it for six phases.
+
+Both paths to ``SizeWindows()`` are driven, because they are separate holes and
+the fix plugs them in two different places:
+
+* a live drag, through ``wxSplitterWindow``'s own ``OnMouseEvent`` -- deferred
+  to ``OnInternalIdle``,
+* a programmatic ``SetSashPosition`` -- run inline.
+
+**What this cannot cover:** that no frame the compositor actually presents holds
+the light band. That needs a real gesture and a screen grab; it was verified
+that way (0 of 38 frames after the fix, 9 of 43 before) and stays a manual
+check with ``automation.cli start-video --method screen``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+wx = pytest.importorskip("wx")
+
+from utils.constants.theme import BORDER_SUBTLE  # noqa: E402
+from widgets.splitter import DarkSplitter  # noqa: E402
+
+#: What ``wxRendererNative`` paints a 3-D sash with, sampled off a probe frame:
+#: a ``#F0F0F0`` band around a ``#FFFFFF`` centre line, closed by ``#A0A0A0``
+#: and ``#696969`` shadow rows.
+NATIVE_SASH_COLOURS = {
+    (0xF0, 0xF0, 0xF0),
+    (0xFF, 0xFF, 0xFF),
+    (0xA0, 0xA0, 0xA0),
+    (0x69, 0x69, 0x69),
+}
+SUBTLE = tuple(BORDER_SUBTLE)
+
+
+def _read_gutter(splitter: wx.SplitterWindow) -> list[tuple[int, int, int]]:
+    """The sash band's pixels, read back off the window's own surface.
+
+    A ``ClientDC`` blit, not ``wx.WindowDC``/``PrintWindow``: the defect is an
+    un-invalidated write to this exact surface, and a re-render cannot see it.
+    """
+    size = splitter.GetClientSize()
+    bitmap = wx.Bitmap(size)
+    memory = wx.MemoryDC(bitmap)
+    memory.Blit(0, 0, size.width, size.height, wx.ClientDC(splitter), 0, 0)
+    memory.SelectObject(wx.NullBitmap)
+    image = bitmap.ConvertToImage()
+
+    position = splitter.GetSashPosition()
+    sash = splitter.GetSashSize()
+    x = min(40, size.width - 1)
+    return [
+        (image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y))
+        for y in range(position, min(size.height, position + sash))
+    ]
+
+
+def _native_rows(gutter: list[tuple[int, int, int]]) -> int:
+    return sum(1 for pixel in gutter if pixel in NATIVE_SASH_COLOURS)
+
+
+@pytest.fixture(name="split_frame")
+def fixture_split_frame(wx_app: wx.App):
+    """A shown frame holding one horizontally split :class:`DarkSplitter`.
+
+    Shown and raised deliberately: an unmapped window has no surface to read
+    back, so the whole measurement would be vacuous.
+    """
+    frame = wx.Frame(None, size=(500, 500))
+    splitter = DarkSplitter(frame)
+    top = wx.Panel(splitter)
+    bottom = wx.Panel(splitter)
+    splitter.SetMinimumPaneSize(40)
+    splitter.SplitHorizontally(top, bottom, 200)
+    frame.Show()
+    frame.Raise()
+    for _ in range(20):
+        wx_app.Yield()
+    yield splitter
+    frame.Destroy()
+    for _ in range(20):
+        wx_app.Yield()
+
+
+def test_sash_is_border_subtle_at_rest(split_frame: DarkSplitter, wx_app: wx.App) -> None:
+    """The baseline the redesign already had: a still sash is ``BORDER_SUBTLE``."""
+    wx_app.Yield()
+    gutter = _read_gutter(split_frame)
+    assert gutter, "no gutter pixels were read back; the frame has no surface"
+    assert _native_rows(gutter) == 0, f"native sash colours at rest: {gutter}"
+    assert gutter.count(SUBTLE) >= len(gutter) - 1, (
+        f"the sash gutter is not BORDER_SUBTLE {SUBTLE}: {gutter}"
+    )
+
+
+def test_sash_stays_dark_through_a_live_mouse_drag(
+    split_frame: DarkSplitter, wx_app: wx.App
+) -> None:
+    """The regression: ``SizeWindows()`` repainting the native sash mid-drag.
+
+    The events go into ``wxSplitterWindow``'s own ``OnMouseEvent`` through the
+    binding table a physical mouse's arrive on, which is what puts the deferred
+    ``SizeWindows()`` -- the actual defect -- under test. ``SetSashPosition``
+    would exercise the *other* path and leave this one unmeasured.
+    """
+    splitter = split_frame
+    splitter.SetSashPosition(150)
+    wx_app.Yield()
+
+    def send(event_type: int, y: int, dragging: bool = False) -> None:
+        event = wx.MouseEvent(event_type)
+        event.SetEventObject(splitter)
+        event.SetPosition(wx.Point(40, y))
+        if dragging:
+            event.SetLeftDown(True)
+        splitter.GetEventHandler().ProcessEvent(event)
+
+    # Grab the sash itself: +3 lands inside the 7px band, which is what
+    # wxSplitterWindow's hit test requires before it will start a drag.
+    send(wx.wxEVT_LEFT_DOWN, 153)
+
+    offenders: list[tuple[int, list[tuple[int, int, int]]]] = []
+    for target in range(160, 320, 10):
+        send(wx.wxEVT_MOTION, target + 3, dragging=True)
+        wx_app.Yield()
+        gutter = _read_gutter(splitter)
+        if _native_rows(gutter) >= 3:
+            offenders.append((splitter.GetSashPosition(), gutter))
+    send(wx.wxEVT_LEFT_UP, 323)
+    wx_app.Yield()
+
+    assert splitter.GetSashPosition() > 150, (
+        "the drag never moved the sash, so nothing was measured -- "
+        "check the hit test still accepts a press inside GetSashSize()"
+    )
+    assert offenders == [], (
+        "wxSplitterWindow::SizeWindows() repainted the native near-white sash "
+        f"during a live drag at sash positions {[pos for pos, _ in offenders]}; "
+        "DarkSplitter.OnInternalIdle must run after it"
+    )
+
+
+def test_sash_stays_dark_through_a_programmatic_move(
+    split_frame: DarkSplitter, wx_app: wx.App
+) -> None:
+    """The other hole: ``SetSashPosition`` runs ``SizeWindows()`` inline.
+
+    No ``Yield`` between the move and the read. That is the point -- it is the
+    gap before the event loop reaches idle that a screen grab caught the light
+    band in, so the fix has to close it at the call rather than at the next
+    idle round.
+    """
+    splitter = split_frame
+    offenders: list[int] = []
+    for position in range(150, 300, 10):
+        splitter.SetSashPosition(position)
+        if _native_rows(_read_gutter(splitter)) >= 3:
+            offenders.append(position)
+
+    assert offenders == [], (
+        "SetSashPosition left the native near-white sash on the surface at "
+        f"{offenders}; the repaint has to happen at the call, not at the next idle"
+    )
+
+
+def test_sash_survives_a_resize(split_frame: DarkSplitter, wx_app: wx.App) -> None:
+    """``wxSplitterWindow::OnSize`` calls ``SizeWindows()`` too."""
+    splitter = split_frame
+    offenders: list[int] = []
+    for width in (480, 460, 440, 420):
+        splitter.GetParent().SetSize((width, 500))
+        wx_app.Yield()
+        if _native_rows(_read_gutter(splitter)) >= 3:
+            offenders.append(width)
+
+    assert offenders == [], (
+        f"a resize left the native near-white sash on the surface at widths {offenders}"
+    )

--- a/widgets/splitter.py
+++ b/widgets/splitter.py
@@ -44,6 +44,51 @@ The 3-D flags are kept deliberately. They no longer draw anything (the paint
 handler does not skip), but ``SP_3DSASH`` is what sets ``GetSashSize()`` to 7,
 and the deck workspace's saved sash position is stored in points that assume it.
 Dropping the flag would silently move every user's split.
+
+``EVT_PAINT`` alone is not enough: ``SizeWindows()`` repaints the sash
+------------------------------------------------------------------------
+The paint handler above is correct at rest and was wrong for the whole duration
+of a live drag, which is the one moment the user is looking straight at the
+sash. ``wxSplitterWindow::SizeWindows()`` ends by drawing the sash **straight
+onto a ``wxClientDC``** -- an immediate, un-invalidated write to the window
+surface that never becomes a ``WM_PAINT`` and so never reaches ``EVT_PAINT``.
+
+Traced on the surface itself (a ``ClientDC`` blit after each step -- a
+``PrintWindow`` capture re-renders the tree and shows the *intended* pixels, so
+it hides this defect completely), one step of a live drag runs:
+
+1. ``OnMouseEvent(MOTION)`` moves the panes; the gutter is briefly unpainted,
+2. ``EVT_PAINT`` runs and fills it with ``BORDER_SUBTLE``,
+3. **then** ``OnInternalIdle`` runs ``SizeWindows()``, which paints the native
+   ``#F0F0F0``/``#FFFFFF``/``#A0A0A0``/``#696969`` band over the top.
+
+The own-drawn colour loses every step because it is painted *first*. Measured on
+the deck workspace: **14 of 15 drag steps** left the native light sash on screen,
+and a ``--method screen`` video of a real sweep caught it in 9 of 43 frames --
+i.e. the divider strobes between ``#39424E`` and near-white at mouse-move
+cadence, which in a dark theme is both the brightest thing on screen and a large
+flickering area.
+
+Neither obvious escape works, and both were measured rather than read:
+
+===================================  =========================================
+route                                result
+===================================  =========================================
+``SetSashInvisible(True)`` plus a     **no effect.** ``GetSashSize()`` is not
+  Python ``GetSashSize()`` override   virtual across the Python boundary: with
+                                      the override returning 7, C++ still laid
+                                      pane two out for a 0px sash. The
+                                      documented trap is not escapable this way
+a ``wx.DelegateRendererNative``       **never called.** wxPython builds no
+  subclass overriding                 director for it, so
+  ``DrawSplitterSash``, installed     ``wxSplitterWindow::DrawSash`` keeps
+  with ``wx.RendererNative.Set``      reaching the native renderer
+===================================  =========================================
+
+What is left is to repaint the gutter *after* ``SizeWindows()`` on each path
+that reaches it. ``OnInternalIdle`` *is* dispatched into Python and is the only
+hook that runs after a live drag's deferred ``SizeWindows()``; a programmatic
+move runs it inline, so ``SetSashPosition`` is overridden for that one.
 """
 
 from __future__ import annotations
@@ -66,17 +111,46 @@ class DarkSplitter(wx.SplitterWindow):
     not apply -- the same call phase 6 made for all ten section cards. The drag
     affordance is the cursor change, which wx still provides because the sash
     keeps its size.
+
+    The colour is applied on **three** paths, because wx paints the sash on
+    three and only one of them is an event (see the module docstring):
+
+    * ``EVT_PAINT`` -- exposure, hot-tracking, and every ordinary repaint,
+    * ``OnInternalIdle`` -- immediately after a live drag's deferred
+      ``SizeWindows()`` has drawn the native sash onto a ``wxClientDC``,
+    * ``SetSashPosition`` -- the same, for a programmatic move and for a
+      resize, both of which run ``SizeWindows()`` inline.
     """
 
     def __init__(self, parent: wx.Window, *args, **kwargs) -> None:
         kwargs.setdefault("style", DEFAULT_SPLITTER_STYLE)
         super().__init__(parent, *args, **kwargs)
+        self._sash_brush = wx.Brush(wx.Colour(*BORDER_SUBTLE))
         # Required by wx.AutoBufferedPaintDC: without it wxMSW leaves the
         # backing store alone and a window that paints everything itself shows
         # whatever was last blitted there (phase 5's finding).
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
         self.SetBackgroundColour(wx.Colour(*BORDER_SUBTLE))
         self.Bind(wx.EVT_PAINT, self._on_paint)
+
+    def _gutter_rect(self) -> wx.Rect:
+        """The sash band, in client coordinates.
+
+        ``GetSashSize()`` rather than a literal 7: it is what ``SizeWindows()``
+        itself lays the panes out with, so this rect is exactly the strip
+        neither pane covers.
+        """
+        size = self.GetClientSize()
+        position = self.GetSashPosition()
+        sash = self.GetSashSize()
+        if self.GetSplitMode() == wx.SPLIT_VERTICAL:
+            return wx.Rect(position, 0, sash, size.height)
+        return wx.Rect(0, position, size.width, sash)
+
+    def _fill_gutter(self, dc: wx.DC, rect: wx.Rect) -> None:
+        dc.SetPen(wx.TRANSPARENT_PEN)
+        dc.SetBrush(self._sash_brush)
+        dc.DrawRectangle(rect)
 
     def _on_paint(self, _event: wx.PaintEvent) -> None:
         """Fill the gutter and **do not skip**.
@@ -86,8 +160,55 @@ class DarkSplitter(wx.SplitterWindow):
         being avoided.
         """
         dc = wx.AutoBufferedPaintDC(self)
-        dc.SetBackground(wx.Brush(wx.Colour(*BORDER_SUBTLE)))
+        dc.SetBackground(self._sash_brush)
         dc.Clear()
+
+    def OnInternalIdle(self) -> None:
+        """Repaint the gutter after ``SizeWindows()`` has drawn the native sash.
+
+        ``super()`` first, and that ordering is the entire point: a live drag's
+        ``SizeWindows()`` runs inside it (``OnMouseEvent`` only sets
+        ``m_needUpdating``), and the ``wxClientDC`` it draws the native sash
+        with never raises a paint event. Painting here is the same immediate
+        write to the same surface, one call later, so the light band is
+        overwritten within a single idle round rather than surviving until the
+        next unrelated repaint.
+
+        This also covers ``wxSplitterWindow::OnSize``, whose inline
+        ``SizeWindows()`` is followed by an idle round before anything is
+        presented.
+        """
+        super().OnInternalIdle()
+        self._repaint_gutter_now()
+
+    def SetSashPosition(self, position: int, redraw: bool = True) -> None:
+        """Move the sash, then undo the native sash ``SizeWindows()`` just drew.
+
+        The idle repaint above is not enough on its own: a *programmatic* move
+        runs ``SizeWindows()`` inline, and the two panes then repaint their
+        (image-heavy) content before the event loop reaches idle -- a gap a
+        screen capture of the deck workspace caught the light band in 4 times
+        in 55 frames. This closes it at the call.
+        """
+        super().SetSashPosition(position, redraw)
+        if redraw:
+            self._repaint_gutter_now()
+
+    def _repaint_gutter_now(self) -> None:
+        """Fill the gutter, unconditionally.
+
+        A "has anything changed?" guard was tried and measured: it skipped 4 of
+        150 idle rounds *while the native sash was on the surface*, because
+        ``SizeWindows()`` can redraw at a position already filled with no
+        ``EVT_PAINT`` in between -- and 4 skips is exactly the residue a screen
+        capture still caught. There is no cheap way to detect that from Python,
+        so the guard cost correctness and bought nothing: an idle app was
+        measured at fewer than 2.5 idle rounds per second, and the work here is
+        one solid fill of a 7px band.
+        """
+        if not self.IsSplit():
+            return
+        self._fill_gutter(wx.ClientDC(self), self._gutter_rect())
 
 
 __all__ = ["DEFAULT_SPLITTER_STYLE", "DarkSplitter"]


### PR DESCRIPTION
The deck workspace's mainboard/sideboard divider was near-white when left alone
and dark grey while it was being dragged. Both halves are the same defect.

## What was wrong

`DarkSplitter` own-draws the sash because wxMSW's native one is unreachable
(`SetBackgroundColour`, `disable_native_theme()` and every `SP_*` flag leave it
light — `docs/WXMSW_BEHAVIOUR.md`). It did that from **`EVT_PAINT` alone**, and
`EVT_PAINT` is not the only place wx paints the sash:

> `wxSplitterWindow::SizeWindows()` ends by drawing the sash **straight onto a
> `wxClientDC`** — an immediate, un-invalidated write to the window surface that
> never becomes a `WM_PAINT`, and so never reaches a paint handler.

That is not an edge case. It runs on every live-drag step, every resize and every
`SetSashPosition`, which is most of the times the sash gets painted at all.

Traced off the surface, one drag step runs in this order:

1. `OnMouseEvent(MOTION)` moves the panes,
2. `EVT_PAINT` fills the gutter with `BORDER_SUBTLE` (`#39424E`),
3. `OnInternalIdle` runs `SizeWindows()`, which paints the native
   `#F0F0F0`/`#FFFFFF`/`#A0A0A0`/`#696969` band **on top**.

The own-drawn colour loses every step because it is painted *first*. So a
freshly laid-out split sits on the native band until something unrelated
repaints it — *"very light alone"* — and a drag generates the repaints that
briefly win it back — *"dark grey when dragged"* — strobing between the two at
mouse-move cadence.

## Design read

`BORDER_SUBTLE` is the right token and is unchanged: a sash separates two regions
each identified by their own content, so WCAG 1.4.11 does not apply. The defect
was never the colour choice, it was that the colour did not stick.

What the bug actually cost, in a dark-themed window:

- **Inverted hierarchy.** A ~1585px × 7px band of `#F0F0F0` around a `#FFFFFF`
  centre line is ≈11k near-white pixels — the brightest element on screen,
  louder than the card art it separates.
- **Luminance flicker over a large area**, alternating at mouse-move cadence,
  right under the pointer the user is tracking. That is a genuine accessibility
  concern, not only polish.
- **The divider vanishing.** Some frames show the gutter carrying a neighbouring
  pane's pixels, so the split momentarily reads as one continuous region. This is
  pane-move-before-repaint tearing, is dark-on-dark, is unchanged by this PR
  (≈40% of frames both before and after), and is out of scope here.

## Measured, not assumed

Per the house rule in `docs/WXMSW_BEHAVIOUR.md` — *never set a colour and assume
it applied*. All numbers are read-back pixels.

| | before | after |
| --- | --- | --- |
| live-drag steps showing the native light sash (probe frame) | **14 / 15** | **0 / 15** |
| frames of a real deck-workspace sweep, `--method screen` video | **9 / 43** | **0 / 38** |
| freshly laid-out split, at rest | **native light, indefinitely** | `#39424E` |

This defect is **invisible to a `PrintWindow` capture**, which re-renders the
widget tree and therefore reports the pixels the handler *intends*. It has to be
read back with a `ClientDC` blit or grabbed off the screen. That is how six
phases of redesign screenshots walked past it.

## The fix

Repaint the gutter *after* `SizeWindows()`, on both paths that reach it:

- **`OnInternalIdle`** — a live drag defers `SizeWindows()` there (`OnMouseEvent`
  only sets `m_needUpdating`), so this is the one hook that runs after it.
- **`SetSashPosition` override** — a programmatic move and a resize run
  `SizeWindows()` inline, and the image-heavy panes then repaint before the loop
  reaches idle; a screen grab caught the light band in that gap 4 times in 55
  frames.

Two obvious routes were probed, do **not** work, and are now written down so the
next person does not spend the time:

| route | result |
| --- | --- |
| `SetSashInvisible(True)` (which *does* stop `DrawSash` at source) plus a Python `GetSashSize()` override to restore the hit test | **no effect** — `GetSashSize()` is not virtual across the Python boundary; with the override returning 7, C++ still laid pane two out for a 0px sash |
| a `wx.DelegateRendererNative` subclass overriding `DrawSplitterSash`, installed via `wx.RendererNative.Set()` | **never called** — wxPython builds no director for it |

A "has anything changed?" guard on the repaint was tried and dropped on
evidence: it skipped 4 of 150 idle rounds *while the native sash was on the
surface*, which was exactly the residue the screen capture still caught. An idle
app measures at fewer than 2.5 idle rounds per second, so the guard bought
nothing and cost correctness.

Behaviour is otherwise untouched: same style flags, so `GetSashSize()` stays 7
and every user's saved sash position still means what it did. Dragging, the
cursor affordance and the min-pane-size clamp are unchanged.

## Tests

`tests/ui/test_splitter_sash_colour.py` pins all three paths (live mouse drag
through wx's own `OnMouseEvent`, programmatic move, resize) plus the rest state,
reading the surface back with a `ClientDC` blit. **All four assertions fail
against the previous code and pass against this one.**

`tests/ui` + `tests/test_widget_audit.py`: 171 passed, 2 xfailed. `ruff check`
and `ruff format --check` clean.

Verified end to end in the running app via the automation harness
(`sash-drag` driven from a single client process while `start-video
--method screen` recorded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)