### PR TITLE
fix(automation): stop the capture modules poisoning the shared user32 handle

### DIFF
--- a/automation/server/video_capture.py
+++ b/automation/server/video_capture.py
@@ -29,8 +29,19 @@ import threading
 import time
 from ctypes import wintypes
 
-_user32 = ctypes.windll.user32 if os.name == "nt" else None  # type: ignore[attr-defined]
-_gdi32 = ctypes.windll.gdi32 if os.name == "nt" else None  # type: ignore[attr-defined]
+# Private handles, NOT ``ctypes.windll.user32``. ``ctypes.windll`` caches one
+# instance per DLL for the whole process and hands the same object to every
+# importer, so the ``argtypes`` assigned below would be assigned on everyone
+# else's ``user32`` too. ``pygetwindow`` calls ``GetWindowRect`` with a ``RECT``
+# of its own making, and once this module has declared the parameter as
+# ``LP_RECT`` over ``wintypes.RECT`` that call raises
+# ``ArgumentError: expected LP_RECT instance instead of pointer to RECT``.
+# ``pygetwindow.getAllTitles()`` swallows it per-window and returns [], which
+# silently disabled the opponent tracker's detection in any ``--automation``
+# process (issue #1013). ``ctypes.WinDLL(...)`` builds a fresh, unshared
+# instance, so the prototypes below stay this module's business.
+_user32 = ctypes.WinDLL("user32") if os.name == "nt" else None
+_gdi32 = ctypes.WinDLL("gdi32") if os.name == "nt" else None
 
 _PW_RENDERFULLCONTENT = 0x00000002
 _DIB_RGB_COLORS = 0

--- a/automation/server/window_capture.py
+++ b/automation/server/window_capture.py
@@ -31,7 +31,10 @@ _SM_CYVIRTUALSCREEN = 79
 _SW_HIDE = 0
 _SW_SHOWNOACTIVATE = 4  # restore from minimized to most-recent rect, no activate
 
