### PR TITLE
feat(updates): add MTGO_TOOLS_FORCE_UPDATE_CHECK to defeat the 24h stamp

### DIFF
--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -176,7 +176,17 @@ The check is background-only and best-effort: it never blocks startup, and being
 offline, rate-limited, or served an unfamiliar payload all resolve to "no update
 info" rather than an error. The answer is cached with a timestamp and refreshed
 at most once every `UPDATE_CHECK_INTERVAL_SECONDS` (24 h), including across
-restarts, so repeat launches make one request a day. When a newer version does
+restarts, so repeat launches make one request a day.
+
+> **Testing the updater.** That 24 h stamp makes the update path awkward to
+> verify: a release published less than a day after your last launch stays
+> invisible until the stamp expires, which looks exactly like the feature being
+> broken. Set **`MTGO_TOOLS_FORCE_UPDATE_CHECK=1`** to skip the stamp and re-ask
+> GitHub every launch. It is a development affordance and deliberately an env
+> var rather than a preference — the throttle exists to respect GitHub's
+> unauthenticated rate limit, so it is not something a user should be able to
+> leave switched on. `=0` (or `false`/`no`/`off`/empty) reads as off, so it is
+> safe to leave in a shell profile. When a newer version does
 exist the app says so in the right-hand status-bar field and in a **Help** menu
 entry that appears only while the update is pending. The whole thing can be
 turned off from **File ▸ Preferences… ▸ Check for updates**.

--- a/services/update_service.py
+++ b/services/update_service.py
@@ -40,6 +40,7 @@ all times.
 
 from __future__ import annotations
 
