### PR TITLE
fix(match-history): white text for the tree rows, headers and date filters

### DIFF
--- a/docs/WXMSW_BEHAVIOUR.md
+++ b/docs/WXMSW_BEHAVIOUR.md
@@ -225,6 +225,25 @@ is worth stating because so much else on this control is not reachable: the rada
 window's four numeric columns had been left at the left-aligned default since they
 were written, and the fix really is the one argument.
 
+`TreeListCtrl` is a wrapper around a `DataViewCtrl`, and the colour calls land on
+three different windows -- measured by capturing five probe controls side by side
+and counting how many text pixels came back near-black:
+
+- `SetForegroundColour` on the **wrapper** repaints the rows, and propagates to
+  the inner `GetDataView()`. Calling it on the inner control directly works too.
+- The same call on the `wxDataViewMainWindow` child -- the window that actually
+  paints the rows -- is a **silent no-op**. It is the obvious place to reach for
+  once you have enumerated the children, and it is the wrong one.
+- The **header text** is drawn by the `wxMSWHeaderCtrl` grandchild in the wx
+  foreground colour, and `SetWindowTheme`'s dark `ItemsView` class does not move
+  it: the header strip comes back `#202020` with the labels still at `#000000`,
+  which is a *worse* pairing (1.29:1) than the untouched light header it
+  replaced. `DataViewCtrl.SetHeaderAttr(wx.ItemAttr)` is the only public call
+  that moves the label colour -- so it is safe **only** once the strip is
+  already dark, i.e. gated on native dark mode being active. (Setting
+  `SetForegroundColour` on the `wxHeaderCtrl` child works identically; the attr
+  is the documented route.)
+
 ### `wx.Gauge`
 
 **both silently ignored**, and Windows' own dark mode does **not** reach it -- so unlike

--- a/tests/test_stylize.py
+++ b/tests/test_stylize.py
@@ -363,6 +363,37 @@ def test_list_ctrl_rows_are_themed(frame: object) -> None:
     assert _rgb(ctrl.GetForegroundColour()) == T.TEXT_PRIMARY
 
 
+def test_tree_list_rows_get_a_text_colour(frame: object) -> None:
+    """Match History's tree painted **black on ``SURFACE_ALT``** (1.53:1).
+
+    The call site set the background and nothing else, so every row of match
+    text kept wx's default black. This pins the pairing at the wx level; the
+    pixels themselves were verified by capturing the window and reading them
+    back, because wxMSW accepts colour calls it then ignores (see
+    ``docs/WXMSW_BEHAVIOUR.md``) and this control has one of those: the same
+    call on the ``wxDataViewMainWindow`` child changes nothing on screen.
+    """
+    import wx.dataview as dv
+
+    tree = dv.TreeListCtrl(frame, style=dv.TL_DEFAULT_STYLE | dv.TL_SINGLE)
+    tree.AppendColumn("Players")
+    stylize.stylize_tree_list(tree)
+    assert _rgb(tree.GetBackgroundColour()) == T.SURFACE_ALT
+    assert _rgb(tree.GetForegroundColour()) == T.TEXT_PRIMARY
+
+
+def test_tree_list_themes_the_wrapped_data_view_too(frame: object) -> None:
+    """``TreeListCtrl`` is a wrapper; the control that draws the rows is inside it."""
+    import wx.dataview as dv
+
+    tree = dv.TreeListCtrl(frame, style=dv.TL_DEFAULT_STYLE | dv.TL_SINGLE)
+    tree.AppendColumn("Players")
+    stylize.stylize_tree_list(tree, surface="panel")
+    inner = tree.GetDataView()
+    assert _rgb(inner.GetBackgroundColour()) == T.SURFACE_PANEL
+    assert _rgb(inner.GetForegroundColour()) == T.TEXT_PRIMARY
+
+
 def test_disable_native_theme_is_safe_to_call(frame: object) -> None:
     """It must never raise: every stylize entry point calls it unconditionally."""
     choice = wx.Choice(frame, choices=["a"])