-_user32 = ctypes.windll.user32 if _os.name == "nt" else None  # type: ignore[attr-defined]
+# A private instance rather than the process-wide ``ctypes.windll.user32``, for
+# the reason spelled out in :mod:`automation.server.video_capture`: ``argtypes``
+# set on the shared handle are set on every other importer's handle as well.
+_user32 = ctypes.WinDLL("user32") if _os.name == "nt" else None
 if _user32 is not None:
     _user32.PrintWindow.argtypes = [
         ctypes.c_void_p,  # HWND

--- a/tests/test_automation_ctypes_isolation.py
+++ b/tests/test_automation_ctypes_isolation.py
@@ -1,0 +1,123 @@
+"""The automation capture modules must not set prototypes on a shared DLL handle.
+
+``ctypes.windll`` is a ``LibraryLoader`` that caches one instance per DLL for the
+whole process and hands that same object to every importer. So a module that does
+
+    ctypes.windll.user32.GetWindowRect.argtypes = [...]
+
+has not configured *its* ``user32`` -- it has configured everyone's, including
+that of any third-party library in the process.
+
+That is not hypothetical here. ``automation/server/video_capture.py`` declared
+``GetWindowRect`` as taking ``POINTER(wintypes.RECT)``; ``pygetwindow`` calls the
+same function with a ``RECT`` class of its own, so after the import its call
+raised ``ArgumentError: expected LP_RECT instance instead of pointer to RECT``.
+The raise happened inside an ``EnumWindows`` callback, where ctypes prints
+``Exception ignored`` and carries on, so ``getAllTitles()`` returned ``[]``
+instead of failing -- and ``utils.find_opponent_names.find_opponent_names()``,
+which is the *only* trigger for the opponent tracker's detection, silently
+returned nothing for the entire life of any ``--automation`` process (#1013).
+
+The fix is a private ``ctypes.WinDLL(...)`` instance per module. This guard
+pins it, because the failure it prevents is invisible: nothing errors, a feature
+just stops working.
+
+``tests/ui/test_card_view_viewport_repaint.py`` documents the same trap from the
+other side ("``argtypes`` on ``GetDIBits`` first wins -- and ``automation.server``
+does"), which is how a second instance of this bug was already being worked
+around rather than fixed.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name != "nt",
+    reason="ctypes.windll and the Win32 capture modules only exist on Windows.",
+)
+
+#: Functions the automation modules declare prototypes for, on the handle they
+#: own. Each must be left untouched on the process-wide handle. ``GetWindowRect``
+#: is the one that actually broke; the others are on the same shared object and
+#: would break some other importer the same way.
+_SHARED_USER32_FUNCTIONS = (
+    "GetWindowRect",
+    "PrintWindow",
+    "GetDC",
+    "ReleaseDC",
+    "SetWindowPos",
+    "IsWindowVisible",
+)
+
+
+def _import_capture_modules() -> None:
+    """Import both capture modules for their import-time prototype assignments."""
+    import automation.server.video_capture  # noqa: F401
+    import automation.server.window_capture  # noqa: F401
+
+
+def test_capture_modules_do_not_touch_shared_user32_prototypes() -> None:
+    """Importing the capture modules must leave ``ctypes.windll.user32`` pristine."""
+    _import_capture_modules()
+
+    shared = ctypes.windll.user32  # type: ignore[attr-defined]
+    polluted = {
+        name: getattr(shared, name).argtypes
+        for name in _SHARED_USER32_FUNCTIONS
+        if getattr(shared, name).argtypes is not None
+    }
+
+    assert not polluted, (
+        "automation.server set argtypes on the process-wide ctypes.windll.user32. "
+        "Use a private ctypes.WinDLL('user32') instead -- the shared handle is "
+        f"also pygetwindow's. Polluted: {polluted}"
+    )
+
+
+def test_capture_modules_do_not_touch_shared_gdi32_prototypes() -> None:
+    """Same guard for ``gdi32``, which ``video_capture`` also configures."""
+    _import_capture_modules()
+
+    shared = ctypes.windll.gdi32  # type: ignore[attr-defined]
+    polluted = {
+        name: getattr(shared, name).argtypes
+        for name in ("BitBlt", "GetDIBits", "CreateCompatibleDC", "SelectObject")
+        if getattr(shared, name).argtypes is not None
+    }
+
+    assert not polluted, (
+        "automation.server set argtypes on the process-wide ctypes.windll.gdi32. "
+        f"Use a private ctypes.WinDLL('gdi32') instead. Polluted: {polluted}"
+    )
+
+
+def test_capture_modules_use_private_dll_instances() -> None:
+    """The handles the modules hold must not be the cached ``ctypes.windll`` ones.
+
+    The prototype checks above pass trivially if a module simply stops declaring
+    prototypes; this one pins the mechanism that makes declaring them safe.
+    """
+    from automation.server import video_capture, window_capture
+
+    assert video_capture._user32 is not ctypes.windll.user32  # type: ignore[attr-defined]
+    assert video_capture._gdi32 is not ctypes.windll.gdi32  # type: ignore[attr-defined]
+    assert window_capture._user32 is not ctypes.windll.user32  # type: ignore[attr-defined]
+
+
+def test_find_opponent_names_survives_importing_the_capture_modules() -> None:
+    """The end-to-end shape of #1013: detection must still be callable afterwards.
+
+    It cannot assert on *which* windows exist -- that depends on the machine --
+    but it can assert the call completes and returns a list. Before the fix this
+    returned ``[]`` on every machine and every input, because each per-window
+    ``GetWindowRect`` raised inside ``pygetwindow``'s enumeration callback.
+    """
+    from utils.find_opponent_names import find_opponent_names
+
+    _import_capture_modules()
+
+    assert isinstance(find_opponent_names(), list)


### PR DESCRIPTION
Fixes #1013.

## The bug

`ctypes.windll` is a `LibraryLoader` that caches **one instance per DLL for the whole process** and hands that same object to every importer. Both capture modules took that shared handle and declared prototypes on it at import time:

```python
_user32 = ctypes.windll.user32 ...                                                # video_capture.py:32
_user32.GetWindowRect.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.RECT)]   # video_capture.py:62
```

So they weren't configuring *their* `user32` — they were configuring everyone's, including `pygetwindow`'s.

`pygetwindow` calls `GetWindowRect` with a `RECT` class of its own making, so after that assignment its call raises:

```
ctypes.ArgumentError: argument 2: TypeError: expected LP_RECT instance instead of pointer to RECT
```

The raise happens **per window, inside an `EnumWindows` callback**, where ctypes reports `Exception ignored ...` and continues. `getAllTitles()` therefore returns `[]` instead of failing, and `utils.find_opponent_names.find_opponent_names()` — the *only* trigger for the opponent tracker's detection (`handlers/polling.py::_poll_worker`) — silently returned nothing for the entire life of the process.

`window_capture.py:34` takes the same shared handle and sets prototypes on it too.

## Proof

One import flips it, in a single process:

```
BEFORE importing automation.server.video_capture: ['connormc02']
AFTER  importing automation.server.video_capture: []
```

## Scope: dev/test only

`automation.server` is imported **only** under `--automation` (`main.py:81`), and packaged builds never pass it. Confirmed empirically: the real app launched **without** the flag, with a decoy `... vs. connormc02` window open, detected the opponent and populated the tracker, with `0` occurrences of the error in its log.

So no user install can hit this. What it did break is **every automation-driven check of the opponent tracker** — #1011's screenshots needed detection short-circuited by hand to get a populated window at all. That is the cost being paid here: a whole feature is invisible to the harness, silently.

## The fix

`ctypes.WinDLL("user32")` / `ctypes.WinDLL("gdi32")` build fresh, unshared instances, so the prototypes stay local to the module that wants them. Two lines of behaviour change; the rest is the comment explaining why, because the next person to write `ctypes.windll.user32` here will reintroduce it.

## Verification

Under `--automation`, after the change:

- the tracker detects an opponent from a decoy window title and populates the radar
- `screenshot-window opponent_tracker` works (740x882 captured)
- `start-video` / `stop-video` work — `video_capture` is the module changed most, so this is the one that mattered
- `ctypes.windll.user32.GetWindowRect.argtypes` is back to `None`

Tests: `2799 passed, 5 skipped, 1 deselected, 2 xfailed` (217s), unchanged in shape from `main`. `ruff check` and `black --check` clean over `automation` and `tests`.

## The guards

`tests/test_automation_ctypes_isolation.py`, 4 tests. **3 of the 4 fail against the unfixed modules.** The fourth (`find_opponent_names` still returns a list) passes either way when no matching window is on screen — its docstring says so rather than pretending otherwise.

They assert two different things on purpose: that the shared handles carry no prototypes, *and* that the modules hold private instances. The first alone would pass trivially if someone just deleted the prototype declarations.

## Related, not done here

- `find_opponent_names()` swallows a total enumeration failure silently. A zero-window enumeration deserves a **warning**-level log so this class of fault is diagnosable from a user's log rather than looking like "no match in progress".
- Dropping `pygetwindow` for a direct `ctypes` `EnumWindows` + `GetWindowTextW` is ~10 lines and would have been immune to this entirely.
- `tests/ui/test_card_view_viewport_repaint.py:265` already documented this exact trap for `GetDIBits` ("`argtypes` ... first wins -- and `automation.server` does") and worked around it instead of fixing it. That workaround can probably go now, but it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fNqNGrTqCKEqTPY3KXjZo
