### PR TITLE
feat(release): keep each line's x.y.0 so an upgrade can be tested

### DIFF
--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -152,12 +152,30 @@ applied silently put the app back on screen afterwards. See
 `scripts/prune_releases.py` keeps the published releases down to what someone
 would actually install:
 
-1. **One release per `MAJOR.MINOR` line** — the newest patch. Nobody wants `1.0.0`
+1. **The newest patch of each `MAJOR.MINOR` line.** Nobody wants `1.0.0`
    once `1.0.4` exists; it is the same line with known bugs still in it. Keeping
    the newest patch of *each* line still lets someone stay on an older line
    deliberately — the last build before a redesign, say.
-2. **At most 10 releases**, newest first, if the number of lines ever grows past
+2. **The `x.y.0` of each line** — its first release, kept even once later patches
+   supersede it.
+3. **At most 10 releases**, newest first, if the number of lines ever grows past
    that.
+
+Rule 2 is the **upgrade-path** rule. Rule 1 on its own made an update impossible
+to test end to end: `v1.2.0` was deleted the instant `v1.2.1` published, so the
+release you would upgrade *from* never coexisted with the one you would upgrade
+*to*, and the in-app updater had nothing to run against. A `.0` is also the
+natural baseline of a line — the build before any of its patches — which makes
+it the one worth keeping if you are keeping two.
+
+Rules 2 and 3 interact, and 3 wins: the cap is applied last and newest-first, so
+a repo with more lines than the cap can still have a `.0` trimmed off the
+*oldest* end. That is deliberate — the cap is a hard ceiling on storage, and the
+lines it reaches are ones nobody is upgrading from any more.
+
+> Pruning is **not** reversible. GitHub deletes release assets permanently, so a
+> `.0` that rule 1 already removed cannot be restored by adding rule 2 — it has
+> to be rebuilt from its tag (which is why the tags are never deleted).
 
 Only the **Release** and its assets (the ~180 MB installer and its checksum
 sidecar) are deleted. **Tags are never