--- a/tests/ui/test_match_history_contrast.py
+++ b/tests/ui/test_match_history_contrast.py
@@ -1,0 +1,116 @@
+"""Every string in the Match History window has a theme text colour.
+
+The window shipped with three controls that were given a background and never a
+foreground, so they painted in wxMSW's default **#000000** on a dark surface:
+the match tree (1.53:1 on ``SURFACE_ALT``), its column header labels (1.29:1 on
+the OS dark header strip) and the two date-filter captions (1.53:1 on
+``SURFACE_PANEL``). A user reported it as "the black font is hard to see".
+
+This is a live-tree audit in the spirit of ``tests/ui/test_live_widget_audit.py``
+rather than a check on the styling helper: ``tests/test_stylize.py`` already
+pins what ``stylize_tree_list`` does, and the bug was never in a helper -- it was
+a call site that used half of one. Walking the built window is the only guard
+that fails when someone builds the *next* label inline.
+
+What it cannot see, and what covered it instead: whether wxMSW honoured any of
+these calls. It accepts colours it then ignores (``docs/WXMSW_BEHAVIOUR.md``),
+and this control has such a route -- the same foreground set on the
+``wxDataViewMainWindow`` child changes nothing on screen while reading back
+perfectly. The pixels were verified by capturing the running window through the
+automation harness and counting them: near-black pixels in the client area went
+6,240 -> 0.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import wx
+
+from tests.ui.conftest import pump_ui_events
+from utils.constants import theme as T
+from widgets.frames.match_history.frame import MatchHistoryFrame
+
+#: Every colour the app's text scale offers. A ``wx.StaticText`` whose
+#: foreground is outside this set has either escaped the styling layer entirely
+#: (wx's default black) or grown a literal, which the palette guard in
+#: ``tests/test_widget_audit.py`` bans separately.
+TEXT_TOKENS: dict[tuple[int, int, int], str] = {
+    T.TEXT_PRIMARY: "TEXT_PRIMARY",
+    T.TEXT_SECONDARY: "TEXT_SECONDARY",
+    T.TEXT_PLACEHOLDER: "TEXT_PLACEHOLDER",
+    T.TEXT_DISABLED: "TEXT_DISABLED",
+}
+
+
+class _StubController:
+    """The two calls ``MatchHistoryFrame`` makes on its controller."""
+
+    def get_current_username(self) -> str | None:
+        return None
+
+    def parse_all_gamelogs(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    def infer_username_from_matches(self, _matches: list[dict[str, Any]]) -> str | None:
+        return None
+
+
+def _rgb(colour: wx.Colour) -> tuple[int, int, int]:
+    return (colour.Red(), colour.Green(), colour.Blue())
+
+
+def _walk(window: wx.Window) -> Iterator[wx.Window]:
+    yield window
+    for child in window.GetChildren():
+        yield from _walk(child)
+
+
+@pytest.fixture(name="history_frame")
+def fixture_history_frame(wx_app: wx.App) -> Iterator[MatchHistoryFrame]:
+    frame = MatchHistoryFrame(controller=_StubController())
+    try:
+        yield frame
+    finally:
+        frame.Destroy()
+        pump_ui_events(wx_app)
+
+
+def test_tree_rows_are_not_black(history_frame: MatchHistoryFrame) -> None:
+    """The bug, at its call site: the tree had a background and no foreground."""
+    tree = history_frame.tree
+    assert _rgb(tree.GetBackgroundColour()) == T.SURFACE_ALT
+    assert _rgb(tree.GetForegroundColour()) == T.TEXT_PRIMARY
+
+
+def test_the_tree_wrapper_and_the_control_that_draws_it_agree(
+    history_frame: MatchHistoryFrame,
+) -> None:
+    """``TreeListCtrl`` is a wrapper; the rows are drawn by the control inside it."""
+    inner = history_frame.tree.GetDataView()
+    assert _rgb(inner.GetBackgroundColour()) == T.SURFACE_ALT
+    assert _rgb(inner.GetForegroundColour()) == T.TEXT_PRIMARY
+
+
+def test_every_label_in_the_window_carries_a_text_token(
+    history_frame: MatchHistoryFrame,
+) -> None:
+    """Catches the next caption someone builds inline, the way the two date ones were.
+
+    Pinned on a count as well as on the offenders: a walk that stops finding
+    labels would otherwise pass silently forever.
+    """
+    labels = [w for w in _walk(history_frame) if isinstance(w, wx.StaticText)]
+    assert len(labels) >= 18, f"the walk found only {len(labels)} labels"
+
+    offenders = [
+        f"{label.GetLabel()!r} -> {_rgb(label.GetForegroundColour())}"
+        for label in labels
+        if _rgb(label.GetForegroundColour()) not in TEXT_TOKENS
+    ]
+    assert offenders == [], (
+        "these labels never got a theme text colour, so wxMSW is painting them "
+        f"in its default black on a dark surface: {offenders}"
+    )

--- a/widgets/frames/match_history/frame.py
+++ b/widgets/frames/match_history/frame.py
@@ -33,9 +33,9 @@ from widgets.stylize import (
     create_divider,
     create_status_label,
     init_top_level_window,
-    strip_native_client_edge,
     stylize_button,
-    stylize_scrollable,
+    stylize_label,
+    stylize_tree_list,
 )
 
 # These were five wx.Colour literals holding a byte-for-byte copy of the
@@ -172,7 +172,7 @@ class MatchHistoryFrame(MatchHistoryHandlersMixin, MatchHistoryPropertiesMixin, 
         filter_row = wx.BoxSizer(wx.HORIZONTAL)
         metrics_sizer.Add(filter_row, 0, wx.EXPAND | wx.TOP, SPACE_SM)
         filter_row.Add(
-            wx.StaticText(box_parent, label=self._t("match.filter.start")),
+            self._filter_label(box_parent, "match.filter.start"),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
             SPACE_XS,
@@ -181,7 +181,7 @@ class MatchHistoryFrame(MatchHistoryHandlersMixin, MatchHistoryPropertiesMixin, 
         self.start_date_ctrl = start_field.ctrl
         filter_row.Add(start_field, 0, wx.RIGHT, SPACE_SM)
         filter_row.Add(
-            wx.StaticText(box_parent, label=self._t("match.filter.end")),
+            self._filter_label(box_parent, "match.filter.end"),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
             SPACE_XS,
@@ -196,20 +196,15 @@ class MatchHistoryFrame(MatchHistoryHandlersMixin, MatchHistoryPropertiesMixin, 
         filter_row.AddStretchSpacer(1)
 
         self.tree = dv.TreeListCtrl(panel, style=dv.TL_DEFAULT_STYLE | dv.TL_SINGLE)
-        self.tree.SetBackgroundColour(DARK_ALT)
         self.tree.AppendColumn(self._t("match.col.players"), width=380)
         self.tree.AppendColumn(self._t("match.col.result"), width=100)
         self.tree.AppendColumn(self._t("match.col.mulligans"), width=90)
         self.tree.AppendColumn(self._t("match.col.date"), width=140)
-        # After the columns exist, so the native header child is there to theme. A
-        # TreeListCtrl wraps a DataViewCtrl and the header and scrollbars belong to
-        # the inner control, so both have to be handed over.
-        stylize_scrollable(self.tree)
-        stylize_scrollable(self.tree.GetDataView())
-        # The sunken edge belongs to the inner DataViewCtrl, not the wrapper --
-        # stripping it from the TreeListCtrl alone changes nothing on screen.
-        strip_native_client_edge(self.tree)
-        strip_native_client_edge(self.tree.GetDataView())
+        # After the columns exist, so the native header child is there to theme.
+        # This site used to set the background and stop there, which left every
+        # row of match text painting in wx's default black; the wrapper/inner
+        # split that made that easy to miss now lives in one helper.
+        stylize_tree_list(self.tree)
         self.tree.Bind(dv.EVT_TREELIST_ITEM_ACTIVATED, self.on_item_activated)
         self.tree.Bind(dv.EVT_TREELIST_SELECTION_CHANGED, self.on_item_selected)
         sizer.Add(self.tree, 1, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, SPACE_SM)
@@ -260,6 +255,19 @@ class MatchHistoryFrame(MatchHistoryHandlersMixin, MatchHistoryPropertiesMixin, 
         value.SetForegroundColour(colour)
         sizer.Add(value, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL)
         return value
+
+    def _filter_label(self, parent: wx.Window, key: str) -> wx.StaticText:
+        """A date-filter caption, themed like the metric labels beside it.
+
+        These two were the only ``wx.StaticText``\\ s in the window built inline
+        with no ``SetForegroundColour``, so they rendered in wx's default black
+        on ``SURFACE_PANEL`` (1.53:1) while every label around them was
+        ``TEXT_PRIMARY``. Routed through the helper so a third one cannot be
+        added without a colour.
+        """
+        label = wx.StaticText(parent, label=self._t(key))
+        stylize_label(label, level="body", surface="panel", tone="primary")
+        return label
 
     def _stylize_button(self, button: wx.Button) -> None:
         stylize_button(button, kind="secondary")

--- a/widgets/stylize.py
+++ b/widgets/stylize.py
@@ -718,6 +718,61 @@ def stylize_list_ctrl(ctrl: wx.ListCtrl, *, surface: str = "alt") -> None:
     strip_native_client_edge(ctrl)
 
 
+def stylize_tree_list(tree: wx.Window, *, surface: str = "alt") -> None:
+    """Theme a ``wx.dataview.TreeListCtrl`` -- rows, header text and chrome.
+
+    ``TreeListCtrl`` is a thin wrapper around a ``DataViewCtrl``, and the split
+    ownership is what makes it easy to half-theme: the wrapper owns the row
+    colours, while the scrollbars, the sunken client edge and the native
+    ``SysHeader32`` all belong to the inner control. Match History set the
+    wrapper's *background* and nothing else, so every row of match text painted
+    in wx's default **#000000 on ``SURFACE_ALT`` -- 1.53:1** (issue: black font
+    in Match History). This function exists so the omission cannot recur one
+    control at a time.
+
+    Three findings, each measured on wxPython 4.2.4 / wxWidgets 3.2.8 (msw) by
+    capturing the control and reading the pixels back, not by asking wx what it
+    thinks it stored:
+
+    * ``SetForegroundColour`` on the **wrapper** repaints the rows and
+      propagates to the inner ``DataViewCtrl``. Setting it on the inner control
+      works too; setting it on the ``wxDataViewMainWindow`` child -- the window
+      that actually draws the rows -- is a silent no-op, which is the trap
+      ``docs/WXMSW_BEHAVIOUR.md`` warns about.
+    * The header **text** is not covered by any of that. It is drawn by
+      ``wxMSWHeaderCtrl`` in the wx foreground colour, which stays black even
+      once :func:`stylize_scrollable` has handed the native header to the OS
+      dark theme -- so the app's dark header strip carried black labels.
+      ``SetHeaderAttr`` is the one public call that moves it.
+    * ``SetHeaderAttr`` sets the foreground only, so it is applied **solely when
+      the OS dark theme is actually painting the header dark**. Without native
+      dark mode the header is still the default near-white and light text on it
+      would be strictly worse than the black it replaced -- the same reasoning
+      that keeps it out of :func:`stylize_list_ctrl`, which has no dark header
+      to pair it with.
+    """
+    fill = _colour(_SURFACE_COLOURS[surface])
+    text = _colour(TEXT_PRIMARY)
+    inner = tree.GetDataView()
+
+    tree.SetBackgroundColour(fill)
+    tree.SetForegroundColour(text)
+    inner.SetBackgroundColour(fill)
+    inner.SetForegroundColour(text)
+
+    # Scrollbars and the native header child belong to the inner control; the
+    # sunken client edge is drawn on both, so both have to be handed over.
+    stylize_scrollable(tree)
+    stylize_scrollable(inner)
+    strip_native_client_edge(tree)
+    strip_native_client_edge(inner)
+
+    if native_dark_mode_active():
+        attr = wx.ItemAttr()
+        attr.SetTextColour(text)
+        inner.SetHeaderAttr(attr)
+
+
 def native_dark_mode_active() -> bool:
     """Whether native controls are being drawn by Windows' dark theme."""
     return is_app_dark_mode_enabled()


