### PR TITLE
fix(card-index): keep Restricted legalities so Vintage decks detect

### DIFF
--- a/repositories/card_repository/__init__.py
+++ b/repositories/card_repository/__init__.py
@@ -22,7 +22,11 @@ from __future__ import annotations
 from repositories.card_repository.card_data_manager import CardDataManager, load_card_manager
 from repositories.card_repository.protocol import CardDataManagerProto, CardRepositoryProto
 from repositories.card_repository.repository import CardRepository
-from repositories.card_repository.schemas import CardEntry, CardIndex
+from repositories.card_repository.schemas import (
+    PLAYABLE_LEGALITY_STATES,
+    CardEntry,
+    CardIndex,
+)
 
 _default_repository: CardRepository | None = None
 
@@ -41,6 +45,7 @@ def reset_card_repository() -> None:
 
 
 __all__ = [
+    "PLAYABLE_LEGALITY_STATES",
     "CardDataManager",
     "CardDataManagerProto",
     "CardEntry",

--- a/repositories/card_repository/builder.py
+++ b/repositories/card_repository/builder.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from repositories.card_repository.schemas import PLAYABLE_LEGALITY_STATES
+
 
 def build_index(atomic_cards: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
     cards: dict[str, dict[str, Any]] = {}
@@ -161,11 +163,37 @@ def _merge_legalities(
     base: dict[str, Any] | None,
     incoming: dict[str, Any] | None,
 ) -> dict[str, Any]:
+    """Union the *playable* legalities of two printings of the same card.
+
+    Playable is ``Legal`` **or** ``Restricted``
+    (:data:`~repositories.card_repository.schemas.PLAYABLE_LEGALITY_STATES`);
+    only ``Banned`` is dropped. Keeping ``Restricted`` out used to cost the app
+    Vintage detection outright: the ~50 cards restricted in Vintage (Black
+    Lotus, the Moxen, Ancestral Recall, Time Walk, Sol Ring, Mana Crypt,
+    Brainstorm, Merchant Scroll, Gitaxian Probe, Urza's Saga, ...) are legal in
+    no other constructed format, so stripping ``Restricted`` left most of them
+    with an *empty* legality map and left the rest looking Legacy-only. The
+    legality intersection in
+    :func:`services.gamelog_service.formats.detect_format_from_cards` then came
+    out empty for any real Vintage deck and the format resolved to "Unknown"
+    (issue seen in Match History, PR #1018).
+
+    The state itself is preserved rather than flattened to ``Legal``, because
+    "one copy maximum" is a real and different answer to "is this card legal
+    here?" and a deck-legality check will eventually want it.
+
+    ``Legal`` wins over ``Restricted`` when two printings disagree: the union
+    is about the widest pool the card is playable in, and a downgrade from a
+    variation would narrow it for no reason.
+    """
     merged: dict[str, Any] = {}
     for source in (base or {}), (incoming or {}):
         for fmt, state in source.items():
-            if state == "Legal":
-                merged[fmt] = state
+            if state not in PLAYABLE_LEGALITY_STATES:
+                continue
+            if merged.get(fmt) == "Legal":
+                continue
+            merged[fmt] = state
     return merged
 
 

--- a/repositories/card_repository/card_data_manager.py
+++ b/repositories/card_repository/card_data_manager.py
@@ -19,7 +19,7 @@ from loguru import logger
 
 from repositories.card_repository import remote, storage
 from repositories.card_repository.builder import build_index
-from repositories.card_repository.schemas import CardEntry
+from repositories.card_repository.schemas import PLAYABLE_LEGALITY_STATES, CardEntry
 from utils.card_names import fold_card_name
 from utils.constants import ATOMIC_DATA_HEAD_TTL_SECONDS, CARD_DATA_DIR
 from utils.perf import timed
@@ -74,6 +74,7 @@ class CardDataManager:
         # a TTL (see ATOMIC_DATA_HEAD_TTL_SECONDS) or when forced.
         if not force and not missing_index and self._head_is_fresh(local_meta):
             self._load_index()
+            storage.prune_superseded_indexes(self.data_dir, self.index_path)
             return
 
         remote_meta = remote.fetch_dataset_headers()
@@ -106,6 +107,9 @@ class CardDataManager:
                     ) from exc
                 logger.warning(f"Failed to refresh MTGJSON data, using cache: {exc}")
         self._load_index()
+        # Only now that the current index has decoded: a bump renames the file,
+        # so without this every past version stays on disk at ~20 MB each.
+        storage.prune_superseded_indexes(self.data_dir, self.index_path)
 
     def search_cards(
         self,
@@ -133,7 +137,7 @@ class CardDataManager:
                 )
                 if not any(query in h for h in haystacks if h):
                     continue
-            if fmt and card.legalities.get(fmt) != "Legal":
+            if fmt and card.legalities.get(fmt) not in PLAYABLE_LEGALITY_STATES:
                 continue
             if type_filter and type_filter not in type_line:
                 continue
@@ -160,7 +164,7 @@ class CardDataManager:
         formats: list[str] = []
         for card in self._cards or []:
             for fmt, state in card.legalities.items():
-                if state != "Legal" or fmt in seen:
+                if state not in PLAYABLE_LEGALITY_STATES or fmt in seen:
                     continue
                 seen.add(fmt)
                 formats.append(fmt)

--- a/repositories/card_repository/schemas.py
+++ b/repositories/card_repository/schemas.py
@@ -12,6 +12,17 @@ from typing import Any
 
 import msgspec
 
+#: The MTGJSON legality states that mean "you may play this card in that
+#: format". MTGJSON emits exactly three values (verified against the
+#: 2026-08-23 ``AtomicCards.json``: 342,773 ``Legal``, 1,217 ``Banned``,
+#: 109 ``Restricted``), and ``Restricted`` is a *playable* state -- it caps the
+#: deck at a single copy, it does not remove the card from the pool. Vintage is
+#: the format built around that distinction: Black Lotus, Ancestral Recall,
+#: Sol Ring, Brainstorm, Merchant Scroll and 48 other printings are restricted
+#: there and legal nowhere else in constructed, so treating ``Restricted`` as
+#: "not legal" makes a Vintage deck look like it has no format at all.
+PLAYABLE_LEGALITY_STATES: frozenset[str] = frozenset({"Legal", "Restricted"})
+
 
 class CardEntry(msgspec.Struct, gc=False):
     """A single card record as stored in the local atomic-cards index.
@@ -67,3 +78,6 @@ class CardIndex(msgspec.Struct):
 
     cards: list[CardEntry]
     cards_by_name: dict[str, int]
+
+
+__all__ = ["PLAYABLE_LEGALITY_STATES", "CardEntry", "CardIndex"]

--- a/repositories/card_repository/storage.py
+++ b/repositories/card_repository/storage.py
@@ -38,15 +38,51 @@ def resolve_paths(data_dir: Path | str = CARD_DATA_DIR) -> tuple[Path, Path, Pat
     The index is persisted as ``msgspec.msgpack`` (binary) for fast, compact
     decode. The version in the filename invalidates older caches: ``_v2`` added
     double-faced-aware records, ``_v3`` stores ``cards_by_name`` as a
-    name -> index map instead of duplicated card objects, and ``_v4`` stops a
+    name -> index map instead of duplicated card objects, ``_v4`` stops a
     combined card's face alias from claiming a real standalone card's name
-    (e.g. "Emeritus of Conflict // Lightning Bolt" over "Lightning Bolt").
+    (e.g. "Emeritus of Conflict // Lightning Bolt" over "Lightning Bolt"), and
+    ``_v5`` keeps ``Restricted`` legalities rather than discarding them along
+    with the banned ones (see
+    :func:`~repositories.card_repository.builder._merge_legalities`). That last
+    one is why the version had to move at all: a v4 index has *already* thrown
+    the restricted entries away, so fixing the builder changes nothing for
+    anyone holding one. The new filename is what forces the rebuild.
     The ``.msgpack`` extension distinguishes the binary index from the legacy
     JSON.
     """
     base = Path(data_dir)
     base.mkdir(parents=True, exist_ok=True)
-    return base, base / "atomic_cards_index_v4.msgpack", base / "atomic_cards_meta.json"
+    return base, base / "atomic_cards_index_v5.msgpack", base / "atomic_cards_meta.json"
+
+
+def prune_superseded_indexes(data_dir: Path | str, keep: Path) -> list[Path]:
+    """Delete index blobs from older schema versions, returning what went.
+
+    The version lives in the filename, so every bump leaves the previous
+    ~20 MB msgpack sitting in ``data/`` forever -- this machine was carrying a
+    ``_v3`` next to its ``_v4`` for exactly that reason. Call this only once
+    *keep* has loaded successfully: an unreadable new index must still be able
+    to fall back on nothing worse than a re-download, and deleting the old one
+    first would not change that, but deleting it *before* knowing the new one
+    decodes is a needless window.
+
+    Only ``atomic_cards_index_v*.msgpack`` files are considered; the legacy
+    JSON has its own one-shot migration in :func:`migrate_legacy_index`.
+    """
+    removed: list[Path] = []
+    keep = Path(keep)
+    for candidate in sorted(Path(data_dir).glob("atomic_cards_index_v*.msgpack")):
+        if candidate.name == keep.name:
+            continue
+        try:
+            candidate.unlink()
+        except OSError as exc:
+            logger.debug(f"Could not remove superseded card index {candidate}: {exc}")
+            continue
+        removed.append(candidate)
+    if removed:
+        logger.info(f"Removed {len(removed)} superseded card index file(s)")
+    return removed
 
 
 def legacy_index_path(data_dir: Path | str = CARD_DATA_DIR) -> Path:
@@ -108,6 +144,7 @@ def write_meta(meta_path: Path, meta: dict[str, Any]) -> None:
 
 __all__ = [
     "legacy_index_path",
+    "prune_superseded_indexes",
     "load_index",
     "load_meta",
     "migrate_legacy_index",

--- a/services/gamelog_service/formats.py
+++ b/services/gamelog_service/formats.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
+from repositories.card_repository.schemas import PLAYABLE_LEGALITY_STATES
+
 if TYPE_CHECKING:
     from repositories.card_repository import CardDataManager
 
@@ -165,7 +167,11 @@ def _detect_format_via_legalities(
         entry = card_manager.get_card(card_name)
         if entry is None:
             continue
-        legal = {fmt for fmt in _COMPETITIVE_FORMATS if entry.legalities.get(fmt) == "Legal"}
+        legal = {
+            fmt
+            for fmt in _COMPETITIVE_FORMATS
+            if entry.legalities.get(fmt) in PLAYABLE_LEGALITY_STATES
+        }
         if legal:
             legal_format_sets.append(legal)
 

--- a/services/search_service/builder_search.py
+++ b/services/search_service/builder_search.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from repositories.card_repository import CardDataManager
+from repositories.card_repository import PLAYABLE_LEGALITY_STATES, CardDataManager
 from services.search_service.mana_filters import (
     matches_color_filter,
     matches_mana_cost,
@@ -82,7 +82,11 @@ class BuilderSearchMixin(_Base):
 
             if selected_formats:
                 legalities = card.get("legalities", {}) or {}
-                if not all(legalities.get(fmt) == "Legal" for fmt in selected_formats):
+                # ``Restricted`` is playable (one copy), so a format filter that
+                # excluded it hid Black Lotus and friends from a Vintage search.
+                if not all(
+                    legalities.get(fmt) in PLAYABLE_LEGALITY_STATES for fmt in selected_formats
+                ):
                     continue
 
             if filters.get("format_pool_enabled") and format_pool_cards:

--- a/tests/test_card_data_aliases.py
+++ b/tests/test_card_data_aliases.py
@@ -145,8 +145,17 @@ def test_build_index_single_face_card():
     assert index["cards_by_name"]["lightning bolt"] == 0
 
 
-def test_build_index_merges_and_filters_legalities():
-    """Only ``Legal`` formats survive, unioned across printings."""
+def test_build_index_drops_banned_but_keeps_restricted():
+    """``Banned`` is dropped; ``Restricted`` survives, unioned across printings.
+
+    MTGJSON emits exactly three legality states -- ``Legal``, ``Banned`` and
+    ``Restricted`` -- and only ``Banned`` means "you may not play this". A
+    restricted card is playable, capped at one copy, which is the whole shape
+    of Vintage. Discarding it alongside the banned cards left Black Lotus and
+    the rest of the restricted list with an *empty* legality map, and the
+    format detector then had nothing to intersect (see
+    :func:`repositories.card_repository.builder._merge_legalities`).
+    """
     payload = {
         "Splinter Twin": [
             {
@@ -168,8 +177,43 @@ def test_build_index_merges_and_filters_legalities():
     index = build_index(payload)
     entry = index["cards"][0]
 
-    # Banned/Restricted dropped; Legal formats from both printings unioned.
-    assert entry["legalities"] == {"legacy": "Legal", "commander": "Legal"}
+    # Banned dropped; Legal and Restricted from both printings unioned, and the
+    # state itself is preserved rather than flattened to "Legal".
+    assert entry["legalities"] == {
+        "legacy": "Legal",
+        "commander": "Legal",
+        "vintage": "Restricted",
+    }
+
+
+def test_build_index_prefers_legal_over_restricted_across_printings():
+    """When two printings disagree, the wider answer (``Legal``) wins.
+
+    The union is about the largest pool the card is playable in, so a
+    variation that happens to carry the narrower state must not downgrade a
+    format another printing calls outright legal.
+    """
+    payload = {
+        "State Flip": [
+            {
+                "name": "State Flip",
+                "manaCost": "{1}",
+                "manaValue": 1,
+                "type": "Artifact",
+                "legalities": {"vintage": "Restricted", "legacy": "Legal"},
+            },
+            {
+                "name": "State Flip",
+                "manaCost": "{1}",
+                "manaValue": 1,
+                "type": "Artifact",
+                "legalities": {"vintage": "Legal", "legacy": "Restricted"},
+            },
+        ]
+    }
+    entry = build_index(payload)["cards"][0]
+
+    assert entry["legalities"] == {"vintage": "Legal", "legacy": "Legal"}
 
 
 def test_build_index_legalities_union_keeps_legal_across_printings():

--- a/tests/test_card_data_refresh.py
+++ b/tests/test_card_data_refresh.py
@@ -196,7 +196,7 @@ def test_index_persists_name_map_as_indices(tmp_path: Path, monkeypatch):
 
     CardDataManager(tmp_path).ensure_latest()
 
-    index_path = tmp_path / "atomic_cards_index_v4.msgpack"
+    index_path = tmp_path / "atomic_cards_index_v5.msgpack"
     raw = msgspec.msgpack.decode(index_path.read_bytes())
     # cards_by_name is persisted as alias -> int index, not duplicated objects.
     assert all(isinstance(v, int) for v in raw["cards_by_name"].values())

--- a/tests/test_card_index_storage.py
+++ b/tests/test_card_index_storage.py
@@ -32,7 +32,7 @@ def test_resolve_paths_uses_msgpack_extension(tmp_path: Path) -> None:
     base, index_path, meta_path = storage.resolve_paths(tmp_path / "data")
     assert base == tmp_path / "data"
     assert base.is_dir()  # resolve_paths must create the directory.
-    assert index_path.name == "atomic_cards_index_v4.msgpack"
+    assert index_path.name == "atomic_cards_index_v5.msgpack"
     assert meta_path.name == "atomic_cards_meta.json"
 
 
@@ -145,3 +145,40 @@ def test_load_meta_invalid_json_returns_none(tmp_path: Path) -> None:
     _, _, meta_path = storage.resolve_paths(tmp_path)
     meta_path.write_text("{not valid json", encoding="utf-8")
     assert storage.load_meta(meta_path) is None
+
+
+def test_prune_superseded_indexes_removes_older_versions_only(tmp_path: Path) -> None:
+    """Old version blobs go; the current one and anything else stays.
+
+    The version lives in the filename, so without this every bump leaves its
+    predecessor behind at ~20 MB -- which is exactly what happened between v3
+    and v4.
+    """
+    _, index_path, meta_path = storage.resolve_paths(tmp_path)
+    storage.write_index(index_path, _sample_index())
+    stale_v3 = tmp_path / "atomic_cards_index_v3.msgpack"
+    stale_v4 = tmp_path / "atomic_cards_index_v4.msgpack"
+    unrelated = tmp_path / "atomic_cards_index_v2.json"
+    for path in (stale_v3, stale_v4, unrelated):
+        path.write_bytes(b"stale")
+    meta_path.write_text("{}", encoding="utf-8")
+
+    removed = storage.prune_superseded_indexes(tmp_path, index_path)
+
+    assert sorted(p.name for p in removed) == [
+        "atomic_cards_index_v3.msgpack",
+        "atomic_cards_index_v4.msgpack",
+    ]
+    assert index_path.exists()
+    # The legacy JSON has its own one-shot migration; this must not touch it,
+    # nor the metadata sidecar.
+    assert unrelated.exists()
+    assert meta_path.exists()
+
+
+def test_prune_superseded_indexes_is_a_no_op_when_alone(tmp_path: Path) -> None:
+    _, index_path, _ = storage.resolve_paths(tmp_path)
+    storage.write_index(index_path, _sample_index())
+
+    assert storage.prune_superseded_indexes(tmp_path, index_path) == []
+    assert index_path.exists()

--- a/tests/test_gamelog_parser.py
+++ b/tests/test_gamelog_parser.py
@@ -38,6 +38,7 @@ def _install_wx_stub() -> None:
 
 _install_wx_stub()
 
+from repositories.card_repository.builder import build_index  # noqa: E402
 from repositories.card_repository.schemas import CardEntry  # noqa: E402
 from services.gamelog_service import (  # noqa: E402
     deck_is_pauper,
@@ -927,6 +928,127 @@ class TestDetectFormatFromCards:
             detect_format_from_cards(list(deck.keys()), manager, last_parsed_format="Modern")
             == "Modern"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: a real Vintage decklist, through the real index builder
+# ---------------------------------------------------------------------------
+
+#: Sixteen real cards from a real Vintage list, each carrying the legality
+#: states MTGJSON actually publishes for it (AtomicCards, 2026-08-23), narrowed
+#: to the six formats ``_COMPETITIVE_FORMATS`` considers. Nothing here is
+#: invented: seven of these cards are ``Restricted`` in Vintage and ``Banned``
+#: or absent everywhere else, which is precisely the combination the index used
+#: to erase.
+_REAL_VINTAGE_LEGALITIES: dict[str, dict[str, str]] = {
+    "Ancestral Recall": {"legacy": "Banned", "vintage": "Restricted"},
+    "Black Lotus": {"legacy": "Banned", "vintage": "Restricted"},
+    "Brainstorm": {"legacy": "Legal", "pauper": "Legal", "vintage": "Restricted"},
+    "Force of Will": {"legacy": "Legal", "vintage": "Legal"},
+    "Mana Crypt": {"legacy": "Banned", "vintage": "Restricted"},
+    "Mana Drain": {"legacy": "Banned", "vintage": "Legal"},
+    "Merchant Scroll": {
+        "legacy": "Legal",
+        "modern": "Legal",
+        "pauper": "Legal",
+        "vintage": "Restricted",
+    },
+    "Mox Jet": {"legacy": "Banned", "vintage": "Restricted"},
+    "Mox Sapphire": {"legacy": "Banned", "vintage": "Restricted"},
+    "Null Rod": {"legacy": "Legal", "vintage": "Legal"},
+    "Sol Ring": {"legacy": "Banned", "vintage": "Restricted"},
+    "Swords to Plowshares": {"legacy": "Legal", "vintage": "Legal"},
+    "Time Walk": {"legacy": "Banned", "vintage": "Restricted"},
+    "Urza's Saga": {"legacy": "Legal", "modern": "Legal", "vintage": "Restricted"},
+    "Volcanic Island": {"legacy": "Legal", "vintage": "Legal"},
+    "Wasteland": {"legacy": "Legal", "vintage": "Legal"},
+}
+
+
+def _vintage_atomic_payload() -> dict[str, list[dict[str, Any]]]:
+    """The list above in MTGJSON ``AtomicCards`` shape, ready for the builder."""
+    return {
+        name: [{"name": name, "type": "Card", "legalities": dict(legalities)}]
+        for name, legalities in _REAL_VINTAGE_LEGALITIES.items()
+    }
+
+
+def _manager_from_built_index(payload: dict[str, list[dict[str, Any]]]) -> _FakeCardManager:
+    """Run the payload through the production index builder, then wrap it."""
+    index = build_index(payload)
+    return _make_manager({card["name"]: card["legalities"] for card in index["cards"]})
+
+
+class TestRealVintageDeckDetection:
+    """The Match History "Unknown format" bug, end to end (PR #1018).
+
+    Every Vintage match in ``scripts/mock_match_history.py`` came out as
+    ``Unknown`` because :func:`~repositories.card_repository.builder.build_index`
+    kept only ``Legal`` legalities. That erased Vintage's restricted list, and a
+    Vintage deck is *built* out of it -- so the legality intersection contained
+    a Vintage-only card on one side and a card that had lost its Vintage
+    legality on the other, came out empty, and the detector fell through to
+    ``last_parsed_format``.
+
+    These go through the real builder rather than hand-written ``CardEntry``
+    legalities, because the bug lived in the builder and a fixture written by
+    hand would simply not have reproduced it.
+    """
+
+    def test_real_vintage_decklist_detects_as_vintage(self):
+        manager = _manager_from_built_index(_vintage_atomic_payload())
+        assert detect_format_from_cards(list(_REAL_VINTAGE_LEGALITIES), manager) == "Vintage"
+
+    def test_restricted_cards_survive_the_index_build(self):
+        index = build_index(_vintage_atomic_payload())
+        by_name = {card["name"]: card["legalities"] for card in index["cards"]}
+        # Banned everywhere it is not restricted: under the old rule these came
+        # out as {} and the detector could not see them at all.
+        assert by_name["Black Lotus"] == {"vintage": "Restricted"}
+        assert by_name["Ancestral Recall"] == {"vintage": "Restricted"}
+        # A card restricted in Vintage and legal elsewhere keeps both.
+        assert by_name["Brainstorm"] == {
+            "legacy": "Legal",
+            "pauper": "Legal",
+            "vintage": "Restricted",
+        }
+
+    def test_dropping_restricted_puts_the_deck_back_in_unknown(self):
+        """The pre-fix behaviour, spelled out so it cannot creep back.
+
+        Same deck, same detector -- only the ``Restricted`` entries removed, as
+        the old ``_merge_legalities`` removed them. If this ever stops
+        returning "Unknown", the assertion above has stopped being evidence of
+        anything.
+        """
+        index = build_index(_vintage_atomic_payload())
+        legal_only = {
+            card["name"]: {
+                fmt: state for fmt, state in card["legalities"].items() if state == "Legal"
+            }
+            for card in index["cards"]
+        }
+        manager = _make_manager(legal_only)
+        assert detect_format_from_cards(list(_REAL_VINTAGE_LEGALITIES), manager) == "Unknown"
+
+    def test_restricted_does_not_pull_a_legacy_deck_into_vintage(self):
+        """Widening "legal" must not cost the neighbouring formats.
+
+        Every card here is Legacy-legal, so ``legacy`` stays in the
+        intersection and wins on ``_COMPETITIVE_FORMATS`` order even though all
+        of them are Vintage-legal too.
+        """
+        legacy_deck = {
+            name: legalities
+            for name, legalities in _REAL_VINTAGE_LEGALITIES.items()
+            if legalities.get("legacy") == "Legal"
+        }
+        payload = {
+            name: [{"name": name, "type": "Card", "legalities": dict(legalities)}]
+            for name, legalities in legacy_deck.items()
+        }
+        manager = _manager_from_built_index(payload)
+        assert detect_format_from_cards(list(legacy_deck), manager) == "Legacy"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The symptom

Match History (#1018) showed **`Unknown` in the Format column for 4 of the 24 mock
matches**. Confirmed by parsing all 24 logs through the production path
(`parse_all_gamelogs` + the real card index + the real rarity index):

| format | rows | before | after |
| --- | --- | --- | --- |
| Pauper | 4 | Pauper | Pauper |
| Modern | 4 | Modern | Modern |
| Legacy | 4 | Legacy | Legacy |
| Standard | 4 | Standard | Standard |
| Pioneer | 4 | Pioneer | Pioneer |
| **Vintage** | **4** | **Unknown** | **Vintage** |

The four rows below the screenshot's fold were the Pauper ones. **The format that
was not being detected is Vintage.**

## Root cause

MTGJSON's `legalities` use exactly three states. Counted over the whole
2026-08-23 `AtomicCards.json` (35,016 cards):

```
Legal 342,773   Banned 1,217   Restricted 109      (vintage alone: 32,588 / 101 / 53)
```

`repositories/card_repository/builder.py::_merge_legalities` kept only `"Legal"`,
so `"Restricted"` was thrown away with `"Banned"`. Vintage is the one format built
around the restricted list, so the index lost it. Dumped straight out of the
shipped v4 index:

```
Black Lotus       -> {}                                   Sol Ring     -> {commander, predh}
Ancestral Recall  -> {}                                   Mana Crypt   -> {}
Brainstorm        -> {..., legacy, pauper}   # no vintage
Merchant Scroll   -> {legacy, modern, pauper} # no vintage
Urza's Saga       -> {legacy, modern}         # no vintage
```

`detect_format_from_cards` intersects each card's legal formats. Traced over the
real mock Vintage match (`MOCK-vintage-0`), the intersection narrows
`{legacy, vintage}` → `{vintage}` on **Mana Drain** (vintage-only), then → `{}` on
**Merchant Scroll**, which had *lost* its `vintage` key by being restricted there.
Empty intersection → fall through to `last_parsed_format` → `"Unknown"`.

`"Restricted"` means *one copy maximum*, not *you may not play this*. It is now
kept.

## The change

* `_merge_legalities` keeps `Legal` **and** `Restricted`, drops only `Banned`, and
  preserves the state string rather than flattening it to `"Legal"` (`Legal` wins
  when two printings of a card disagree).
* `PLAYABLE_LEGALITY_STATES = frozenset({"Legal", "Restricted"})` in
  `card_repository.schemas`; every reader of the index now asks
  `state in PLAYABLE_LEGALITY_STATES`: the format detector, `search_cards`,
  `available_formats`, and the deck builder's format filter (which had been hiding
  Black Lotus from a Vintage search).
* No schema change was needed — the earlier investigation
  (`docs/reports/per_format_match_stats_investigation.md`, §2.1) predicted a
  `CardEntry` change, but `legalities` is already `dict[str, str]`.

## The index version bump, and what it costs

The built v4 index has *already* discarded the restricted entries, so fixing the
builder alone changes nothing for anyone holding one. The version lives in the
filename, so the artefact is now `atomic_cards_index_v5.msgpack`.

**Cost, measured on this machine** (app launched with only v3+v4 present, real
launch, real network):

```
08:35:33.400  No atomic card index found or force refresh requested
08:35:33.401  Refreshing MTGJSON AtomicCards dataset
08:35:46.029  Removed 2 superseded card index file(s)
08:35:46.031  Card database loaded
```

* **12.6 s**, on the next launch, on the existing background card-data thread.
  Not silent: the status bar reads "Loading card database…" then "Card database
  loaded", the same as any refresh.
* **48.8 MB download** (`AtomicCards.json.zip`, `content-length 51,162,200`;
  6.9 s here). There is no cheaper migration: the restricted states are not in the
  v4 file to recover, and nothing else on disk carries them.
* **Disk: about −19.6 MB, not +19.6 MB.** The version has never been pruned — this
  machine was carrying a stale `_v3` (19.6 MB) beside its `_v4` — so
  `storage.prune_superseded_indexes` now removes older index blobs once the current
  one has decoded. v5 is 19,618,821 bytes, 1,997 bytes larger than v4.

## Guard: per-format accuracy, before and after

Widening "legal" changes the intersection for **every** format, so this was measured
rather than argued. Corpus: `cache/archetype_decks_cache.json` (keys
`"<format>-<archetype>"`, real MTGGoldfish labels) joined against the deck texts in
`cache/deck_cache.db` — **2,566 format-labelled decklists** (modern 878, legacy 482,
pauper 462, standard 404, pioneer 201, vintage 139), deduplicated by deck number
with conflicting labels dropped. "before" runs the identical code against the v4
index, which is exact: a v4 index contains no `Restricted` at all, so
`state in {Legal, Restricted}` over it is `state == "Legal"`.

Whole maindeck (1 seed) / half the names (mean of 10 seeds) / six names (mean of 10):

| format | n | whole: before → after | half: before → after | six: before → after |
| --- | --- | --- | --- | --- |
| standard | 404 | 80.45% → 80.45% | 90.22% → 90.22% | 94.23% → 94.23% |
| pioneer | 201 | 100.00% → 100.00% | 99.90% → 99.90% | 98.36% → 98.36% |
| modern | 878 | 99.09% → 99.09% | 99.50% → 99.50% | 98.30% → 98.30% |
| legacy | 482 | 100.00% → **95.44%** | 99.36% → **97.16%** | 91.45% → **90.66%** |
| vintage | 139 | **0.00% → 100.00%** | **9.42% → 99.14%** | **11.44% → 93.53%** |
| pauper | 462 | 100.00% → 100.00% | 100.00% → 100.00% | 100.00% → 100.00% |

**Legacy is the one format that got worse, and it is worth stating plainly.** The
whole-maindeck regression is exactly **22 decks, and every one of them contains
`The Fantasticar`** — banned in Legacy, restricted in Vintage. They are pre-ban
lists cached from MTGGoldfish; by current legality a deck containing that card is
playable only in Vintage, which is what the detector now says. Before the fix they
were called Legacy only because the card had been erased from the index. The single
`modern → Vintage` change (1 deck of 878, invisible at 2 d.p.) is the same shape.

**Pauper is untouched by construction** and measured so: `deck_is_pauper` is a
rarity predicate over the Scryfall bulk (`services/card_rarity_service.py`) and runs
*before* the legality intersection. The rarity index was loaded for every run above
(`cache/common_printings_v1.json` present), so the 100% rows are real, not a
degraded-to-off artefact.

## Verification

* **Regression tests** (`TestRealVintageDeckDetection` in `tests/test_gamelog_parser.py`):
  sixteen real cards from a real Vintage list carrying their real MTGJSON states, run
  through the **production `build_index`** rather than hand-written `CardEntry`
  legalities — the bug lived in the builder, so a hand-written fixture would not
  reproduce it. Asserts the deck detects as `Vintage`, that `Black Lotus` survives the
  build as `{"vintage": "Restricted"}`, that stripping `Restricted` again puts the same
  deck back to `"Unknown"` (the pre-fix behaviour, pinned), and that an all-Legacy-legal
  subset still answers `Legacy`.
* `tests/test_card_data_aliases.py`: `Banned` dropped / `Restricted` kept, and `Legal`
  beating `Restricted` across printings.
* `tests/test_card_index_storage.py`: `prune_superseded_indexes` removes old
  `_v*.msgpack` and leaves the current index, the meta sidecar and the legacy JSON alone.
* **Full suite: 2,884 passed, 5 skipped, 1 deselected, 2 xfailed** (3m43s).
  `ruff check .` and `black --check .` clean.
* **Seen in the UI**: app launched from this branch, Match History loads 24 mock
  matches and the Vintage rows read `Vintage`. The v5 index was rebuilt by that launch
  from scratch, which is also where the timings above come from.

Fixes the `Unknown` rows visible in #1018. Based on `main`, not on #1018 — this is a
card-index fix and stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fNqNGrTqCKEqTPY3KXjZo