+import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -76,6 +77,34 @@ _API_HEADERS = {
 # release) is still usable. The sidecar, by contrast, is required to be exactly
 # ``<installer name>.sha256``: a checksum file that names *some other* build is
 # worse than no checksum at all, because it would be trusted.
+#: Set to a truthy value to make every launch re-ask GitHub, ignoring the
+#: once-a-day stamp. Development and QA only, and deliberately an env var rather
+#: than a preference: the throttle exists to respect GitHub's unauthenticated
+#: rate limit, so this is not something a user should be able to leave on.
+#:
+#: It exists because the throttle makes the update path effectively untestable.
+#: A release published less than a day after your last launch is invisible until
+#: the stamp expires, so verifying the updater end to end meant hand-deleting
+#: `UPDATE_CHECK_CACHE_FILE` between runs -- which is both undiscoverable and
+#: easy to mistake for the feature being broken (it was, once, on 2026-08-21:
+#: a fresh 1.2.0 install showed no update because a stamp written four hours
+#: earlier still said the newest release was 1.1.7).
+FORCE_CHECK_ENV_VAR = "MTGO_TOOLS_FORCE_UPDATE_CHECK"
+
+#: Values that read as "off" when the variable is set but not meant to be on, so
+#: `MTGO_TOOLS_FORCE_UPDATE_CHECK=0` in a shell profile does what it looks like.
+_FALSEY = {"", "0", "false", "no", "off"}
+
+
+def force_check_requested() -> bool:
+    """Whether :data:`FORCE_CHECK_ENV_VAR` is set to something truthy.
+
+    Read at call time rather than import time so a test can set it with
+    ``monkeypatch.setenv`` and so it can be toggled in a long-running session.
+    """
+    return os.environ.get(FORCE_CHECK_ENV_VAR, "").strip().lower() not in _FALSEY
+
+
 INSTALLER_ASSET_PREFIX = "MTGOTools_Setup_"
 INSTALLER_ASSET_SUFFIX = ".exe"
 CHECKSUM_ASSET_SUFFIX = ".sha256"
@@ -259,9 +288,16 @@ class UpdateService:
         the app is launched. A stamp dated in the *future* counts as stale: a
         clock that ran fast and was then corrected would otherwise pin the
         cached answer permanently.
+
+        Setting :data:`FORCE_CHECK_ENV_VAR` skips the stamp entirely and asks
+        GitHub every launch. That is a development affordance, not a feature:
+        see the constant for why it is an env var.
         """
         stamp = self._read_stamp()
-        if stamp is not None and 0 <= (time.time() - stamp.checked_at) < self.check_interval:
+        forced = force_check_requested()
+        if forced:
+            logger.info(f"Update check: {FORCE_CHECK_ENV_VAR} is set, ignoring the cached result")
+        elif stamp is not None and 0 <= (time.time() - stamp.checked_at) < self.check_interval:
             logger.debug("Update check: cached result is still fresh")
             return self._to_update_info(stamp)
 

--- a/tests/test_update_service.py
+++ b/tests/test_update_service.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 
 from services.update_service import (
+    FORCE_CHECK_ENV_VAR,
     NO_RELEASE,
     RELEASES_PAGE_URL,
     UpdateInfo,
@@ -452,6 +453,80 @@ def test_the_throttle_suppresses_a_second_check(tmp_path: Path) -> None:
 
     assert len(calls) == 1
     assert first == second
+
+
+def test_the_force_env_var_defeats_the_throttle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dev escape hatch: every launch re-asks, stamp or no stamp.
+
+    Without it the update path is effectively untestable — a release published
+    less than a day after your last launch stays invisible until the stamp
+    expires, which is indistinguishable from the feature being broken.
+    """
+    monkeypatch.setenv(FORCE_CHECK_ENV_VAR, "1")
+    service, calls = _service(
+        tmp_path, responses=[_release_payload("v1.0.3"), _release_payload("v1.0.4")]
+    )
+
+    first = service.check()
+    second = service.check()
+
+    assert len(calls) == 2
+    assert first is not None and first.version == "1.0.3"
+    assert second is not None and second.version == "1.0.4"
+
+
+def test_the_force_env_var_defeats_a_stamp_from_a_previous_launch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exact shape of the bug it exists for.
+
+    A stamp on disk says the newest release is 1.0.2 (true when it was written);
+    1.0.4 has shipped since. Unforced, the launch believes the stamp and stays
+    quiet; forced, it re-asks and finds the release.
+    """
+    first_run, _ = _service(tmp_path, responses=[_release_payload("v1.0.2")])
+    assert first_run.check() is None  # nothing newer than the running 1.0.2
+
+    monkeypatch.setenv(FORCE_CHECK_ENV_VAR, "1")
+    second_run, second_calls = _service(tmp_path, responses=[_release_payload("v1.0.4")])
+    result = second_run.check()
+
+    assert len(second_calls) == 1
+    assert result is not None
+    assert result.version == "1.0.4"
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "  OFF  "])
+def test_a_falsey_force_env_var_leaves_the_throttle_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """`MTGO_TOOLS_FORCE_UPDATE_CHECK=0` in a profile does what it looks like."""
+    monkeypatch.setenv(FORCE_CHECK_ENV_VAR, value)
+    service, calls = _service(
+        tmp_path, responses=[_release_payload("v1.0.3"), _release_payload("v1.0.4")]
+    )
+
+    service.check()
+    service.check()
+
+    assert len(calls) == 1
+
+
+def test_the_throttle_holds_when_the_force_env_var_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default is unchanged: one request a day, however often you launch."""
+    monkeypatch.delenv(FORCE_CHECK_ENV_VAR, raising=False)
+    service, calls = _service(
+        tmp_path, responses=[_release_payload("v1.0.3"), _release_payload("v1.0.4")]
+    )
+
+    service.check()
+    service.check()
+
+    assert len(calls) == 1
 
 
 def test_the_throttle_survives_a_restart(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

The update check answers from an on-disk stamp for `UPDATE_CHECK_INTERVAL_SECONDS`
(24 h). That is right for users — it holds a ten-launches-a-day user to one
unauthenticated GitHub request — and it makes the feature effectively
untestable.

**This is not theoretical.** Testing the 1.2.0 → 1.2.1 upgrade on 2026-08-21, a
fresh 1.2.0 install showed no status-bar notice and no Help-menu entry. The
stamp on disk:

```json
{ "checked_at": 1787319405.06,   → 10:36:45 that morning, 4.1 h old → "fresh"
  "latest_version": "1.1.7" }
```

`check()` never contacted GitHub, returned the cached 1.1.7, and
`_to_update_info` resolved `1.1.7 <= 1.2.0` to "nothing newer". Three releases
(1.1.8, 1.2.0, 1.2.1) had shipped in between. Telling that apart from a broken
updater took reading the TRACE log, and the only way to proceed was to
hand-delete `UPDATE_CHECK_CACHE_FILE` — undiscoverable, and easy to mistake for
the bug it looks like.

## What

`MTGO_TOOLS_FORCE_UPDATE_CHECK=1` skips the stamp and re-asks GitHub every
launch.

- **An env var, not a preference.** The throttle exists to respect a rate limit,
  so this should not be something a user can leave switched on. It mirrors the
  existing `MTGO_TOOLS_INSTALL_DEBUG` hatch.
- **Falsey values read as off** (`""`, `0`, `false`, `no`, `off`, any casing or
  surrounding space), so it is safe to leave in a shell profile.
- **Read at call time**, not import time, so a test can `monkeypatch.setenv` it
  and it can be toggled in a long-running session.
- Logs at INFO when it fires, so a forced check is visible in the log rather
  than silently different from a normal one.

## What is unchanged

The default path. With the variable absent the stamp is consulted exactly as
before — pinned by `test_the_throttle_holds_when_the_force_env_var_is_absent`,
which counts requests rather than trusting the shape of the code.

## Tests

`tests/test_update_service.py` + `tests/test_update_installer.py`: 114 passed.
Four new cases — the hatch defeating the throttle, the hatch defeating a stamp
from a previous launch (the exact shape of the bug above), falsey values leaving
the throttle alone, and the absent-variable default. **The two behaviour tests
fail against the unmodified `check()`**, verified by stubbing the flag to
`False` and re-running. `black` and `ruff` clean.

> Touches `docs/VERSIONING.md`, as does #1004 — different sections, so they
> should merge cleanly, but worth knowing if one lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)