### PR DESCRIPTION
## The complaint

> In Match History, change the font colors that are black/dark to white — it is hard to see the black font against the current background.

Measured on a populated window before the change: **6,240 near-black pixels in the client area**, and the tree's row text was pure `#000000` on `SURFACE_ALT` — **1.53:1**, against a 4.5:1 AA floor the rest of the app clears at 11–13:1.

## Root cause

Three separate omissions, all the same shape — a control that was given a background and never a foreground, so it kept wx's default black.

1. **The match tree (the bulk of the window).** `frame.py` did `self.tree.SetBackgroundColour(DARK_ALT)` with no matching `SetForegroundColour`. Every row — players, archetypes, result, mulligans, date — painted black on the dark row fill.
2. **The tree's column headers.** `stylize_scrollable` hands the native `SysHeader32` to the OS dark theme, so the header *strip* was dark — but the header **labels** are drawn by `wxMSWHeaderCtrl` in the wx foreground colour, which was still black. Black on `#202020`: **1.29:1**. This one was invisible in code review; only the pixels show it.
3. **The two date-filter captions.** `match.filter.start` / `match.filter.end` were built as bare inline `wx.StaticText`, the only two labels in the window not routed through `_add_metric` or a `stylize_*` helper, so they were black on `SURFACE_PANEL` — **1.53:1**.

