### PR TITLE
docs: add code of conduct and code signing policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<TODO: CONTACT EMAIL>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq].
+Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,72 @@
+# Code Signing Policy
+
+MTGO Tools publishes signed Windows binaries so that users can verify that a
+release came from this project and reached them unmodified.
+
+> Free code signing provided by [SignPath.io](https://signpath.io), certificate by
+> [SignPath Foundation](https://signpath.org).
+
+## Team roles
+
+MTGO Tools is currently maintained by a single person. The roles below are
+defined separately anyway, because they describe distinct responsibilities and
+because the project is open to additional maintainers — a contributor taking on
+one of these roles does not have to take on all of them.
+
+| Role | Who | Responsibility |
+| --- | --- | --- |
+| **Author** | <TODO: NAME> (@Pedrogush) | Commit access. May modify the repository directly. |
+| **Reviewer** | <TODO: NAME> (@Pedrogush) | Reviews every pull request opened by a non-committer before it is merged. |
+| **Approver** | <TODO: NAME> (@Pedrogush) | Approves each individual signing request. No release is signed automatically. |
+
+All people holding any of these roles are required to have multi-factor
+authentication enabled on both their GitHub account and their SignPath account.
+
+Contributions from people without commit access arrive as pull requests and are
+reviewed before merge. Contributions from AI coding assistants are treated as
+proposals from a non-committer regardless of who ran the tool: they are reviewed
+and approved by a human maintainer before merge, and are attributed in the commit
+history with a `Co-Authored-By` trailer.
+
+## Build and release process
+
+Releases are built and published by an automated pipeline; no binary is built on
+a maintainer's workstation and uploaded by hand.
+
+1. The version number is derived from conventional-commit messages by
+   `scripts/next_version.py` and written to the repository-root `VERSION` file,
+   which is the single source of truth for the app, the installer, and the
+   release tag.
+2. GitHub Actions (`.github/workflows/release.yml`) builds the application with
+   PyInstaller, builds the bundled .NET bridge as a self-contained publish, and
+   packages both into a Windows installer with Inno Setup
+   (`packaging/installer.iss`).
+3. The installer is submitted to SignPath for signing. A human approver
+   authorises each signing request individually.
+4. The signed installer is published as a GitHub Release together with a
+   `.sha256` sidecar containing its SHA-256 digest.
+
+The application's own updater refuses to execute a downloaded installer whose
+SHA-256 does not match the published sidecar; there is no verification-optional
+path (`services/update_installer.py`).
+
+## Privacy
+
+MTGO Tools does not collect analytics or telemetry, and does not transmit
+personal data to the project or to any third party operated by the project.
+
+- **Local diagnostics** are opt-in, anonymised, and written only to a local file
+  on the user's machine. They are never uploaded (`utils/diagnostics.py`).
+- **Network access** is limited to fetching public data the application
+  displays: card data and images, metagame and decklist data, and the GitHub
+  Releases API for update checks. These requests carry no user identifier.
+- **User data stays local.** Collection data, saved decks, match history, and
+  settings are stored on the user's machine and are not sent anywhere.
+- **Code signing metadata.** SignPath receives the built artifact and the
+  associated build metadata from the CI pipeline. It does not receive user data.
+
+## Reporting a problem
+
+Security or signing concerns can be reported by opening an issue at
+<https://github.com/Pedrogush/MTGO_Tools/issues> or by contacting
+<TODO: CONTACT EMAIL>.


### PR DESCRIPTION
Groundwork for a **SignPath Foundation** application. Draft until the
placeholders below are filled.

## Why

MTGO Tools ships unsigned, which is why Windows Smart App Control refuses to
launch it on some machines — `CreateProcess failed; code 4551`
(`ERROR_SYSTEM_INTEGRITY_POLICY_VIOLATION`). Smart App Control has no per-app
allowlist; code signing is the only remedy. SignPath Foundation provides free
OV code signing to open source projects and requires both of these documents.

(#1008 makes the app explain that failure instead of showing a raw
`[WinError 4551]`. It improves the message; it does not unblock anything.)

## What's here

**`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, unmodified apart from the
contact address.

**`CODE_SIGNING_POLICY.md`** — the author / reviewer / approver roles, the build
and release process, privacy practices, and the Foundation's required
attribution line.

Two things in it are deliberate rather than incidental:

- **The roles are written out separately even though one person currently holds
  all three.** They are distinct responsibilities, and the project is open to
  more maintainers — somebody taking on review should not have to take on
  signing approval as well.
- **AI-assisted contributions are stated to be treated as proposals from a
  non-committer**: reviewed and approved by a human before merge, attributed
  with a `Co-Authored-By` trailer. The Foundation's terms say nothing about
  AI-generated code, and SignPath's own platform markets governance *for* it —
  but their whole model rests on a named human taking responsibility for what
  gets signed, so it is better said than left implied.

## Before this leaves draft

- [ ] Name for the roles table — legal name, or "Pedro (@Pedrogush)"?
- [ ] Contact email — `pedrogush@gmail.com`, or a separate public address?
- [ ] Either wire the SignPath signing step into `.github/workflows/release.yml`,
      or soften the "Build and release process" wording — it currently describes
      an intended end state that does not exist yet.
- [ ] Add the SignPath attribution line to `README.md` (the application form
      requires the *download page* to mention it, and the repo page is the
      download page).

Not blocking this PR, but tracked alongside it: set the repository
**description**, **topics**, and **homepage URL** — all three are currently
empty, which is the first thing a Foundation reviewer sees.

Full application plan, baseline metrics and draft form answers live outside the
repo at `../SIGNPATH_APPLICATION_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
