### PR TITLE
fix(installer): drop the launch-after-install checkbox for Start menu instructions

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -19,11 +19,18 @@ the installer understands one of ours:
 - **`/RELAUNCH`** — start the app once the install finishes. Intended for the in-app
   updater, which runs `MTGOTools_Setup_v<VERSION>.exe /SILENT /RELAUNCH` and then exits
   so its own files can be replaced; without the switch nothing would be left running to
-  bring the app back. It is *not* the "Launch MTGO Tools" checkbox on the Finished page:
-  that checkbox is a `postinstall` [Run] entry flagged `skipifsilent`, so it is
-  suppressed under `/SILENT` by design. `/RELAUNCH` is a separate [Run] entry gated by a
-  `Check:` function in `installer.iss`, which is why it works in a silent install. Omit
-  the switch and an interactive install behaves exactly as it always has.
+  bring the app back. `/RELAUNCH` is a [Run] entry gated by a `Check:` function in
+  `installer.iss` rather than a `postinstall` one, which is why it fires in a silent
+  install (`postinstall` entries become Finished-page checkboxes, and `skipifsilent`
+  suppresses those under `/SILENT` by design). Omit the switch and an interactive
+  install behaves exactly as it always has.
+
+  This used to be contrasted with a "Launch MTGO Tools" checkbox on the Finished page.
+  That checkbox is gone: Setup launching the app is what Windows Application Control
+  refuses (#1009), so the Finished page now points at the Start Menu shortcut instead,
+  and it should come back once the binary is code-signed. `/RELAUNCH` still launches the
+  app from Setup and so is expected to hit the same block on the same machines; it is
+  kept because removing it would break the auto-update restart for everyone. See #1020.
 
 **Debugging an installed build:** the shipped executable is windowed (no console), but `debugpy` is bundled so you can attach an IDE debugger the same way you would in the editor. Set `MTGO_TOOLS_INSTALL_DEBUG=1` (or `MTGO_TOOLS_INSTALL_DEBUG=<port>`) before launching to have it listen on 127.0.0.1:5678, then use your IDE's "attach to process/port". Set `MTGO_TOOLS_INSTALL_DEBUG_WAIT=1` to block startup until the debugger attaches (for breaking on early startup code). The hook is inert unless the env var is set. File logs are always written to `%LOCALAPPDATA%\MTGO Tools\logs`; set `MTGO_LOG_LEVEL=DEBUG` for verbose output.
 

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -53,6 +53,31 @@ ArchitecturesInstallIn64BitMode=x64compatible
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
+[Messages]
+; Finished-page wording. This replaces the "launch the app now" checkbox that
+; used to live in [Run] -- see the comment there for why it is gone.
+;
+; Chosen over the alternatives deliberately. An InfoAfterFile would add a whole
+; extra wizard page for two sentences, and a [CustomMessages] string needs
+; [Code] to get onto the page at all; overriding the stock messages puts the
+; instruction exactly where the user is already looking, with no new page and no
+; Pascal. Inno picks FinishedLabel when Setup created a shortcut and
+; FinishedLabelNoIcons when it did not, and it picks at run time, so both are
+; overridden -- an override on only one of them is a finish page that silently
+; reverts to the stock text under conditions you cannot see from here.
+;
+; Untagged (no "english." prefix), so these apply to every entry in [Languages].
+; That section currently lists exactly one language, English, so there is no
+; second catalogue to keep in sync today -- but if a language is ever added
+; here, these two lines still cover it in English rather than going blank, and
+; that is the moment to add "<lang>.FinishedLabel=" siblings. The app's own
+; en-US/pt-BR catalogues under utils/i18n/ are unrelated: they translate the
+; application, not Setup, which ships only what [Languages] declares.
+;
+; %n is Inno's newline escape and [name] expands to AppName.
+FinishedLabel=Setup has finished installing [name] on your computer.%n%nTo start it, open the Start menu and choose [name] (or use the desktop shortcut, if you asked for one).%n%nSetup does not start [name] for you: on some machines Windows Application Control blocks a program that an installer launches. Opening it from the Start menu is not affected.
+FinishedLabelNoIcons=Setup has finished installing [name] on your computer.%n%nTo start it, open the Start menu and choose [name].%n%nSetup does not start [name] for you: on some machines Windows Application Control blocks a program that an installer launches. Opening it from the Start menu is not affected.
+
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
@@ -122,19 +147,48 @@ Name: "{group}\README"; Filename: "{app}\README.md"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-; Option to launch the application after installation
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+; There is deliberately no "Launch MTGO Tools" checkbox here.
+;
+; It used to be this entry:
+;
+;   Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,...}";
+;       Flags: nowait postinstall skipifsilent
+;
+; `postinstall` is what turns a [Run] entry into that checkbox, and ticking it
+; made *Setup* the process that started the app. On a machine with Windows
+; Application Control active (Smart App Control on consumer Windows 11, App
+; Control for Business / WDAC on managed ones) that is refused, and the install
+; ends on "CreateProcess failed; code 4551 -- an Application Control policy has
+; blocked this file" (issue #1009). The app is installed and fine at that point;
+; the same user can open it from the Start menu immediately afterwards, which is
+; the workaround #1009 reports. So the checkbox does not fail gracefully -- it
+; manufactures an error dialog for an install that worked.
+;
+; Rather than word that error better, we stopped provoking it: the finish page
+; now points at the Start Menu shortcut created in [Icons] (see the [Messages]
+; overrides above). The cost is one extra click for everyone; the benefit is
+; that nobody's install ends on a scary failure.
+;
+; RESTORE THIS ONCE THE BINARY IS CODE-SIGNED. Application Control blocks
+; mtgo_tools.exe because it carries no trusted publisher signature; a signed
+; build is expected to launch from Setup normally, at which point the checkbox
+; is a straight usability win and should come back (together with reverting the
+; FinishedLabel/FinishedLabelNoIcons overrides above). A code-signing
+; certificate is being pursued through the SignPath Foundation open-source
+; programme. Do not restore it before then: doing so reopens #1009.
+;
 ; Relaunch after an in-app update. The updater downloads this installer, verifies
 ; its SHA256, runs it as `/SILENT /RELAUNCH`, and exits so its own files can be
 ; overwritten — which means nothing is left running to bring the app back. This
 ; entry is what brings it back.
 ;