Everything else in the window (toolbar button, status label, section heading, the eight metric label/value pairs, the opponent heading, the date inputs) was already themed and measured fine.

## The fix

**`widgets/stylize.py` — new `stylize_tree_list(tree, *, surface="alt")`.** The call site had six lines of wrapper-vs-inner theming and a comment explaining the split; it was missing the one line that mattered. Rather than adding a seventh line at the call site, the whole treatment now lives in one helper next to `stylize_list_ctrl`, so the next `TreeListCtrl` anyone writes cannot be half-themed the same way. It sets background **and** `TEXT_PRIMARY` on the wrapper and the inner `DataViewCtrl`, applies the dark scrollbars/native header, strips the client edge, and sets the header text colour.

**`widgets/frames/match_history/frame.py`** — the tree goes through the helper; the two filter captions go through a new `_filter_label()` that calls `stylize_label(level="body", surface="panel", tone="primary")`.

No new colour literals: everything comes from the existing `TEXT_PRIMARY` / `_SURFACE_COLOURS` tokens, per the note at `frame.py:41`.

### Three wx findings, measured not assumed

`docs/WXMSW_BEHAVIOUR.md` warns that wxMSW accepts colour calls it then ignores, so each of these was verified by capturing the control with `PrintWindow` and counting pixels, never by reading `GetForegroundColour()` back:

