### PR TITLE
fix(stats): bundle WebView2Loader.dll so the deck-stats charts stop rendering on IE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
       # deficiency, the type and spacing scales, the ban on bare wx.StaticBox /
       # wx.Notebook / wx.StaticLine / wx.SplitterWindow / wx.TextCtrl, every
       # button reaching the button system, the enforced window minimums in both
-      # locales, live layout overflow in both locales, and card-view scroll
-      # snapping.
+      # locales, live layout overflow in both locales, card-view scroll
+      # snapping, and the WebView backend the deck-stats charts render on.
       - name: Design-system guards (issue #962)
         run: >-
           pytest -q
@@ -59,6 +59,7 @@ jobs:
           tests/test_native_dark.py
           tests/test_deck_stats_palette.py
           tests/test_visible_defects.py
+          tests/test_webview_backend.py
           tests/test_menu_bar_spec.py
           tests/test_preferences_spec.py
           tests/test_window_titles.py

--- a/docs/WXMSW_BEHAVIOUR.md
+++ b/docs/WXMSW_BEHAVIOUR.md
@@ -261,9 +261,31 @@ screenshot, which is the only way this shows up. Own-draw instead (see
 
 ### `wx.html2.WebView`
 
-needs the Edge WebView2 runtime; `WebView.New` raises (or returns `None`) without it, so
-every construction site needs a fallback. It also takes a light 1px client edge unless
-constructed with `wx.BORDER_NONE`
+needs the Edge WebView2 runtime, and **does not tell you when it has not got it**. The
+entry here used to say `WebView.New` raises or returns `None` without the runtime; it
+does neither. Measured on a machine with `WebView2Loader.dll` moved out of the wx
+package: `IsBackendAvailable("wxWebViewEdge")` goes `False`, and `New()` -- with the
+default backend *and* with `backend="wxWebViewEdge"` asked for by name -- still returns a
+live, non-`None` control. What you get is the **IE** backend, i.e. Trident in IE7
+document mode, which has no flexbox: every `display:flex` in a page collapses to a
+block. Screenshotted side by side, the deck-stats charts then render every bar at full
+panel width, with the value labels centred above them and the row labels on top of
+their own tracks -- a *wrong* chart, not a plainer one, and it shipped in 1.2.3 because
+nothing checked. The only reliable signal is `IsBackendAvailable` before constructing;
+see `widgets.charts.view.create_webview`.
+
+Its loader DLL is a packaging trap of the same shape. wxPython keeps
+`WebView2Loader.dll` next to `wx/_html2*.pyd` and wxWidgets loads it by **bare name** at
+runtime, so no extension module imports it and PyInstaller's dependency analysis never
+sees it -- a bundle silently downgrades to IE. Measured by moving the DLL around: wx
+finds it beside its own package and in the process's working directory -- neither of
+which a bundled app can count on. Bundling it (`packaging/mtgo_tools.spec`) is therefore
+only half the fix; the half that does not depend on Windows' search order is to
+`ctypes`-load it by absolute path before touching `wx.html2`
+(`widgets.charts.view.ensure_webview2_loader`), after which Windows resolves wx's own
+load-by-name to the already-loaded module -- measured both ways.
+
+It also takes a light 1px client edge unless constructed with `wx.BORDER_NONE`
 
 ### `wx.ListBox`
 

--- a/packaging/mtgo_tools.spec
+++ b/packaging/mtgo_tools.spec
@@ -43,6 +43,34 @@ for rel in [
 # It is downloaded to {app}/mtgo_integration/ by the Inno Setup installer.
 binaries = []
 
+# wxPython's Edge/WebView2 backend loads WebView2Loader.dll by bare name at
+# runtime, so no .pyd imports it and PyInstaller's dependency analysis never sees
+# it. Shipping without it does not disable the WebView: wxWidgets silently hands
+# back the IE backend instead, which is Trident in IE7 document mode and has no
+# flexbox -- which is how the installed build rendered every deck-stats bar at
+# full panel width while the same code from source looked right.
+#
+# It is bundled into ``wx/`` so the layout matches site-packages, and
+# ``widgets.charts.view.ensure_webview2_loader`` loads it from there by absolute
+# path. Both strings are cross-checked against that module by
+# tests/test_webview_backend.py.
+WEBVIEW2_LOADER_NAME = "WebView2Loader.dll"
+WEBVIEW2_LOADER_DEST = "wx"
+
+import importlib.util  # noqa: E402
+
+_wx_spec = importlib.util.find_spec("wx")
+_wx_dir = pathlib.Path(_wx_spec.origin).parent if _wx_spec and _wx_spec.origin else None
+_webview2_loader = _wx_dir / WEBVIEW2_LOADER_NAME if _wx_dir else None
+if _webview2_loader and _webview2_loader.exists():
+    binaries += [(str(_webview2_loader), WEBVIEW2_LOADER_DEST)]
+elif sys.platform == "win32":
+    # Fail the build rather than ship a bundle whose charts render on IE.
+    raise SystemExit(
+        f"{WEBVIEW2_LOADER_NAME} not found next to the wx package "
+        f"({_wx_dir}); the packaged app would fall back to the IE WebView backend"
+    )
+
 entry_point = project_root / "main.py"
 app_icon = project_root / "assets" / "icons" / "hammer.ico"
 

--- a/tests/test_webview_backend.py
+++ b/tests/test_webview_backend.py
@@ -1,0 +1,182 @@
+"""The deck-stats charts must never render on wx's IE WebView backend.
+
+The bug this pins shipped in 1.2.3 and was visible only in the installed build:
+every bar in the Deck Stats tab drew at full panel width, the value labels
+centred themselves above the bars instead of sitting beside them, and the Card
+Types labels landed on top of their own tracks. Running the same code from
+source looked right.
+
+Nothing about the chart code differed. What differed was the backend behind
+``wx.html2.WebView``:
+
+* ``WebView.New()`` with the default backend does not fail when WebView2 is
+  unavailable on MSW -- it silently returns the **IE** backend, Trident in IE7
+  document mode, which has no flexbox. Every ``display:flex`` in the chart CSS
+  then collapses to a block, which is exactly the screenshot.
+* WebView2 was unavailable in the bundle because ``WebView2Loader.dll`` was not
+  in it. wxPython keeps that DLL next to ``wx/_html2*.pyd`` and loads it by bare
+  name at runtime, so no extension module imports it and PyInstaller's
+  dependency analysis never saw it.
+
+Both halves are guarded here, and neither guard needs a frozen build to run: the
+lookup is exercised against a simulated ``sys.frozen`` bundle, the bundling is
+read out of the spec, and the backend choice is exercised against a stand-in
+``wx.html2``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import wx
+import wx.html2  # noqa: F401  -- ensures ``import wx.html2`` inside the code under test is a no-op
+
+from widgets.charts import view as view_module
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = ROOT / "packaging" / "mtgo_tools.spec"
+
+
+# ---------------------------------------------------------------------------
+# Where the loader DLL is looked for, and where the spec puts it
+# ---------------------------------------------------------------------------
+
+
+def test_loader_path_is_none_from_source() -> None:
+    """From source wx finds the DLL beside its own extension module."""
+    assert view_module.webview2_loader_path() is None
+
+
+def test_loader_path_points_into_the_bundle_when_frozen(tmp_path, monkeypatch) -> None:
+    """The frozen lookup is the whole fix; simulate the bundle rather than build one."""
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    assert view_module.webview2_loader_path() == (
+        tmp_path / view_module.WEBVIEW2_LOADER_DEST / view_module.WEBVIEW2_LOADER_NAME
+    )
+
+
+def test_a_bundle_without_the_loader_says_so(tmp_path, monkeypatch) -> None:
+    """The old failure was silent. A missing loader now warns and reports False."""
+    from loguru import logger
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        loaded = view_module.ensure_webview2_loader()
+    finally:
+        logger.remove(sink_id)
+
+    assert loaded is False
+    assert any(view_module.WEBVIEW2_LOADER_NAME in message for message in messages)
+
+
+def _spec_constant(name: str) -> str:
+    """Read a string constant out of the PyInstaller spec.
+
+    Text-parsed rather than executed: evaluating the spec needs PyInstaller
+    imported and a project root on ``sys.path``, and this only has to pin two
+    string literals. Same approach as ``tests/test_ci_guards.py``.
+    """
+    assert SPEC.exists(), f"{SPEC} is missing"
+    match = re.search(rf'^{name}\s*=\s*"([^"]+)"', SPEC.read_text(encoding="utf-8"), re.MULTILINE)
+    assert match, f"{SPEC} no longer defines {name}"
+    return match.group(1)
+
+
+def test_the_spec_bundles_the_loader_where_the_runtime_looks_for_it() -> None:
+    """Bundling it somewhere the lookup does not read would silently reopen the bug."""
+    assert _spec_constant("WEBVIEW2_LOADER_NAME") == view_module.WEBVIEW2_LOADER_NAME
+    assert _spec_constant("WEBVIEW2_LOADER_DEST") == view_module.WEBVIEW2_LOADER_DEST
+
+
+def test_the_spec_actually_adds_the_loader_to_the_binaries() -> None:
+    """Constants that match but are never used would pass the check above."""
+    text = SPEC.read_text(encoding="utf-8")
+    assert "binaries += [(str(_webview2_loader), WEBVIEW2_LOADER_DEST)]" in text
+
+
+# ---------------------------------------------------------------------------
+# Which backend the WebView is allowed to come back on
+# ---------------------------------------------------------------------------
+
+
+class _FakeWebView:
+    """Stands in for ``wx.html2.WebView`` so the backend choice is inspectable."""
+
+    def __init__(self, available: bool) -> None:
+        self.available = available
+        self.asked_about: list[object] = []
+        self.new_kwargs: dict[str, object] | None = None
+
+    def IsBackendAvailable(self, backend: object) -> bool:  # noqa: N802 - wx spelling
+        self.asked_about.append(backend)
+        return self.available
+
+    def New(self, parent: object, **kwargs: object) -> str:  # noqa: N802 - wx spelling
+        self.new_kwargs = kwargs
+        return "webview"
+
+
+@pytest.fixture
+def fake_html2(monkeypatch):
+    """Swap ``wx.html2`` for a stand-in, and pin the platform to MSW."""
+
+    def install(*, edge_available: bool) -> _FakeWebView:
+        fake_view = _FakeWebView(edge_available)
+        module = type(sys)("wx.html2")
+        module.WebView = fake_view
+        monkeypatch.setattr(wx, "html2", module)
+        monkeypatch.setattr(wx, "Platform", "__WXMSW__")
+        monkeypatch.delenv(view_module.DISABLE_WEBVIEW_ENV, raising=False)
+        return fake_view
+
+    return install
+
+
+def test_no_webview_at_all_when_edge_is_missing(fake_html2) -> None:
+    """The painted fallback is right-but-plain; the IE backend is simply wrong."""
+    from loguru import logger
+
+    fake_view = fake_html2(edge_available=False)
+
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        result = view_module.create_webview(parent=None)
+    finally:
+        logger.remove(sink_id)
+
+    assert result is None, "a WebView on the IE backend must not reach the charts"
+    assert fake_view.new_kwargs is None, "WebView.New must not even be attempted"
+    assert any("Edge" in message for message in messages)
+
+
+def test_the_edge_backend_is_requested_by_name(fake_html2) -> None:
+    """Defaulting the backend is what let IE through in the first place."""
+    fake_view = fake_html2(edge_available=True)
+
+    result = view_module.create_webview(parent=None)
+
+    assert result == "webview"
+    assert fake_view.new_kwargs is not None
+    assert fake_view.new_kwargs["backend"] == view_module.EDGE_BACKEND
+    assert fake_view.asked_about == [view_module.EDGE_BACKEND]
+
+
+def test_off_msw_the_default_backend_is_fine(fake_html2, monkeypatch) -> None:
+    """Only wxMSW has an IE backend to fall back to; WebKit renders the CSS."""
+    fake_view = fake_html2(edge_available=False)
+    monkeypatch.setattr(wx, "Platform", "__WXGTK__")
+
+    assert view_module.create_webview(parent=None) == "webview"
+    assert fake_view.asked_about == [], "no backend probe belongs off MSW"
+    assert fake_view.new_kwargs is not None
+    assert fake_view.new_kwargs["backend"] == view_module.DEFAULT_BACKEND

--- a/widgets/charts/view.py
+++ b/widgets/charts/view.py
@@ -1,4 +1,4 @@
-"""A chart surface that degrades from WebView2 to wxHTML.
+"""A chart surface that degrades from WebView2 to an own-drawn fallback.
 
 ``wx.html2.WebView`` needs the Microsoft Edge WebView2 runtime. It ships with
 Windows 11 and with current Windows 10, but it is not guaranteed, and a machine
@@ -8,7 +8,7 @@ itself, so the only visible artefact was an empty panel).
 
 :class:`ChartView` therefore has two backends and always has one:
 
-1. ``wx.html2.WebView`` when it constructs,
+1. ``wx.html2.WebView`` **on its Edge backend**, when that constructs,
 2. an own-drawn :class:`~widgets.charts.painter.BarChartPanel` otherwise. The
    first attempt used ``wx.html.HtmlWindow`` for the fallback and, screenshotted,
    drew every label and no bars — see that module for what wxHTML refuses.
@@ -16,15 +16,37 @@ itself, so the only visible artefact was an empty panel).
 The caller passes data, never markup, so both backends are fed from the same
 tuples. ``MTGO_TOOLS_DISABLE_WEBVIEW=1`` forces the fallback, which is how the
 no-WebView2 path gets exercised on a machine that has the runtime installed.
+
+Why the Edge backend is demanded by name
+----------------------------------------
+``wxWebView::New()`` with the default backend does *not* fail when WebView2 is
+unavailable on MSW: it silently hands back the **IE** backend, which is Trident
+in IE7 document mode. IE7 has no flexbox, so every ``display:flex`` row in the
+chart CSS collapses to a block — each bar stretches to the full panel width, the
+value labels centre themselves above the bars instead of sitting beside them, and
+the Card Types labels land on top of their own tracks. That is a *wrong* chart,
+not a plainer one, and it is worse than the painted fallback.
+
+It shipped that way because a PyInstaller build did not bundle
+``WebView2Loader.dll``. The DLL lives in the wxPython package next to
+``wx/_html2*.pyd`` and is loaded by name at runtime, so PyInstaller's static
+analysis never sees it; the spec now bundles it and
+:func:`ensure_webview2_loader` loads it out of the bundle by absolute path before
+wx goes looking. From source nothing changes — wx finds it next to its own
+extension module.
 """
 
 from __future__ import annotations
 
+import ctypes
 import os
+import sys
+from pathlib import Path
 
 import wx
 from loguru import logger
 
+from utils.constants.paths import resource_path
 from utils.constants.theme import SURFACE_BASE
 from widgets.charts.bars import ChartBar, build_webview_page
 from widgets.charts.painter import BarChartPanel
@@ -33,39 +55,127 @@ from widgets.charts.painter import BarChartPanel
 #: than cached at import so a test can flip it between frames.
 DISABLE_WEBVIEW_ENV = "MTGO_TOOLS_DISABLE_WEBVIEW"
 
+#: Where ``packaging/mtgo_tools.spec`` puts ``WebView2Loader.dll`` inside the
+#: bundle: the same ``wx/`` layout it has in site-packages. The spec declares the
+#: same two strings and ``tests/test_webview_backend.py`` cross-checks them, so
+#: the bundling and the lookup cannot drift apart.
+WEBVIEW2_LOADER_DEST = "wx"
+WEBVIEW2_LOADER_NAME = "WebView2Loader.dll"
+
+#: wxPython 4.2 spells the backend names as bytes; ``IsBackendAvailable`` and
+#: ``New`` both take either, and the ``str`` form is what logs readably.
+EDGE_BACKEND = "wxWebViewEdge"
+
+#: What ``wx.html2.WebViewBackendDefault`` is: "pick for me". Only wxMSW has an
+#: IE backend to be silently picked, so it is the only platform that names one.
+DEFAULT_BACKEND = ""
+
 
 def webview_disabled_by_env() -> bool:
     """Whether the environment has asked for the non-WebView path."""
     return os.environ.get(DISABLE_WEBVIEW_ENV, "").strip().lower() in {"1", "true", "yes"}
 
 
+def webview2_loader_path() -> Path | None:
+    """Absolute path of the bundled ``WebView2Loader.dll``, or ``None`` from source.
+
+    Only a frozen build needs this: running from source, the DLL sits beside
+    ``wx/_html2*.pyd`` in site-packages where wxWidgets' own load finds it.
+    """
+    if not getattr(sys, "frozen", False):
+        return None
+    return resource_path(WEBVIEW2_LOADER_DEST, WEBVIEW2_LOADER_NAME)
+
+
+def ensure_webview2_loader() -> bool:
+    """Pre-load the bundled WebView2 loader DLL so wx's Edge backend can find it.
+
+    wxWidgets loads the DLL with a bare ``LoadLibrary("WebView2Loader.dll")``,
+    and the places Windows then searches are not places a PyInstaller bundle can
+    count on. Loading it here by absolute path puts it in the process's module
+    table under that base name, and wx's later load by name resolves to it —
+    measured both ways.
+
+    Returns whether the loader is in the process (``True`` when running from
+    source, where wx does its own lookup).
+    """
+    path = webview2_loader_path()
+    if path is None:
+        return True
+    if not path.exists():
+        logger.warning(
+            f"{WEBVIEW2_LOADER_NAME} is missing from the bundle at {path}; "
+            "the WebView2 chart backend cannot start"
+        )
+        return False
+    try:
+        ctypes.WinDLL(str(path))  # type: ignore[attr-defined]  # MSW only
+    except Exception as exc:  # pragma: no cover - depends on the host runtime
+        logger.warning(f"could not load {path}: {exc}")
+        return False
+    return True
+
+
+def preferred_backend() -> str:
+    """The backend :func:`create_webview` will ask for by name.
+
+    Naming Edge on MSW is the fix: the default backend there degrades to IE
+    without a word. Off MSW the default is WebKit, which renders the chart CSS,
+    so nothing needs naming.
+    """
+    return EDGE_BACKEND if wx.Platform == "__WXMSW__" else DEFAULT_BACKEND
+
+
+def edge_backend_available() -> bool:
+    """Whether wx can give us a WebView that renders the chart CSS.
+
+    On MSW that means the Edge backend specifically: the default backend falls
+    back to IE without saying so, and IE renders the charts wrong (see the module
+    docstring). Elsewhere the default backend is WebKit, which is fine.
+    """
+    import wx.html2
+
+    if wx.Platform != "__WXMSW__":  # pragma: no cover - MSW is the shipped platform
+        return True
+    return bool(wx.html2.WebView.IsBackendAvailable(EDGE_BACKEND))
+
+
 def create_webview(parent: wx.Window) -> wx.Window | None:
     """Construct a ``wx.html2.WebView`` on ``parent``, or ``None`` if unavailable.
 
-    Both the import and the construction are guarded: ``wx.html2`` imports fine on
-    a machine with no WebView2 runtime and only fails when ``WebView.New`` goes
-    looking for the backend, and some failures come back as ``None`` rather than
-    an exception.
+    Every step is guarded: ``wx.html2`` imports fine on a machine with no WebView2
+    runtime, ``WebView.New`` can come back as ``None`` rather than raise, and --
+    the failure this function exists to catch -- it can come back as a *working
+    control on the wrong backend*.
     """
     if webview_disabled_by_env():
-        logger.info(f"{DISABLE_WEBVIEW_ENV} is set; using the wxHTML chart fallback")
+        logger.info(f"{DISABLE_WEBVIEW_ENV} is set; using the painted chart fallback")
         return None
+    ensure_webview2_loader()
     try:
         import wx.html2
 
-        # wxMSW frames the control with a light 1px client edge otherwise --
+        if not edge_backend_available():
+            logger.warning(
+                "the WebView2 (Edge) backend is unavailable; using the painted chart "
+                "fallback rather than wx's silent IE fallback, which cannot render "
+                "the chart layout"
+            )
+            return None
+        # The backend is named rather than defaulted: see the module docstring.
+        # wxMSW also frames the control with a light 1px client edge otherwise --
         # the same native chrome phase 2 stripped off wx.Button.
-        view = wx.html2.WebView.New(parent, style=wx.BORDER_NONE)
+        view = wx.html2.WebView.New(parent, backend=preferred_backend(), style=wx.BORDER_NONE)
     except Exception as exc:  # pragma: no cover - depends on the host runtime
-        logger.warning(f"WebView2 unavailable; using the wxHTML chart fallback: {exc}")
+        logger.warning(f"WebView2 unavailable; using the painted chart fallback: {exc}")
         return None
     if view is None:  # pragma: no cover - defensive; WebView.New can return None
-        logger.warning("WebView2 returned no control; using the wxHTML chart fallback")
+        logger.warning("WebView2 returned no control; using the painted chart fallback")
     return view
 
 
 class ChartView(wx.Panel):
-    """Renders a sorted bar chart, on WebView2 if present and wxHTML if not."""
+    """Renders a sorted bar chart: on WebView2 if present, own-drawn if not."""
 
     def __init__(self, parent: wx.Window) -> None:
         super().__init__(parent, style=wx.BORDER_NONE)

--- a/widgets/panels/deck_stats_panel/frame.py
+++ b/widgets/panels/deck_stats_panel/frame.py
@@ -5,10 +5,13 @@ curve, colour distribution, type counts, and opening-hand land probability.
 
 Two backends, one data path
 ---------------------------
-The rich rendering needs ``wx.html2.WebView``, which needs the Microsoft Edge
-WebView2 runtime. That runtime ships with Windows 11 and current Windows 10 but
-is not guaranteed, so the panel falls back to ``wx.html.HtmlWindow`` -- wxWidgets'
-own HTML 3.2 renderer, compiled into wxPython and therefore always present.
+The rich rendering needs ``wx.html2.WebView`` *on its Edge backend*, which needs
+the Microsoft Edge WebView2 runtime. That runtime ships with Windows 11 and
+current Windows 10 but is not guaranteed, so the panel falls back to a painted
+:class:`~widgets.charts.painter.BarChartPanel` -- see
+:mod:`widgets.charts.view` for why the backend is demanded by name (wx hands
+back the IE backend instead of failing, and IE draws these charts wrong) and why
+wxHTML was rejected as the fallback.
 
 Before phase 5 the fallback existed only in the sense that construction did not
 crash: the panel logged a warning and left an empty sizer, so a user without


### PR DESCRIPTION
## The bug

The Deck Stats tab renders wrong in the **installed** build and right from source: every bar draws at full panel width, the value labels centre themselves above the bars instead of sitting beside them, the mana-curve and colour labels vanish, and the Card Types labels land on top of their own tracks.

## Root cause

Not the chart code — the backend behind `wx.html2.WebView`.

wxPython keeps `WebView2Loader.dll` next to `wx/_html2*.pyd` and wxWidgets loads it by **bare name** at runtime, so no extension module imports it and PyInstaller's dependency analysis never sees it. `build/mtgo_tools/Analysis-00.toc` confirms it: `wx\_html2*.pyd` is in the bundle, the loader DLL is not.

Without that loader, the Edge backend is unavailable — and `wx.html2.WebView.New()` **does not fail**. It silently returns the **IE** backend (Trident, IE7 document mode), which has no flexbox, so every `display:flex` in the chart CSS collapses to a block. The installed app's own log shows it was rendering happily (`PERF | stats: WebView SetPage`) with no warning anywhere.

Reproduced without building an installer: moved `WebView2Loader.dll` out of the wx package, rendered the same deck-stats page on each backend and screenshotted. The IE rendering is pixel-for-pixel the reported bug.

| | |
|---|---|
| `IsBackendAvailable("wxWebViewEdge")` with the loader | `True` |
| ... with the loader moved away | `False` |
| `New()` with the default backend, no loader | returns a live control (IE) |
| `New(backend="wxWebViewEdge")`, no loader | **also** returns a live control |

## The fix

* **`packaging/mtgo_tools.spec`** bundles the DLL into `wx/`, and fails the build on Windows if it cannot find it rather than shipping a bundle whose charts render on IE.
* **`ensure_webview2_loader()`** `ctypes`-loads it out of the bundle by absolute path before wx goes looking, so the fix does not depend on Windows' DLL search order — Windows resolves wx's later load-by-name to the already-loaded module. Verified in both directions.
* **`create_webview()`** now probes `IsBackendAvailable` and names the Edge backend. A machine genuinely without the WebView2 runtime gets the painted `BarChartPanel` — plainer, but correct — plus a warning in the log, instead of a silent IE rendering. From source nothing changes.

End-to-end, with the wx package's copy of the DLL hidden:

| scenario | before | after |
|---|---|---|
| not frozen, no loader (today's installed build) | IE WebView, broken charts, silent | `create_webview -> None` → painted fallback + warning |
| frozen, loader bundled at `wx/` (the fixed build) | n/a | Edge available → real WebView2 |
| normal source run | Edge | Edge (unchanged) |

## Regression test

`tests/test_webview_backend.py` (8 tests) targets the mechanism, not the pixels, because the bug only manifests when frozen:

* the loader lookup runs against a simulated `sys.frozen` / `sys._MEIPASS` bundle;
* a bundle missing the loader must warn and report `False` (the old failure was silent);
* the spec's `WEBVIEW2_LOADER_NAME` / `WEBVIEW2_LOADER_DEST` are cross-checked against the constants the runtime looks them up with, so bundling it somewhere the lookup does not read cannot pass;
* the backend choice runs against a stand-in `wx.html2`: Edge missing must yield no WebView at all, and Edge present must be asked for **by name**.

Reverting either half of the fix fails these (3 fail on the backend half, 1 on the packaging half). Added to CI's design-system guard step. Full suite: 2808 passed, 5 skipped.

Also corrects the `wx.html2.WebView` entry in `docs/WXMSW_BEHAVIOUR.md`, which claimed `WebView.New` raises or returns `None` without the runtime. It does neither.

## Note

This needs a rebuilt installer to reach users — the packaging half of the fix is in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)