-; It cannot be folded into the entry above: `postinstall` turns a [Run] entry into
-; a checkbox on the Finished page, and `skipifsilent` deliberately suppresses that
-; page's actions under /SILENT — which is precisely the mode a self-update runs in.
-; The two flags together mean "launch only when a human is watching", so a silent
-; install can never launch anything through them. The trap is that this looks like
-; it should work and simply does nothing.
+; It could not be folded into the postinstall checkbox that used to sit above,
+; and must not be folded into it if that checkbox is ever restored: `postinstall`
+; turns a [Run] entry into a checkbox on the Finished page, and `skipifsilent`
+; deliberately suppresses that page's actions under /SILENT — which is precisely
+; the mode a self-update runs in. The two flags together mean "launch only when a
+; human is watching", so a silent install can never launch anything through them.
+; The trap is that this looks like it should work and simply does nothing.
 ;
 ; So this is a plain [Run] entry (no postinstall): it executes at the end of the
 ; install regardless of silence, and a Check: function is what makes it conditional
@@ -145,6 +199,16 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 ; started unless told not to, and the app runs for hours. Without it Setup would
 ; stay alive for the entire session — a stray process holding an install lock,
 ; long after the update it performed was finished.
+;
+; KNOWN, UNFIXED: this entry is still Setup calling CreateProcess on an unsigned
+; mtgo_tools.exe, so on a machine with Application Control active it should be
+; refused for exactly the same reason the checkbox above was — meaning an
+; auto-update there leaves the app closed and it does not come back. It is left
+; alone on purpose: removing it would break the update restart for everyone to
+; help the few, and the obvious alternative (launching the Start Menu shortcut
+; via explorer.exe, so the launch is re-parented the way the #1009 workaround is)
+; cannot be verified without a machine that actually has Smart App Control on.
+; Tracked in #1020. Code-signing resolves this one too.
 Filename: "{app}\{#MyAppExeName}"; Flags: nowait; Check: RelaunchRequested
 
 [Code]


### PR DESCRIPTION
Closes #1009.

> **Note:** this PR was rewritten. It previously carried a 435-line error-classification
> subsystem (`utils/process_launch.py`, a `LaunchBlocked` exception, i18n strings, bridge
> and updater changes, tests). That approach explained the error better; this one stops
> causing it. See [What happened to the previous approach](#what-happened-to-the-previous-approach).

## The report

A user installed the app and Setup ended on:

> **Unable to execute file:**
> `C:\Users\...\AppData\Local\Programs\MTGO Tools\mtgo_tools.exe`
>
> CreateProcess failed; code 4551.
> Uma politica de Controle de Aplicativo bloqueou este arquivo.

Win32 `4551` (`0x11C7`) is `ERROR_SYSTEM_INTEGRITY_POLICY_VIOLATION` — "An Application
Control policy has blocked this file". On consumer Windows 11 that is **Smart App
Control**; on managed machines it is **App Control for Business / WDAC**. MTGO Tools
ships unsigned and installs under `%LOCALAPPDATA%\Programs`, which is exactly the shape
both refuse by default.

The install **succeeded**. Every file is on disk in the right place. Windows refused to
*start* the executable — and specifically, refused to start it *when Setup was the one
starting it*. #1009 says so in as many words: **"Workaround is starting from the start
menu."**

## The change

That makes the fix a one-liner rather than an error-handling project: **the thing that
provokes the block is Setup launching the app, so Setup stops launching the app.**

Removed from `[Run]`:

```
Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,...}"; Flags: nowait postinstall skipifsilent
```

`postinstall` is what turns a `[Run]` entry into the "Launch MTGO Tools" checkbox on the
finish page, and ticking it made Setup the parent process. With it gone, an install on an
affected machine simply ends normally.

In its place the finish page now says where to go. The Start Menu shortcut already existed
in `[Icons]`; it just was not what the finish page pointed at.

### What the finish page says now

> **Completing the MTGO Tools Setup Wizard**
>
> Setup has finished installing MTGO Tools on your computer.
>
> To start it, open the Start menu and choose MTGO Tools (or use the desktop shortcut, if you asked for one).
>
> Setup does not start MTGO Tools for you: on some machines Windows Application Control blocks a program that an installer launches. Opening it from the Start menu is not affected.
>
> Click Finish to exit Setup.

("Click Finish to exit Setup." is Inno's own `ClickFinish` message, appended automatically.)

### How, and why that way

Overriding **`FinishedLabel` and `FinishedLabelNoIcons`** in `[Messages]`. The alternatives
were considered and rejected: an `InfoAfterFile` adds an entire extra wizard page for two
sentences, and a `[CustomMessages]` string needs `[Code]` to get onto the page at all.
Overriding the stock messages puts the instruction exactly where the user is already
looking, with no new page and no Pascal.

**Both** are overridden, not just one: Inno picks `FinishedLabel` when Setup created a
shortcut and `FinishedLabelNoIcons` when it did not, and it picks at run time. Overriding
only one leaves a finish page that silently reverts to stock text under conditions you
cannot see from the script.

**Languages:** `[Languages]` in `packaging/installer.iss` declares exactly one entry,
`english`. So a single untagged override covers every configured language and there is no
second catalogue to keep in sync. (The app's own en-US/pt-BR catalogues under `utils/i18n/`
are unrelated — they translate the *application*; Setup ships only what `[Languages]`
declares.) The comment in the file flags that adding a language here is the moment to add
`<lang>.FinishedLabel=` siblings; until then the untagged lines fall back to English rather
than going blank.

**The checkbox is meant to come back.** The removal site carries an explicit
`RESTORE THIS ONCE THE BINARY IS CODE-SIGNED` comment naming #1009, so the next person
does not restore it and reopen the bug. Application Control refuses `mtgo_tools.exe`
because it carries no trusted publisher signature; a signed build should launch from Setup
normally, at which point the checkbox is a straight usability win. A certificate is being
pursued through the SignPath Foundation open-source programme.

**Cost:** one extra click for the ~everyone who was never blocked. That is the trade —
a small, universal inconvenience instead of a small number of installs ending on an error
dialog that looks like the app is broken when it isn't.

## Finding: the `/RELAUNCH` path has the same problem, and is NOT fixed here

This is the part worth reviewing carefully. `[Run]` has a **second** entry that launches
the app from Setup:

```
Filename: "{app}\{#MyAppExeName}"; Flags: nowait; Check: RelaunchRequested
```

That is the in-app auto-updater's restart. `services/update_installer.py` runs the
downloaded Setup as `/SILENT /NORESTART /RELAUNCH` and then **exits so its own files can be
overwritten** — so nothing is left running to bring the app back, and this entry is the only
thing that does.

It is deliberately not `postinstall` (that plus `skipifsilent` means "only when a human is
watching", which a silent self-update never is), but the *mechanism is identical*:
`CreateProcess` on an unsigned `mtgo_tools.exe` with Setup as the parent. **If launching
from Setup is what Application Control refuses, this is refused too** — and the consequence
is worse than #1009's symptom: on an affected machine an in-app update leaves the app
closed and it does not come back. The user asked for an update, the app vanished, and under
`/SILENT` there is little explaining why.

**I did not change it, on purpose.** Removing it breaks the auto-update restart for
*everyone* to help the few, which is the wrong trade. Making the app relaunch itself is
impossible by construction (it has to be gone before its files are replaced). A detached
relauncher helper is a new unsigned binary launched by Setup — same refusal, plus a new
component.

There is a candidate fix — launch the Start Menu `.lnk` through `explorer.exe` so the launch
is re-parented the way the working #1009 workaround is:

```
Filename: "{win}\explorer.exe"; Parameters: """{group}\{#MyAppName}.lnk"""; Check: RelaunchRequested
```

but it **may not help at all**: if Application Control is refusing the *image* rather than
the parent relationship, re-parenting changes nothing. The Start-menu workaround in #1009 is
one user's empirical report and the mechanism behind it is not established. It also makes
the launch silent on failure and adds a hard dependency on the `[Icons]` shortcut name that
no compiler would catch. Shipping that untested, in the PR that is supposed to be the
*simple* fix, would trade a known-narrow bug for an unknown-breadth one.

So: **filed as #1020**, with the candidate fix and the exact test that would settle it
(a Windows 11 box with Smart App Control actually on). A `KNOWN, UNFIXED` comment sits on
the entry in the `.iss` pointing at it. Code-signing resolves this one too.

## What happened to the previous approach

The earlier version of this PR built out error classification instead: `utils/process_launch.py`
mapping the `winerror` values that mean *refused* rather than *failed* (4550–4553, 1260,
225/226), a `LaunchBlocked` exception in the updater, translated copy in both locales, better
messages from the MTGO bridge, a README troubleshooting section, and 18 tests.

None of that is wrong, and it covers `CreateProcess` sites this PR does not touch — the
bridge (`mtgo_integration/MTGOBridge.exe`, also unsigned, also under
`%LOCALAPPDATA%\Programs`) and the updater running the downloaded Setup out of `%TEMP%`.
Both can still be refused on the machines in question, and both currently report it as an
opaque `OSError`.

But it is not what fixes #1009, and the maintainer asked for the simple fix. So it is
removed here rather than carried alongside, and preserved in **#1019**, which describes each
piece and links the commit it lives in:
**`06c87ad40f4a4c588a5bac7a6d8d25bd205c7251`** (reachable from this PR's force-push
timeline). Nothing was lost silently — it can be revived deliberately, and #1019 says which
parts are worth reviving first.

This PR is now **two files, +84/-13**, and most of that is comments. The second file is
`packaging/README.md`, whose `/RELAUNCH` section explained the switch by contrasting it
with the checkbox this PR deletes — stale the moment the checkbox went, so it is corrected
in the same commit.

## Verification

- **Installer compiles.** `ISCC.exe` on the modified `packaging/installer.iss` against the
  real payload (64 MB app + 145 MB bundled .NET bridge + 75 MB seed + vendor data), full
  `lzma2/max` solid compression, no `-SkipDotNetBuild` shortcut. Exit code 0, "Successful
  compile". Output was redirected via `/O` `/F` so it did not clobber `dist/installer`.
- **Finish page confirmed in pixels.** A throwaway harness carrying the exact
  `FinishedLabel`/`FinishedLabelNoIcons` lines from this diff (same `WizardStyle=modern`,
  same `AppName`, `Uninstallable=no` so nothing was registered) was compiled, run, and
  screenshotted on the Finished page. The text above is transcribed from that screenshot:
  the checkbox is gone, `[name]` expands, and the three paragraphs wrap inside the label
  with room to spare. The harness install was removed afterwards.
- **Tests / lint:** full `pytest` on the Windows venv — **2828 passed, 5 skipped,
  1 deselected, 2 xfailed** in 5m03s, exit 0. `ruff check .` clean; `black --check .` clean
  (662 files unchanged). The diff touches no Python at all, so the suite is really a
  regression check on the *removal* of the previous approach: nothing outside the deleted
  files referenced the deleted symbols (`process_launch`, `LaunchBlocked`, the two i18n
  keys), which a grep across `.py`/`.ps1`/`.md`/`.yml`/`.toml` also confirms.

## What this does not do

It does not unblock anything. Smart App Control has no per-app allowlist; only code-signing
does. It removes the one place where an install that worked ends on a message that says it
didn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fNqNGrTqCKEqTPY3KXjZo