- `SetForegroundColour` on the **wrapper** repaints the rows and propagates to the inner `DataViewCtrl`. Setting it on the inner control works too.
- Setting it on the `wxDataViewMainWindow` child — the window that actually draws the rows — is a **silent no-op**. Exactly the trap the doc describes.
- `SetHeaderAttr` is the only public call that moves the header label colour. It applies the foreground *only*, so the helper applies it **solely when native dark mode is actually painting the header dark** — without it the header is still near-white and light text would be strictly worse than the black it replaces. That is the same reasoning that deliberately keeps `SetHeaderAttr` out of `stylize_list_ctrl`, which has no dark header to pair it with.

## Strings recoloured

| String / control | Before | After |
|---|---|---|
| Every tree row: `"<me> (<arch>) vs <opp> (<arch>)"` | `#000000` on `#282E36` — 1.53:1 | `#ECECEC` — **11.59:1** |
| Tree column "Result" values (`Vitória 2-1` / `Derrota 0-2`) | 1.53:1 | **11.59:1** |
| Tree column "Mulligans" values (`3 (2, 1)`) | 1.53:1 | **11.59:1** |
| Tree column "Date" values (`2025-08-15 18:33`) | 1.53:1 | **11.59:1** |
| Column headers: Players / Result / Mulligans / Date | `#000000` on `#202020` — 1.29:1 | `#ECECEC` — **13.79:1** |
| `match.filter.start` caption ("Início (AAAA-MM-DD)") | `#000000` on `#22272E` — 1.53:1 | `#ECECEC` — **11.59:1** |
| `match.filter.end` caption ("Fim (AAAA-MM-DD)") | 1.53:1 | **11.59:1** |

Selected-row state checked separately, since a highlight can invert contrast: white on the selection fill `#20415E` = **10.61:1**.

**Whole-window check:** near-black pixels (`R+G+B < 45`) inside the client area went **6,240 → 0**. The only pure black left in the capture is the window border itself.

## How it was verified

The app's automation harness, against a **populated** window — this machine had no MTGO GameLogs, and the bug is invisible on an empty tree:

```
python -m automation.cli --port 19847 open-widget match_history
python -m automation.cli --port 19847 screenshot-window match_history --path mh_after.png
```