--- a/scripts/prune_releases.py
+++ b/scripts/prune_releases.py
@@ -1,14 +1,26 @@
 #!/usr/bin/env python3
 """Keep the published GitHub Releases down to the ones anyone would install.
 
-Two rules, applied in order:
+Three rules, applied in order:
 
-1. **One release per ``MAJOR.MINOR`` line** -- the newest patch. Nobody wants
-   1.0.0 once 1.0.4 exists; it is the same line with known bugs still in it.
-   Keeping the newest patch of *each* line still lets someone stay on an older
-   line deliberately (the last build before a redesign, say).
-2. **At most ``--max`` releases** (default 10), newest first, in case the number
+1. **The newest patch of each ``MAJOR.MINOR`` line.** Nobody wants 1.0.0 once
+   1.0.4 exists; it is the same line with known bugs still in it. Keeping the
+   newest patch of *each* line still lets someone stay on an older line
+   deliberately (the last build before a redesign, say).
+2. **The ``x.y.0`` of each line** -- the line's first release, kept even once
+   later patches supersede it. This is the *upgrade-path* rule, and it exists
+   because rule 1 on its own made an update impossible to test: v1.2.0 was
+   deleted the instant v1.2.1 published, so the release you would upgrade *from*
+   never coexisted with the one you would upgrade *to*. A ``.0`` is also the
+   natural baseline of a line -- the build before any of its patches -- which
+   makes it the one worth keeping if you are keeping two.
+3. **At most ``--max`` releases** (default 10), newest first, in case the number
    of lines ever grows past that.
+
+Note how 2 and 3 interact: the cap is applied last and newest-first, so a repo
+with more lines than ``--max`` can still have a ``.0`` trimmed off the *oldest*
+end. That is the intended precedence -- the cap is a hard ceiling on storage,
+and the lines it reaches are the ones nobody is upgrading from any more.
 
 Only the **Release** is deleted, never the tag. Tags are the version history and
 the base ``next_version.py`` computes from, they cost nothing, and deleting one
@@ -61,13 +73,29 @@ def published_releases() -> list[tuple[int, int, int]]:
 def select_keep(
     versions: list[tuple[int, int, int]], max_releases: int = DEFAULT_MAX_RELEASES
 ) -> list[tuple[int, int, int]]:
-    """The releases that survive: newest patch per line, capped at ``max_releases``."""
+    """The releases that survive.
+
+    The newest patch of each ``MAJOR.MINOR`` line, plus that line's ``x.y.0`` if
+    it was ever published, capped at ``max_releases`` newest-first. A line whose
+    newest patch *is* its ``.0`` contributes one release, not two.
+
+    ``versions`` is only read, never assumed sorted -- the cap does its own
+    ordering, so a caller passing them oldest-first still gets the newest kept.
+    """
+    keep: set[tuple[int, int, int]] = set()
     newest_per_line: dict[tuple[int, int], tuple[int, int, int]] = {}
     for version in versions:
         line = (version[0], version[1])
         if version > newest_per_line.get(line, (-1, -1, -1)):
             newest_per_line[line] = version
-    return sorted(newest_per_line.values(), reverse=True)[:max_releases]
+        # The line's baseline, kept alongside the newest patch so there is
+        # always something to upgrade *from*. Only if it was really published:
+        # this iterates what `gh release list` returned, so a line that never
+        # shipped a .0 simply does not contribute one.
+        if version[2] == 0:
+            keep.add(version)
+    keep.update(newest_per_line.values())
+    return sorted(keep, reverse=True)[:max_releases]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_next_version.py
+++ b/tests/test_next_version.py
@@ -195,9 +195,34 @@ def test_apply_writes_the_computed_version(repo: Path) -> None:
 
 
 # ------------------------------------------------------------- retention ---
-def test_select_keep_keeps_the_newest_patch_of_each_line() -> None:
+def test_select_keep_keeps_the_newest_patch_and_the_baseline_of_each_line() -> None:
+    """Two per line: the newest patch, and the ``x.y.0`` it started from.
+
+    The middle patches go -- 1.1.5 and 1.0.4/1.0.2 are superseded builds of a
+    line whose newest is already kept.
+    """
     versions = [(1, 1, 6), (1, 1, 5), (1, 1, 0), (1, 0, 5), (1, 0, 4), (1, 0, 2), (1, 0, 0)]
-    assert select_keep(versions) == [(1, 1, 6), (1, 0, 5)]
+    assert select_keep(versions) == [(1, 1, 6), (1, 1, 0), (1, 0, 5), (1, 0, 0)]
+
+
+def test_select_keep_keeps_an_upgrade_path_within_a_line() -> None:
+    """The case that motivated the rule (#1003 -> v1.2.1).
+
+    Under the newest-patch-only rule v1.2.0 was deleted the instant v1.2.1
+    published, so there was no published release to upgrade *from* and the
+    in-app updater could not be exercised end to end.
+    """
+    assert select_keep([(1, 2, 1), (1, 2, 0), (1, 1, 8)]) == [(1, 2, 1), (1, 2, 0), (1, 1, 8)]
+
+
+def test_select_keep_does_not_double_count_a_line_that_is_only_a_baseline() -> None:
+    """A line whose newest patch *is* its ``.0`` contributes one release, not two."""
+    assert select_keep([(1, 3, 0), (1, 2, 4), (1, 2, 0)]) == [(1, 3, 0), (1, 2, 4), (1, 2, 0)]
+
+
+def test_select_keep_skips_a_baseline_that_was_never_published() -> None:
+    """A line that never shipped a ``.0`` just does not contribute one."""
+    assert select_keep([(1, 4, 3), (1, 4, 1)]) == [(1, 4, 3)]
 
 
 def test_select_keep_caps_the_total() -> None:
@@ -211,3 +236,14 @@ def test_select_keep_caps_the_total() -> None:
 def test_select_keep_is_ordered_newest_first() -> None:
     kept = select_keep([(1, 0, 0), (2, 1, 3), (1, 4, 2)])
     assert kept == [(2, 1, 3), (1, 4, 2), (1, 0, 0)]
+
+
+def test_the_cap_still_wins_over_a_baseline() -> None:
+    """``--max`` is a hard ceiling, applied last and newest-first.
+
+    A repo with more lines than the cap can lose a ``.0`` off the *oldest* end.
+    That is the intended precedence: the cap bounds storage, and the lines it
+    reaches are ones nobody is upgrading from any more.
+    """
+    versions = [(1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
+    assert select_keep(versions, max_releases=3) == [(1, 1, 1), (1, 1, 0), (1, 0, 1)]


### PR DESCRIPTION
## Why

Retention kept **only the newest patch of each `MAJOR.MINOR` line**. That means
the release you would upgrade *from* never coexists with the one you would
upgrade *to*: publishing `v1.2.1` deleted `v1.2.0` **in the same workflow run**,
so the in-app updater that shipped in 1.2.0 could not be exercised end to end
against a real published release.

That is how this surfaced — the plan was "install 1.2.0 and watch it update to
1.2.1", and 1.2.0's installer no longer existed.

## The rule

`select_keep` now keeps, per `MAJOR.MINOR` line:

1. the newest patch (unchanged), **and**
2. the line's **`x.y.0`** — its first release, held even once later patches
   supersede it.

A `.0` is the natural baseline of a line, the build before any of its patches,
which makes it the one worth keeping if you are keeping two.

Edge cases, each pinned by a test:

- a line whose newest patch **is** its `.0` contributes one release, not two;
- a line that never published a `.0` contributes none — the selection only runs
  over what `gh release list` actually returned, so nothing is invented;
- `--max` is unchanged and still **wins**. It is applied last and newest-first,
  so a repo with more lines than the cap can have a `.0` trimmed off the
  *oldest* end. That is the intended precedence: the cap bounds storage, and the
  lines it reaches are ones nobody upgrades from any more.

## Effect on this repo

Against the full tag history:

```
keep : 1.2.1, 1.2.0, 1.1.8, 1.1.0, 1.0.5, 1.0.0
drop : 1.1.7, 1.1.6, 1.1.5, 1.1.4, 1.1.3, 1.1.2, 1.1.1, 1.0.4, 1.0.2
```

Six releases instead of the three the old rule would keep, and the 1.2.1/1.2.0
pair is exactly the upgrade path that was missing.

## What this does *not* do

**It cannot bring `v1.2.0` back.** Rule 1 already deleted its assets and GitHub
removes them permanently — which is precisely why the tags are never deleted:
the build is reproducible from the tag. `v1.2.0` was rebuilt locally from
`v1.2.0` for the upgrade test; this PR only stops it happening again.

Assumption worth confirming: I read "keep x.y.0" as **the `.0` patch of each
minor line** (so 1.0.0, 1.1.0, 1.2.0 …), which is what the notation says and
what fixes the upgrade-path problem. The alternative reading — only the earliest
minor of each *major*, i.e. just 1.0.0 — would not have kept 1.2.0 and so would
not have solved the case that prompted this.

## Tests

`tests/test_next_version.py`: 39 passed. Five new cases cover the baseline rule,
the upgrade path that motivated it, the two degenerate lines, and the cap
precedence. `ruff` and `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)