**Populating the window:** Match History reads real `Match_GameLog_*.dat` files discovered by `services/gamelog_service/discovery.find_all_gamelog_dirs()` under the MTGO ClickOnce AppData tree. That tree existed here but held no logs, so 12 synthetic GameLog files were written into it by a scratch script (matching the parser's `@P`-delimited format: joins, mulligans, per-game winners, match score, and cards chosen so `detect_archetype` resolves real names). They parsed into 12 matches with a correctly inferred username, mixed W/L, and mulligan detail. **The seeding script lives outside the repo and the files were deleted afterwards — nothing about it is in this diff.**

One consequence worth stating: `tests/test_gamelog_parser.py::TestGamelogParserVsScreenshots` is `skipif`-gated on `find_all_gamelog_dirs()` finding logs, so while the fixtures were on disk that class would have un-skipped and run against synthetic data with no relationship to `tests/fixtures/match_history_screenshots.json`. The first suite run was discarded for exactly that reason; the results below are from a clean run with the seeded files removed, which puts that class back to skipped as it is on `main`.

Because the harness has no "select a tree row" or "expand a node" command, the selected-row and parent/child cases were captured from a standalone probe frame driving the same `stylize_tree_list` helper — expanded parent node, indented child rows, one child selected, plus a `create_text_input` holding a date. All legible.

Screenshots (before/after full window, 2–3x zooms of the tree and filter row, and the nested/selected capture) are in `screenshots/match_history_contrast/` — gitignored, local to the user's checkout.

## Tests

- **`tests/ui/test_match_history_contrast.py`** (new) — a live-tree audit in the spirit of `tests/ui/test_live_widget_audit.py`: builds a real `MatchHistoryFrame` against a stub controller and asserts the tree (and the `DataViewCtrl` inside it) carry `SURFACE_ALT` + `TEXT_PRIMARY`, and that **every** `wx.StaticText` in the window has one of the four theme text tokens. That last one is the guard that fails when someone builds the *next* caption inline, which is how the two date labels got there.
- **`tests/test_stylize.py`** — two tests pinning `stylize_tree_list` itself, next to the existing `stylize_list_ctrl` test.
- **`docs/WXMSW_BEHAVIOUR.md`** — a `TreeListCtrl` entry under `wx.dataview`, recording all three measurements including the route that does **not** work. That file's stated house rule is to write down the dead ends so the next person does not retry them.

## Judgement calls

- **Helper vs. one-off call.** Added `stylize_tree_list` rather than a bare `SetForegroundColour` line. The call site already had two comments about the wrapper/inner split and still missed the foreground, which is the definition of a fix that belongs one level up. It is a consolidation of what was already there plus the missing line — not a speculative refactor.
- **Header colour is gated.** `SetHeaderAttr` fires only under `native_dark_mode_active()`. Ungated it would be a regression on any machine where the OS is not theming the header dark.
- **`DARK_ALT` is now unused in `frame.py` and was left in place.** It is part of the documented five-token alias block at the top of the file (`DARK_PANEL` was already unused before this change); deleting one entry would make that block inconsistent for no gain.
- **The tree is flat.** Despite the class docstring saying "grouped by event", `handlers._populate_history` appends every match directly to the root — there are no expandable event nodes to expand in the real window today. The parent/child case was still verified in the probe so the fix is known to cover it if grouping lands.

## Checks

- `pytest -q` from the worktree: **2804 passed, 5 skipped, 2 xfailed, 1 deselected** (~3.5 min). Same shape as `main` plus the three new UI tests.
- `ruff check widgets tests` — clean. `black --check widgets tests` — clean, 370 files unchanged.
- The three new UI tests were checked against the **pre-fix** code and all three fail there, naming the offenders (`'Start (YYYY-MM-DD)' -> (0, 0, 0)`). A guard that cannot fail is not a guard.

## Not covered

- **The "Deck Lists" `wx.MessageDialog`** (`handlers.on_item_activated`) is a native modal; the automation README explicitly forbids opening modals from a script, so it was not captured. It is native-themed and outside the window's own painting.
- **Radar and the sideboard guide** use `DataViewListCtrl` and correctly set both colours on the rows, but neither sets a header text colour — by the same mechanism found here, their column headers are likely black-on-dark too. Not touched: out of scope for this issue, and each needs its own before/after capture. `stylize_tree_list` is written so the header handling is easy to lift into `stylize_list_ctrl`'s neighbourhood when someone takes that on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fNqNGrTqCKEqTPY3KXjZo
